### PR TITLE
fix: Update enhancement labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,7 +1,7 @@
 ---
 name: Enhancement Request
 about: Suggest an enhancement to CAPOCI
-labels: feature
+labels: enhancement
 
 ---
 <!-- Please only use this template for submitting enhancement requests -->


### PR DESCRIPTION
**What this PR does / why we need it**:
The `feature` label never existed. The correct label is `enhancement`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
No open issue for this change.
