### PR TITLE
docs: bump CAPOCI version to next release

### DIFF
--- a/docs/src/gs/create-workload-cluster.md
+++ b/docs/src/gs/create-workload-cluster.md
@@ -194,6 +194,6 @@ By default, the [OCI Cloud Controller Manager (CCM)][oci-ccm] is not installed i
 [calico]: ../networking/calico.md
 [cni]: https://www.cni.dev/
 [oci-ccm]: https://github.com/oracle/oci-cloud-controller-manager
-[latest-release]: https://github.com/oracle/cluster-api-provider-oci/releases/tag/v0.1.0
+[latest-release]: https://github.com/oracle/cluster-api-provider-oci/releases/tag/v0.3.0
 [install-oci-ccm]: ./install-oci-ccm.md
 [configure-authentication]: ./install-cluster-api.html#configure-authentication

--- a/docs/src/gs/install-cluster-api.md
+++ b/docs/src/gs/install-cluster-api.md
@@ -18,7 +18,7 @@
    ```yaml
    providers:
      - name: oci
-       url: https://github.com/oracle/cluster-api-provider-oci/releases/v0.1.0/infrastructure-components.yaml
+       url: https://github.com/oracle/cluster-api-provider-oci/releases/v0.3.0/infrastructure-components.yaml
        type: InfrastructureProvider
    ```
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -6,5 +6,5 @@
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 releaseSeries:
   - major: 0
-    minor: 1
+    minor: 3
     contract: v1beta1


### PR DESCRIPTION
**What this PR does / why we need it**:
To help make sure we don't forget to do this (until things are automated)
I wanted to bump the version for our next release now that v0.2.0 has
been cut.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
No open issues for this at this time.
