### PR TITLE
fix: update introduction document links to clear up 404s

### DIFF
--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -28,7 +28,7 @@ The API itself is shared across multiple cloud providers allowing for true hybri
 - [Networking][networking]: Networking guide
 - Installation:
   - [Install Cluster API for OCI][install_cluster_api]
-  - [Install Workload Cluster][install_workload_cluster]
+  - [Create Workload Cluster][create_workload_cluster]
 
 ## Support Policy
 
@@ -49,10 +49,10 @@ policy may be made to more closely align with other providers in the Cluster API
 | ---------------------------- | ----- | ----- |
 | OCI Provider v1beta1 (v0.1)  |   ✓   |   ✓  |
 
-[cluster_api]: https://github.com/kubernetes-sigs/cluster-api-oci
+[cluster_api]: https://github.com/oracle/cluster-api-provider-oci
 [image_builder_book]: https://image-builder.sigs.k8s.io/capi/providers/oci.html
 [deployment]: ./gs/overview.md
-[install_cluster_api]: ./gs/install_cluster_api.md
-[install_workload_cluster]: ./gs/install_workload_cluster.md
+[install_cluster_api]: ./gs/install-cluster-api.md
+[create_workload_cluster]: ./gs/create-workload-cluster.md
 [networking]: ./networking/networking.md
 [prerequisites]: ./prerequisites.md


### PR DESCRIPTION
**What this PR does / why we need it**:
The getting started Installation links were 404ing (wrong path) 
and the main cluster_api link was pointing to the wrong repo

**Which issue(s) this PR fixes**:
Fixes #8
