### PR TITLE
Add support for externally managed VCN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ SKIP_CREATE_MGMT_CLUSTER ?= false
 ARTIFACTS ?= $(ROOT_DIR)/_artifacts
 KUBETEST_CONF_PATH ?= $(abspath $(E2E_DATA_DIR)/kubetest/conformance.yaml)
 KUBETEST_FAST_CONF_PATH ?= $(abspath $(E2E_DATA_DIR)/kubetest/conformance-fast.yaml)
-GINKGO_FOCUS ?= Workload cluster creation
+GINKGO_FOCUS ?= "PRBlocking"
 GINKGO_SKIP ?= "Bare Metal|Multi-Region|VCNPeering"
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
@@ -255,6 +255,7 @@ generate-e2e-templates: kustomize
 	$(KUSTOMIZE) build $(OCI_TEMPLATES)/v1beta1/cluster-template-cluster-class --load_restrictor LoadRestrictionsNone > $(OCI_TEMPLATES)/v1beta1/cluster-template-cluster-class.yaml
 	$(KUSTOMIZE) build $(OCI_TEMPLATES)/v1beta1/cluster-template-local-vcn-peering --load_restrictor LoadRestrictionsNone > $(OCI_TEMPLATES)/v1beta1/cluster-template-local-vcn-peering.yaml
 	$(KUSTOMIZE) build $(OCI_TEMPLATES)/v1beta1/cluster-template-remote-vcn-peering --load_restrictor LoadRestrictionsNone > $(OCI_TEMPLATES)/v1beta1/cluster-template-remote-vcn-peering.yaml
+	$(KUSTOMIZE) build $(OCI_TEMPLATES)/v1beta1/cluster-template-externally-managed-vcn --load_restrictor LoadRestrictionsNone > $(OCI_TEMPLATES)/v1beta1/cluster-template-externally-managed-vcn.yaml
 
 .PHONY: test-e2e-run
 test-e2e-run: generate-e2e-templates ginkgo $(ENVSUBST) ## Run e2e tests

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -239,7 +239,7 @@ type Role string
 
 type SubnetType string
 
