### PR TITLE
feat: remove CompartmentId mandatory from ocicluster_types

### DIFF
--- a/api/v1beta1/ocicluster_types.go
+++ b/api/v1beta1/ocicluster_types.go
@@ -46,7 +46,8 @@ type OCIClusterSpec struct {
 	DefinedTags map[string]map[string]string `json:"definedTags,omitempty"`
 
 	// Compartment to create the cluster network.
-	CompartmentId string `mandatory:"true" json:"compartmentId"`
+	// +optional
+	CompartmentId string `json:"compartmentId"`
 
 	// Region the cluster operates in. It must be one of available regions in Region Identifier format.
 	// See https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm

--- a/api/v1beta1/ocicluster_webhook.go
+++ b/api/v1beta1/ocicluster_webhook.go
@@ -93,8 +93,15 @@ func (c *OCICluster) ValidateUpdate(old runtime.Object) error {
 func (c *OCICluster) validate() field.ErrorList {
 	var allErrs field.ErrorList
 
-	// simple validity test for compartment
-	if !validOcid(c.Spec.CompartmentId) {
+	if len(c.Spec.CompartmentId) <= 0 {
+		allErrs = append(
+			allErrs,
+			field.Invalid(field.NewPath("spec", "compartmentId"), c.Spec.CompartmentId, "field is required"))
+	}
+
+	// Handle case where CompartmentId exists, but isn't valid
+	// the separate "blank" check above is a more clear error for the user
+	if len(c.Spec.CompartmentId) > 0 && !validOcid(c.Spec.CompartmentId) {
 		allErrs = append(
 			allErrs,
 			field.Invalid(field.NewPath("spec", "compartmentId"), c.Spec.CompartmentId, "field is invalid"))

--- a/api/v1beta1/ocicluster_webhook_test.go
+++ b/api/v1beta1/ocicluster_webhook_test.go
@@ -34,12 +34,20 @@ func TestOCICluster_ValidateCreate(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			name: "shouldn't allow bad ImageId",
+			name: "shouldn't allow bad CompartmentId",
 			c: &OCICluster{
 				ObjectMeta: metav1.ObjectMeta{},
 				Spec: OCIClusterSpec{
 					CompartmentId: "badocid",
 				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "shouldn't allow blank CompartmentId",
+			c: &OCICluster{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec:       OCIClusterSpec{},
 			},
 			expectErr: true,
 		},

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclusters.yaml
@@ -936,8 +936,6 @@ spec:
                 description: Region the cluster operates in. It must be one of available
                   regions in Region Identifier format. See https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm
                 type: string
-            required:
-            - compartmentId
             type: object
           status:
             description: OCIClusterStatus defines the observed state of OCICluster

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclustertemplates.yaml
@@ -1063,8 +1063,6 @@ spec:
                         description: Region the cluster operates in. It must be one
                           of available regions in Region Identifier format. See https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm
                         type: string
-                    required:
-                    - compartmentId
                     type: object
                 required:
                 - spec

--- a/templates/clusterclass-example.yaml
+++ b/templates/clusterclass-example.yaml
@@ -76,7 +76,7 @@ spec:
           matchResources:
             infrastructureCluster: true
         jsonPatches:
-          - op: replace
+          - op: add
             path: "/spec/template/spec/compartmentId"
             valueFrom:
               variable: compartmentId
@@ -162,8 +162,7 @@ metadata:
   name: ocicluster
 spec:
   template:
-    spec:
-      compartmentId: REPLACE
+    spec: {}
 ---
 kind: KubeadmControlPlaneTemplate
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1

--- a/test/e2e/data/infrastructure-oci/v1beta1/cluster-template-cluster-class/clusterclass-test-cluster-class.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta1/cluster-template-cluster-class/clusterclass-test-cluster-class.yaml
@@ -76,7 +76,7 @@ spec:
           matchResources:
             infrastructureCluster: true
         jsonPatches:
-          - op: replace
+          - op: add
             path: "/spec/template/spec/compartmentId"
             valueFrom:
               variable: compartmentId
@@ -162,8 +162,7 @@ metadata:
   name: ocicluster
 spec:
   template:
-    spec:
-      compartmentId: REPLACE
+    spec: {}
 ---
 kind: KubeadmControlPlaneTemplate
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
**What this PR does / why we need it**:
`CompartmentId` is still mandatory, but the admission webhook is now handling the validation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #66 
