### PR TITLE
test: Add e2e template to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ test/e2e/data/infrastructure-oci/v1beta1/cluster-template-multiple-node-nsg.yaml
 test/e2e/data/infrastructure-oci/v1beta1/cluster-template-local-vcn-peering.yaml
 test/e2e/data/infrastructure-oci/v1beta1/cluster-template-cluster-class.yaml
 test/e2e/data/infrastructure-oci/v1beta1/cluster-template-remote-vcn-peering.yaml
+test/e2e/data/infrastructure-oci/v1beta1/cluster-template-externally-managed-vcn.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
Simply adds a generated e2e template to the git ignore list.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
No open issue around this.