-//Subnet defines the configuration for a network's subnet
+// Subnet defines the configuration for a network's subnet
 // https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingVCNs_topic-Overview_of_VCNs_and_Subnets.htm#Overview
 type Subnet struct {
 	// Role defines the subnet role (eg. control-plane, control-plane-endpoint, service-lb, worker).
@@ -335,6 +335,11 @@ type LoadBalancer struct {
 
 // NetworkSpec specifies what the OCI networking resources should look like.
 type NetworkSpec struct {
+	// SkipNetworkManagement defines if the networking spec(VCN related) specified by the user needs to be reconciled(actioned-upon)
+	// or used as it is. APIServerLB will still be reconciled.
+	// +optional
+	SkipNetworkManagement bool `json:"skipNetworkManagement,omitempty"`
+
 	// VCN configuration.
 	// +optional
 	Vcn VCN `json:"vcn,omitempty"`

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclusters.yaml
@@ -82,6 +82,11 @@ spec:
                         description: LoadBalancer Name.
                         type: string
                     type: object
+                  skipNetworkManagement:
+                    description: SkipNetworkManagement defines if the networking spec(VCN
+                      related) specified by the user needs to be reconciled(actioned-upon)
+                      or used as it is. APIServerLB will still be reconciled.
+                    type: boolean
                   vcn:
                     description: VCN configuration.
                     properties:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclustertemplates.yaml
@@ -93,6 +93,12 @@ spec:
                                 description: LoadBalancer Name.
                                 type: string
                             type: object
+                          skipNetworkManagement:
+                            description: SkipNetworkManagement defines if the networking
+                              spec(VCN related) specified by the user needs to be
+                              reconciled(actioned-upon) or used as it is. APIServerLB
+                              will still be reconciled.
+                            type: boolean
                           vcn:
                             description: VCN configuration.
                             properties:

--- a/docs/src/networking/custom-networking.md
+++ b/docs/src/networking/custom-networking.md
@@ -19,6 +19,7 @@ kind: OCICluster
 metadata:
   name: "${CLUSTER_NAME}"
 spec:
+  compartmentId: "${OCI_COMPARTMENT_ID}"
   networkSpec:
     vcn:
       name: ${CLUSTER_NAME}
@@ -53,6 +54,7 @@ kind: OCICluster
 metadata:
   name: "${CLUSTER_NAME}"
 spec:
+  compartmentId: "${OCI_COMPARTMENT_ID}"
   networkSpec:
     vcn:
       name: ${CLUSTER_NAME}
@@ -179,6 +181,7 @@ kind: OCICluster
 metadata:
   name: "${CLUSTER_NAME}"
 spec:
+  compartmentId: "${OCI_COMPARTMENT_ID}"
   networkSpec:
     vcn:
       name: ${CLUSTER_NAME}
@@ -269,5 +272,39 @@ spec:
 ```
 
 Related documentation: [comparison of Security Lists and Network Security Groups][sl-vs-nsg]
+
+## Example spec for externally managed VCN infrastructure
+
+CAPOCI can be used to create a cluster using existing VCN infrastructure. In this case, only the
+API Server Load Balancer will be managed by CAPOCI.
+
+Example spec is given below
+
+```yaml
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OCICluster
+metadata:
+  name: "${CLUSTER_NAME}"
+spec:
+  compartmentId: "${OCI_COMPARTMENT_ID}"
+  networkSpec:
+    skipNetworkManagement: true
+    vcn:
+      id: <Insert VCN OCID Here>
+      networkSecurityGroups:
+        - id: <Insert Control Plane Endpoint NSG OCID Here>
+          role: control-plane-endpoint
+        - id: <Insert Worker NSG OCID Here>
+          role: worker
+        - id: <Insert Control Plane NSG OCID Here>
+          role: control-plane
+      subnets:
+        - id: <Insert Control Plane Endpoint Subnet OCID Here>
+          role: control-plane-endpoint
+        - id: <Insert Worker Subnet OCID Here>
+          role: worker
+        - id: <Insert control Plane Subnet OCID Here>
+          role: control-plane
+```
 
 [sl-vs-nsg]: https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/securityrules.htm#comparison

--- a/test/e2e/cluster_test.go
+++ b/test/e2e/cluster_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Workload cluster creation", func() {
 		dumpSpecResourcesAndCleanup(ctx, cleanInput)
 	})
 
-	It("Default CNI - with 1 control-plane nodes and 1 worker nodes", func() {
+	It("Default CNI - with 1 control-plane nodes and 1 worker nodes [PRBlocking]", func() {
 		clusterName = getClusterName(clusterNamePrefix, "simple")
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: bootstrapClusterProxy,
@@ -130,7 +130,7 @@ var _ = Describe("Workload cluster creation", func() {
 		}, result)
 	})
 
-	It("Default CNI - With 3 control plane nodes spread across failure domains", func() {
+	It("Default CNI - With 3 control plane nodes spread across failure domains [PRBlocking]", func() {
 		clusterName = getClusterName(clusterNamePrefix, "3nodecontrolplane")
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: bootstrapClusterProxy,
@@ -198,7 +198,7 @@ var _ = Describe("Workload cluster creation", func() {
 		validateOLImage(namespace.Name, clusterName)
 	})
 
-	It("Cloud Provider OCI testing", func() {
+	It("Cloud Provider OCI testing [PRBlocking]", func() {
 		clusterName = getClusterName(clusterNamePrefix, "ccm-testing")
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: bootstrapClusterProxy,
@@ -283,7 +283,7 @@ var _ = Describe("Workload cluster creation", func() {
 		deletePVC(nginxStatefulsetInfo, clusterClient)
 	})
 
-	It("Custom networking NSG", func() {
+	It("Custom networking NSG [PRBlocking]", func() {
 		clusterName = getClusterName(clusterNamePrefix, "custom-nsg")
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: bootstrapClusterProxy,
@@ -467,7 +467,7 @@ var _ = Describe("Workload cluster creation", func() {
 		}, result)
 	})
 
-	It("ClusterClass - with 1 control-plane nodes and 1 worker nodes", func() {
+	It("ClusterClass - with 1 control-plane nodes and 1 worker nodes [PRBlocking]", func() {
 		clusterName = getClusterName(clusterNamePrefix, "clusterclass")
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: bootstrapClusterProxy,
@@ -477,6 +477,29 @@ var _ = Describe("Workload cluster creation", func() {
 				KubeconfigPath:           bootstrapClusterProxy.GetKubeconfigPath(),
 				InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
 				Flavor:                   "cluster-class",
+				Namespace:                namespace.Name,
+				ClusterName:              clusterName,
+				KubernetesVersion:        e2eConfig.GetVariable(capi_e2e.KubernetesVersion),
+				ControlPlaneMachineCount: pointer.Int64Ptr(1),
+				WorkerMachineCount:       pointer.Int64Ptr(1),
+			},
+			CNIManifestPath:              e2eConfig.GetVariable(capi_e2e.CNIPath),
+			WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
+			WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
+			WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
+		}, result)
+	})
+
+	It("Externally managed VCN", func() {
+		clusterName = getClusterName(clusterNamePrefix, "externally-managed-vcn")
+		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+			ClusterProxy: bootstrapClusterProxy,
+			ConfigCluster: clusterctl.ConfigClusterInput{
+				LogFolder:                filepath.Join(artifactFolder, "clusters", bootstrapClusterProxy.GetName()),
+				ClusterctlConfigPath:     clusterctlConfigPath,
+				KubeconfigPath:           bootstrapClusterProxy.GetKubeconfigPath(),
+				InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+				Flavor:                   "externally-managed-vcn",
 				Namespace:                namespace.Name,
 				ClusterName:              clusterName,
 				KubernetesVersion:        e2eConfig.GetVariable(capi_e2e.KubernetesVersion),

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -68,6 +68,7 @@ providers:
           - sourcePath: "../data/infrastructure-oci/v1beta1/cluster-template-cluster-class/clusterclass-test-cluster-class.yaml"
           - sourcePath: "../data/infrastructure-oci/v1beta1/cluster-template-local-vcn-peering.yaml"
           - sourcePath: "../data/infrastructure-oci/v1beta1/cluster-template-remote-vcn-peering.yaml"
+          - sourcePath: "../data/infrastructure-oci/v1beta1/cluster-template-externally-managed-vcn.yaml"
           - sourcePath: "../data/shared/v1beta1/metadata.yaml"
 
 
@@ -92,6 +93,13 @@ variables:
   LOCAL_DRG_ID: "${LOCAL_DRG_ID}"
   PEER_DRG_ID: "${PEER_DRG_ID}"
   PEER_REGION_NAME: "${PEER_REGION_NAME}"
+  EXTERNAL_VCN_ID: "${EXTERNAL_VCN_ID}"
+  EXTERNAL_VCN_CPE_NSG: "${EXTERNAL_VCN_CPE_NSG}"
+  EXTERNAL_VCN_WORKER_NSG: "${EXTERNAL_VCN_WORKER_NSG}"
+  EXTERNAL_VCN_CP_NSG: "${EXTERNAL_VCN_CP_NSG}"
+  EXTERNAL_VCN_CPE_SUBNET: "${EXTERNAL_VCN_CPE_SUBNET}"
+  EXTERNAL_VCN_WORKER_SUBNET: "${EXTERNAL_VCN_WORKER_SUBNET}"
+  EXTERNAL_VCN_CP_SUBNET: "${EXTERNAL_VCN_CP_SUBNET}"
 
 intervals:
   default/wait-controllers: ["3m", "10s"]

--- a/test/e2e/data/infrastructure-oci/v1beta1/cluster-template-cluster-class/clusterclass-test-cluster-class.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta1/cluster-template-cluster-class/clusterclass-test-cluster-class.yaml
@@ -203,7 +203,6 @@ spec:
     spec:
       metadata: {}
       shapeConfig: {}
-
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OCIMachineTemplate

--- a/test/e2e/data/infrastructure-oci/v1beta1/cluster-template-externally-managed-vcn/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta1/cluster-template-externally-managed-vcn/cluster.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OCICluster
+metadata:
+  name: "${CLUSTER_NAME}"
+spec:
+  networkSpec:
+    skipNetworkManagement: true
+    vcn:
+      id: "${EXTERNAL_VCN_ID}"
+      networkSecurityGroups:
+        - id: "${EXTERNAL_VCN_CPE_NSG}"
+          role: control-plane-endpoint
+        - id:  "${EXTERNAL_VCN_WORKER_NSG}"
+          role: worker
+        - id: "${EXTERNAL_VCN_CP_NSG}"
+          role: control-plane
+      subnets:
+        - id: "${EXTERNAL_VCN_CPE_SUBNET}"
+          role: control-plane-endpoint
+        - id: "${EXTERNAL_VCN_WORKER_SUBNET}"
+          role: worker
+        - id: "${EXTERNAL_VCN_CP_SUBNET}"
+          role: control-plane

--- a/test/e2e/data/infrastructure-oci/v1beta1/cluster-template-externally-managed-vcn/kustomization.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta1/cluster-template-externally-managed-vcn/kustomization.yaml
@@ -1,0 +1,7 @@
+bases:
+  - ../bases/cluster.yaml
+  - ../bases/md.yaml
+  - ../bases/ccm.yaml
+patchesStrategicMerge:
+  - ./cluster.yaml
+


### PR DESCRIPTION
**What this PR does / why we need it**:
Support use case where VCN can be managed externally but API Server LB can be managed by CAPOCI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #64 
