### PR TITLE
test: add bare metal support for e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ test/e2e/data/infrastructure-oci/v1beta1/cluster-template-md-remediation.yaml
 test/e2e/data/infrastructure-oci/v1beta1/cluster-template-node-drain.yaml
 test/e2e/data/infrastructure-oci/v1beta1/cluster-template-oracle-linux.yaml
 test/e2e/data/infrastructure-oci/v1beta1/cluster-template.yaml
+test/e2e/data/infrastructure-oci/v1beta1/cluster-template-bare-metal.yaml
 test/e2e/data/infrastructure-oci/v1beta1/cluster-template-custom-networking-seclist.yaml
 test/e2e/data/infrastructure-oci/v1beta1/cluster-template-custom-networking-nsg.yaml
 test/e2e/data/infrastructure-oci/v1beta1/cluster-template-multiple-node-nsg.yaml

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ ARTIFACTS ?= $(ROOT_DIR)/_artifacts
 KUBETEST_CONF_PATH ?= $(abspath $(E2E_DATA_DIR)/kubetest/conformance.yaml)
 KUBETEST_FAST_CONF_PATH ?= $(abspath $(E2E_DATA_DIR)/kubetest/conformance-fast.yaml)
 GINKGO_FOCUS ?= Workload cluster creation
-GINKGO_SKIP ?=
+GINKGO_SKIP ?= "Bare Metal"
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
@@ -233,6 +233,7 @@ endef
 .PHONY: generate-e2e-templates ## Generate OCI infrastructure templates for e2e test suite.
 generate-e2e-templates: kustomize
 	$(KUSTOMIZE) build $(OCI_TEMPLATES)/v1beta1/cluster-template --load_restrictor LoadRestrictionsNone > $(OCI_TEMPLATES)/v1beta1/cluster-template.yaml
+	$(KUSTOMIZE) build $(OCI_TEMPLATES)/v1beta1/cluster-template-bare-metal --load_restrictor LoadRestrictionsNone > $(OCI_TEMPLATES)/v1beta1/cluster-template-bare-metal.yaml
 	$(KUSTOMIZE) build $(OCI_TEMPLATES)/v1beta1/cluster-template-md-remediation --load_restrictor LoadRestrictionsNone > $(OCI_TEMPLATES)/v1beta1/cluster-template-md-remediation.yaml
 	$(KUSTOMIZE) build $(OCI_TEMPLATES)/v1beta1/cluster-template-kcp-remediation --load_restrictor LoadRestrictionsNone > $(OCI_TEMPLATES)/v1beta1/cluster-template-kcp-remediation.yaml
 	$(KUSTOMIZE) build $(OCI_TEMPLATES)/v1beta1/cluster-template-node-drain --load_restrictor LoadRestrictionsNone > $(OCI_TEMPLATES)/v1beta1/cluster-template-node-drain.yaml

--- a/test/e2e/cluster_test.go
+++ b/test/e2e/cluster_test.go
@@ -370,6 +370,31 @@ var _ = Describe("Workload cluster creation", func() {
 
 		verifyMultipleNsgSubnet(ctx, namespace.Name, clusterName, result.MachineDeployments)
 	})
+
+	When("Bare Metal workload cluster creation", func() {
+
+		It("Bare Metal - With 1 control-plane nodes and 1 worker nodes", func() {
+			clusterName = getClusterName(clusterNamePrefix, "bare-metal")
+			clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+				ClusterProxy: bootstrapClusterProxy,
+				ConfigCluster: clusterctl.ConfigClusterInput{
+					LogFolder:                filepath.Join(artifactFolder, "clusters", bootstrapClusterProxy.GetName()),
+					ClusterctlConfigPath:     clusterctlConfigPath,
+					KubeconfigPath:           bootstrapClusterProxy.GetKubeconfigPath(),
+					InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+					Flavor:                   "bare-metal",
+					Namespace:                namespace.Name,
+					ClusterName:              clusterName,
+					KubernetesVersion:        e2eConfig.GetVariable(capi_e2e.KubernetesVersion),
+					ControlPlaneMachineCount: pointer.Int64Ptr(1),
+					WorkerMachineCount:       pointer.Int64Ptr(1),
+				},
+				WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster-bare-metal"),
+				WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane-bare-metal"),
+				WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes-bare-metal"),
+			}, result)
+		})
+	})
 })
 
 func verifyMultipleNsgSubnet(ctx context.Context, namespace string, clusterName string, mcDeployments []*clusterv1.MachineDeployment) {

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -53,6 +53,7 @@ providers:
         contract: v1beta1
         files:
           - sourcePath: "../data/infrastructure-oci/v1beta1/cluster-template.yaml"
+          - sourcePath: "../data/infrastructure-oci/v1beta1/cluster-template-bare-metal.yaml"
           - sourcePath: "../data/infrastructure-oci/v1beta1/cluster-template-kcp-remediation.yaml"
           - sourcePath: "../data/infrastructure-oci/v1beta1/cluster-template-md-remediation.yaml"
           - sourcePath: "../data/infrastructure-oci/v1beta1/cluster-template-node-drain.yaml"
@@ -89,6 +90,9 @@ intervals:
   default/wait-cluster: ["30m", "10s"]
   default/wait-control-plane: ["30m", "10s"]
   default/wait-worker-nodes: ["30m", "10s"]
+  default/wait-cluster-bare-metal: [ "60m", "10s" ]
+  default/wait-control-plane-bare-metal: [ "60m", "10s" ]
+  default/wait-worker-nodes-bare-metal: [ "60m", "10s" ]
   default/wait-delete-cluster: ["30m", "10s"]
   default/wait-machine-upgrade: ["60m", "10s"]
   default/wait-machine-remediation: ["30m", "10s"]

--- a/test/e2e/data/infrastructure-oci/v1beta1/cluster-template-bare-metal/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta1/cluster-template-bare-metal/cluster.yaml
@@ -1,0 +1,12 @@
+kind: OCIMachineTemplate
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  template:
+    spec:
+      shape: "BM.Standard2.52"
+      shapeConfig:
+        ocpus: "52"
+        memoryInGBs: "768"
+      isPvEncryptionInTransitEnabled: false

--- a/test/e2e/data/infrastructure-oci/v1beta1/cluster-template-bare-metal/kustomization.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta1/cluster-template-bare-metal/kustomization.yaml
@@ -1,0 +1,9 @@
+bases:
+  - ../bases/cluster.yaml
+  - ../bases/md.yaml
+  - ../bases/crs.yaml
+  - ../bases/ccm.yaml
+
+patchesStrategicMerge:
+  - ./cluster.yaml
+  - ./md.yaml

--- a/test/e2e/data/infrastructure-oci/v1beta1/cluster-template-bare-metal/md.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta1/cluster-template-bare-metal/md.yaml
@@ -1,0 +1,12 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OCIMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      shape: "BM.Standard2.52"
+      shapeConfig:
+        ocpus: "52"
+        memoryInGBs: "768"
+      isPvEncryptionInTransitEnabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support to bare metal tests, but also making sure our default e2e testing strategy doesn't run them by default.

**Which issue(s) this PR fixes**:
Currently no open issues.
