### PR TITLE
Fix bug where clusterctl move does not work, and add correct default …

### DIFF
--- a/api/v1beta1/ocicluster_types.go
+++ b/api/v1beta1/ocicluster_types.go
@@ -32,9 +32,17 @@ const (
 
 // OCIClusterSpec defines the desired state of OciCluster
 type OCIClusterSpec struct {
+
+	// The unique ID which will be used to tag all the resources created by this Cluster.
+	// The tag will be used to identify resources belonging to this cluster.
+	// this will be auto-generated and should not be set by the user.
+	// +optional
+	OCIResourceIdentifier string `json:"ociResourceIdentifier,omitempty"`
+
 	// NetworkSpec encapsulates all things related to OCI network.
 	// +optional
 	NetworkSpec NetworkSpec `json:"networkSpec,omitempty"`
+
 	// Free-form tags for this resource.
 	// +optional
 	FreeformTags map[string]string `json:"freeformTags,omitempty"`
@@ -99,6 +107,11 @@ func (c *OCICluster) GetConditions() clusterv1.Conditions {
 // SetConditions will set the given conditions on an OCICluster object.
 func (c *OCICluster) SetConditions(conditions clusterv1.Conditions) {
 	c.Status.Conditions = conditions
+}
+
+// GetOCIResourceIdentifier will return the OCI resource identifier.
+func (c *OCICluster) GetOCIResourceIdentifier() string {
+	return c.Spec.OCIResourceIdentifier
 }
 
 func init() {

--- a/api/v1beta1/ocicluster_webhook_test.go
+++ b/api/v1beta1/ocicluster_webhook_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -52,11 +53,22 @@ func TestOCICluster_ValidateCreate(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "should succeed",
+			name: "shouldn't allow blank OCIResourceIdentifier",
 			c: &OCICluster{
 				ObjectMeta: metav1.ObjectMeta{},
 				Spec: OCIClusterSpec{
 					CompartmentId: "ocid",
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "should succeed",
+			c: &OCICluster{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: OCIClusterSpec{
+					CompartmentId:         "ocid",
+					OCIResourceIdentifier: "uuid",
 				},
 			},
 			expectErr: false,
@@ -99,18 +111,39 @@ func TestOCICluster_ValidateUpdate(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "should succeed",
+			name: "shouldn't change OCIResourceIdentifier",
 			c: &OCICluster{
 				ObjectMeta: metav1.ObjectMeta{},
 				Spec: OCIClusterSpec{
-					CompartmentId: "ocid",
-					Region:        "old-region",
+					CompartmentId:         "ocid",
+					Region:                "old-region",
+					OCIResourceIdentifier: "uuid-1",
 				},
 			},
 			old: &OCICluster{
 				ObjectMeta: metav1.ObjectMeta{},
 				Spec: OCIClusterSpec{
-					Region: "old-region",
+					Region:                "old-region",
+					OCIResourceIdentifier: "uuid-2",
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "should succeed",
+			c: &OCICluster{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: OCIClusterSpec{
+					CompartmentId:         "ocid",
+					Region:                "old-region",
+					OCIResourceIdentifier: "uuid",
+				},
+			},
+			old: &OCICluster{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: OCIClusterSpec{
+					Region:                "old-region",
+					OCIResourceIdentifier: "uuid",
 				},
 			},
 			expectErr: false,
@@ -128,5 +161,33 @@ func TestOCICluster_ValidateUpdate(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestOCICluster_CreateDefault(t *testing.T) {
+
+	tests := []struct {
+		name   string
+		c      *OCICluster
+		expect func(g *gomega.WithT, c *OCICluster)
+	}{
+		{
+			name: "should set default OCIResourceIdentifier",
+			c: &OCICluster{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: OCIClusterSpec{
+					CompartmentId: "badocid",
+				},
+			},
+			expect: func(g *gomega.WithT, c *OCICluster) {
+				g.Expect(c.Spec.OCIResourceIdentifier).To(Not(BeNil()))
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			test.c.Default()
+			test.expect(g, test.c)
+		})
+	}
 }

--- a/cloud/ociutil/ociutil.go
+++ b/cloud/ociutil/ociutil.go
@@ -19,9 +19,10 @@ package ociutil
 import (
 	"context"
 	"fmt"
-	nlb "github.com/oracle/cluster-api-provider-oci/cloud/services/networkloadbalancer"
 	"net/http"
 	"time"
+
+	nlb "github.com/oracle/cluster-api-provider-oci/cloud/services/networkloadbalancer"
 
 	"github.com/oracle/oci-go-sdk/v63/common"
 	"github.com/oracle/oci-go-sdk/v63/core"
@@ -31,9 +32,12 @@ import (
 )
 
 const (
-	WorkRequestPollInterval = 5 * time.Second
-	WorkRequestTimeout      = 2 * time.Minute
-	MaxOPCRetryTokenBytes   = 64
+	WorkRequestPollInterval   = 5 * time.Second
+	WorkRequestTimeout        = 2 * time.Minute
+	MaxOPCRetryTokenBytes     = 64
+	CreatedBy                 = "CreatedBy"
+	OCIClusterAPIProvider     = "OCIClusterAPIProvider"
+	ClusterResourceIdentifier = "ClusterResourceIdentifier"
 )
 
 // ErrNotFound is for simulation during testing, OCI SDK does not have a way
@@ -102,13 +106,13 @@ func GetBaseLineOcpuOptimizationEnum(baseLineOcpuOptmimizationString string) (co
 // GetDefaultClusterTags creates and returns a map of the default tags for all clusters
 func GetDefaultClusterTags() map[string]string {
 	tags := make(map[string]string)
-	tags["CreatedBy"] = "OCIClusterAPIProvider"
+	tags[CreatedBy] = OCIClusterAPIProvider
 	return tags
 }
 
-// BuildClusterTags uses the default tags and adds the ClusterUUID tag
-func BuildClusterTags(clusterUUID string) map[string]string {
+// BuildClusterTags uses the default tags and adds the ClusterResourceUID tag
+func BuildClusterTags(ClusterResourceUID string) map[string]string {
 	tags := GetDefaultClusterTags()
-	tags["ClusterUUID"] = clusterUUID
+	tags[ClusterResourceIdentifier] = ClusterResourceUID
 	return tags
 }

--- a/cloud/ociutil/ociutil_test.go
+++ b/cloud/ociutil/ociutil_test.go
@@ -71,8 +71,8 @@ func TestGetCloudProviderConfig(t *testing.T) {
 func TestAddToDefaultClusterTags(t *testing.T) {
 	testUUID := "UUIDTEST"
 	tags := BuildClusterTags(testUUID)
-	if tags["ClusterUUID"] != testUUID {
-		t.Errorf("Tags don't match Expected: %s, Actual: %s", testUUID, tags["ClusterUUID"])
+	if tags[ClusterResourceIdentifier] != testUUID {
+		t.Errorf("Tags don't match Expected: %s, Actual: %s", testUUID, tags[ClusterResourceIdentifier])
 	}
 
 	// should also contain default tags

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -124,7 +124,7 @@ func (s *ClusterScope) ReconcileFailureDomains(ctx context.Context) error {
 }
 
 func (s *ClusterScope) IsResourceCreatedByClusterAPI(resourceFreeFormTags map[string]string) bool {
-	tagsAddedByClusterAPI := ociutil.BuildClusterTags(string(s.OCICluster.UID))
+	tagsAddedByClusterAPI := ociutil.BuildClusterTags(s.OCICluster.GetOCIResourceIdentifier())
 	for k, v := range tagsAddedByClusterAPI {
 		if resourceFreeFormTags[k] != v {
 			return false
@@ -251,7 +251,7 @@ func (s *ClusterScope) GetFreeFormTags() map[string]string {
 	if tags == nil {
 		tags = make(map[string]string)
 	}
-	tagsAddedByClusterAPI := ociutil.BuildClusterTags(string(s.OCICluster.UID))
+	tagsAddedByClusterAPI := ociutil.BuildClusterTags(string(s.OCICluster.GetOCIResourceIdentifier()))
 	for k, v := range tagsAddedByClusterAPI {
 		tags[k] = v
 	}

--- a/cloud/scope/drg_reconciler.go
+++ b/cloud/scope/drg_reconciler.go
@@ -123,7 +123,7 @@ func (s *ClusterScope) createDRG(ctx context.Context) (*core.Drg, error) {
 			DefinedTags:   s.GetDefinedTags(),
 			DisplayName:   common.String(s.GetDRGName()),
 		},
-		OpcRetryToken: ociutil.GetOPCRetryToken("%s-%s", "create-drg", string(s.OCICluster.UID)),
+		OpcRetryToken: ociutil.GetOPCRetryToken("%s-%s", "create-drg", string(s.OCICluster.GetOCIResourceIdentifier())),
 	})
 	if err != nil {
 		return nil, err

--- a/cloud/scope/drg_reconciler_test.go
+++ b/cloud/scope/drg_reconciler_test.go
@@ -51,11 +51,12 @@ func TestDRGReconciliation(t *testing.T) {
 		client := fake.NewClientBuilder().Build()
 		ociCluster = infrastructurev1beta1.OCICluster{
 			ObjectMeta: metav1.ObjectMeta{
-				UID:  "a",
+				UID:  "cluster_uid",
 				Name: "cluster",
 			},
 			Spec: infrastructurev1beta1.OCIClusterSpec{
-				CompartmentId: "compartment-id",
+				CompartmentId:         "compartment-id",
+				OCIResourceIdentifier: "resource_uid",
 			},
 		}
 		ociCluster.Spec.ControlPlaneEndpoint.Port = 6443
@@ -66,8 +67,8 @@ func TestDRGReconciliation(t *testing.T) {
 			Client:     client,
 		})
 		tags = make(map[string]string)
-		tags["CreatedBy"] = "OCIClusterAPIProvider"
-		tags["ClusterUUID"] = "a"
+		tags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+		tags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 		vcnPeering = infrastructurev1beta1.VCNPeering{}
 		g.Expect(err).To(BeNil())
 	}
@@ -167,8 +168,8 @@ func TestDRGReconciliation(t *testing.T) {
 				vcnPeering.DRG.Manage = true
 				vcnPeering.DRG.ID = common.String("drg-id")
 				existingTags := make(map[string]string)
-				existingTags["CreatedBy"] = "OCIClusterAPIProvider"
-				existingTags["ClusterUUID"] = "a"
+				existingTags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+				existingTags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 				existingTags["test"] = "test"
 				clusterScope.OCICluster.Spec.NetworkSpec.VCNPeering = &vcnPeering
 				vcnClient.EXPECT().GetDrg(gomock.Any(), gomock.Eq(core.GetDrgRequest{
@@ -209,7 +210,7 @@ func TestDRGReconciliation(t *testing.T) {
 						DefinedTags:   make(map[string]map[string]interface{}),
 						DisplayName:   common.String("cluster"),
 					},
-					OpcRetryToken: ociutil.GetOPCRetryToken("%s-%s", "create-drg", "a"),
+					OpcRetryToken: ociutil.GetOPCRetryToken("%s-%s", "create-drg", "resource_uid"),
 				})).
 					Return(core.CreateDrgResponse{
 						Drg: core.Drg{
@@ -258,11 +259,12 @@ func TestDRGDeletion(t *testing.T) {
 		client := fake.NewClientBuilder().Build()
 		ociCluster = infrastructurev1beta1.OCICluster{
 			ObjectMeta: metav1.ObjectMeta{
-				UID:  "a",
+				UID:  "cluster_uid",
 				Name: "cluster",
 			},
 			Spec: infrastructurev1beta1.OCIClusterSpec{
-				CompartmentId: "compartment-id",
+				CompartmentId:         "compartment-id",
+				OCIResourceIdentifier: "resource_uid",
 			},
 		}
 		ociCluster.Spec.ControlPlaneEndpoint.Port = 6443
@@ -273,8 +275,8 @@ func TestDRGDeletion(t *testing.T) {
 			Client:     client,
 		})
 		tags = make(map[string]string)
-		tags["CreatedBy"] = "OCIClusterAPIProvider"
-		tags["ClusterUUID"] = "a"
+		tags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+		tags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 		vcnPeering = infrastructurev1beta1.VCNPeering{}
 		g.Expect(err).To(BeNil())
 	}

--- a/cloud/scope/drg_rpc_attachment_reconciler_test.go
+++ b/cloud/scope/drg_rpc_attachment_reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
 	infrastructurev1beta1 "github.com/oracle/cluster-api-provider-oci/api/v1beta1"
+	"github.com/oracle/cluster-api-provider-oci/cloud/ociutil"
 	"github.com/oracle/cluster-api-provider-oci/cloud/services/vcn/mock_vcn"
 	"github.com/oracle/oci-go-sdk/v63/common"
 	"github.com/oracle/oci-go-sdk/v63/core"
@@ -52,11 +53,12 @@ func TestDRGRPCAttachmentReconciliation(t *testing.T) {
 		client := fake.NewClientBuilder().Build()
 		ociCluster = infrastructurev1beta1.OCICluster{
 			ObjectMeta: metav1.ObjectMeta{
-				UID:  "a",
+				UID:  "cluster_uid",
 				Name: "cluster",
 			},
 			Spec: infrastructurev1beta1.OCIClusterSpec{
-				CompartmentId: "compartment-id",
+				CompartmentId:         "compartment-id",
+				OCIResourceIdentifier: "resource_uid",
 			},
 		}
 
@@ -74,8 +76,8 @@ func TestDRGRPCAttachmentReconciliation(t *testing.T) {
 			ClientProvider: mockProvider,
 		})
 		tags = make(map[string]string)
-		tags["CreatedBy"] = "OCIClusterAPIProvider"
-		tags["ClusterUUID"] = "a"
+		tags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+		tags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 		vcnPeering = infrastructurev1beta1.VCNPeering{}
 		g.Expect(err).To(BeNil())
 	}
@@ -843,11 +845,12 @@ func TestDRGRPCAttachmentDeletion(t *testing.T) {
 		client := fake.NewClientBuilder().Build()
 		ociCluster = infrastructurev1beta1.OCICluster{
 			ObjectMeta: metav1.ObjectMeta{
-				UID:  "a",
+				UID:  "cluster_uid",
 				Name: "cluster",
 			},
 			Spec: infrastructurev1beta1.OCIClusterSpec{
-				CompartmentId: "compartment-id",
+				CompartmentId:         "compartment-id",
+				OCIResourceIdentifier: "resource_uid",
 			},
 		}
 
@@ -867,8 +870,8 @@ func TestDRGRPCAttachmentDeletion(t *testing.T) {
 			ClientProvider: mockProvider,
 		})
 		tags = make(map[string]string)
-		tags["CreatedBy"] = "OCIClusterAPIProvider"
-		tags["ClusterUUID"] = "a"
+		tags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+		tags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 		vcnPeering = infrastructurev1beta1.VCNPeering{}
 		g.Expect(err).To(BeNil())
 	}

--- a/cloud/scope/drg_vcn_attachment_reconciler_test.go
+++ b/cloud/scope/drg_vcn_attachment_reconciler_test.go
@@ -51,11 +51,12 @@ func TestDRGVCNAttachmentReconciliation(t *testing.T) {
 		client := fake.NewClientBuilder().Build()
 		ociCluster = infrastructurev1beta1.OCICluster{
 			ObjectMeta: metav1.ObjectMeta{
-				UID:  "a",
+				UID:  "cluster_uid",
 				Name: "cluster",
 			},
 			Spec: infrastructurev1beta1.OCIClusterSpec{
-				CompartmentId: "compartment-id",
+				CompartmentId:         "compartment-id",
+				OCIResourceIdentifier: "resource_uid",
 			},
 		}
 		ociCluster.Spec.ControlPlaneEndpoint.Port = 6443
@@ -66,8 +67,8 @@ func TestDRGVCNAttachmentReconciliation(t *testing.T) {
 			Client:     client,
 		})
 		tags = make(map[string]string)
-		tags["CreatedBy"] = "OCIClusterAPIProvider"
-		tags["ClusterUUID"] = "a"
+		tags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+		tags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 		vcnPeering = infrastructurev1beta1.VCNPeering{}
 		g.Expect(err).To(BeNil())
 	}
@@ -139,8 +140,8 @@ func TestDRGVCNAttachmentReconciliation(t *testing.T) {
 				vcnPeering.DRG.VcnAttachmentId = common.String("attachment-id")
 				clusterScope.OCICluster.Spec.NetworkSpec.VCNPeering = &vcnPeering
 				existingTags := make(map[string]string)
-				existingTags["CreatedBy"] = "OCIClusterAPIProvider"
-				existingTags["ClusterUUID"] = "a"
+				existingTags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+				existingTags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 				existingTags["test"] = "test"
 				vcnClient.EXPECT().GetDrgAttachment(gomock.Any(), gomock.Eq(core.GetDrgAttachmentRequest{
 					DrgAttachmentId: common.String("attachment-id"),
@@ -235,11 +236,12 @@ func TestDRGVcnAttachmentDeletion(t *testing.T) {
 		client := fake.NewClientBuilder().Build()
 		ociCluster = infrastructurev1beta1.OCICluster{
 			ObjectMeta: metav1.ObjectMeta{
-				UID:  "a",
+				UID:  "cluster_uid",
 				Name: "cluster",
 			},
 			Spec: infrastructurev1beta1.OCIClusterSpec{
-				CompartmentId: "compartment-id",
+				CompartmentId:         "compartment-id",
+				OCIResourceIdentifier: "resource_uid",
 			},
 		}
 		ociCluster.Spec.ControlPlaneEndpoint.Port = 6443
@@ -250,8 +252,8 @@ func TestDRGVcnAttachmentDeletion(t *testing.T) {
 			Client:     client,
 		})
 		tags = make(map[string]string)
-		tags["CreatedBy"] = "OCIClusterAPIProvider"
-		tags["ClusterUUID"] = "a"
+		tags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+		tags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 		vcnPeering = infrastructurev1beta1.VCNPeering{}
 		g.Expect(err).To(BeNil())
 	}

--- a/cloud/scope/internet_gateway_reconciler_test.go
+++ b/cloud/scope/internet_gateway_reconciler_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	infrastructurev1beta1 "github.com/oracle/cluster-api-provider-oci/api/v1beta1"
+	"github.com/oracle/cluster-api-provider-oci/cloud/ociutil"
 	"github.com/oracle/cluster-api-provider-oci/cloud/services/vcn/mock_vcn"
 	"github.com/oracle/oci-go-sdk/v63/common"
 	"github.com/oracle/oci-go-sdk/v63/core"
@@ -37,8 +38,8 @@ func TestClusterScope_ReconcileInternetGateway(t *testing.T) {
 	vcnClient := mock_vcn.NewMockClient(mockCtrl)
 
 	tags := make(map[string]string)
-	tags["CreatedBy"] = "OCIClusterAPIProvider"
-	tags["ClusterUUID"] = "a"
+	tags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+	tags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 
 	definedTags := map[string]map[string]string{
 		"ns1": {
@@ -256,16 +257,17 @@ func TestClusterScope_ReconcileInternetGateway(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ociCluster := infrastructurev1beta1.OCICluster{
 				ObjectMeta: metav1.ObjectMeta{
-					UID: "a",
+					UID: "cluster_uid",
 				},
 				Spec: tt.spec,
 			}
+			ociCluster.Spec.OCIResourceIdentifier = "resource_uid"
 			s := &ClusterScope{
 				VCNClient:  vcnClient,
 				OCICluster: &ociCluster,
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						UID: "a",
+						UID: "cluster_uid",
 					},
 				},
 				Logger: &l,
@@ -289,8 +291,8 @@ func TestClusterScope_DeleteInternetGateway(t *testing.T) {
 	vcnClient := mock_vcn.NewMockClient(mockCtrl)
 
 	tags := make(map[string]string)
-	tags["CreatedBy"] = "OCIClusterAPIProvider"
-	tags["ClusterUUID"] = "a"
+	tags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+	tags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 	vcnClient.EXPECT().GetInternetGateway(gomock.Any(), gomock.Eq(core.GetInternetGatewayRequest{
 		IgId: common.String("normal_id"),
 	})).
@@ -383,15 +385,16 @@ func TestClusterScope_DeleteInternetGateway(t *testing.T) {
 			ociCluster := infrastructurev1beta1.OCICluster{
 				Spec: tt.spec,
 				ObjectMeta: metav1.ObjectMeta{
-					UID: "a",
+					UID: "cluster_uid",
 				},
 			}
+			ociCluster.Spec.OCIResourceIdentifier = "resource_uid"
 			s := &ClusterScope{
 				VCNClient:  vcnClient,
 				OCICluster: &ociCluster,
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						UID: "a",
+						UID: "cluster_uid",
 					},
 				},
 				Logger: &l,

--- a/cloud/scope/load_balancer_reconciler.go
+++ b/cloud/scope/load_balancer_reconciler.go
@@ -195,7 +195,7 @@ func (s *ClusterScope) CreateLB(ctx context.Context, lb infrastructurev1beta1.Lo
 	s.Logger.Info("Creating network load balancer")
 	lbResponse, err := s.LoadBalancerClient.CreateNetworkLoadBalancer(ctx, networkloadbalancer.CreateNetworkLoadBalancerRequest{
 		CreateNetworkLoadBalancerDetails: lbDetails,
-		OpcRetryToken:                    ociutil.GetOPCRetryToken("%s-%s", "create-lb", string(s.OCICluster.UID)),
+		OpcRetryToken:                    ociutil.GetOPCRetryToken("%s-%s", "create-lb", s.OCICluster.GetOCIResourceIdentifier()),
 	})
 	if err != nil {
 		s.Logger.Error(err, "failed to create apiserver lb, failed to create work request")

--- a/cloud/scope/load_balancer_reconciler_test.go
+++ b/cloud/scope/load_balancer_reconciler_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"testing"
+
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
 	infrastructurev1beta1 "github.com/oracle/cluster-api-provider-oci/api/v1beta1"
@@ -31,7 +33,6 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 )
 
 func TestLBReconciliation(t *testing.T) {
@@ -54,7 +55,8 @@ func TestLBReconciliation(t *testing.T) {
 				Name: "cluster",
 			},
 			Spec: infrastructurev1beta1.OCIClusterSpec{
-				CompartmentId: "compartment-id",
+				CompartmentId:         "compartment-id",
+				OCIResourceIdentifier: "resource_uid",
 			},
 		}
 		ociCluster.Spec.ControlPlaneEndpoint.Port = 6443
@@ -65,8 +67,8 @@ func TestLBReconciliation(t *testing.T) {
 			Client:             client,
 		})
 		tags = make(map[string]string)
-		tags["CreatedBy"] = "OCIClusterAPIProvider"
-		tags["ClusterUUID"] = "a"
+		tags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+		tags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 		g.Expect(err).To(BeNil())
 	}
 	teardown := func(t *testing.T, g *WithT) {
@@ -283,7 +285,7 @@ func TestLBReconciliation(t *testing.T) {
 						FreeformTags: tags,
 						DefinedTags:  definedTagsInterface,
 					},
-					OpcRetryToken: ociutil.GetOPCRetryToken("%s-%s", "create-lb", string("a")),
+					OpcRetryToken: ociutil.GetOPCRetryToken("%s-%s", "create-lb", string("resource_uid")),
 				})).
 					Return(networkloadbalancer.CreateNetworkLoadBalancerResponse{
 						NetworkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
@@ -366,7 +368,7 @@ func TestLBReconciliation(t *testing.T) {
 						FreeformTags: tags,
 						DefinedTags:  map[string]map[string]interface{}{},
 					},
-					OpcRetryToken: ociutil.GetOPCRetryToken("%s-%s", "create-lb", string("a")),
+					OpcRetryToken: ociutil.GetOPCRetryToken("%s-%s", "create-lb", string("resource_uid")),
 				})).
 					Return(networkloadbalancer.CreateNetworkLoadBalancerResponse{}, errors.New("request failed"))
 			},
@@ -418,7 +420,7 @@ func TestLBReconciliation(t *testing.T) {
 						FreeformTags: tags,
 						DefinedTags:  make(map[string]map[string]interface{}),
 					},
-					OpcRetryToken: ociutil.GetOPCRetryToken("%s-%s", "create-lb", string("a")),
+					OpcRetryToken: ociutil.GetOPCRetryToken("%s-%s", "create-lb", string("resource_uid")),
 				})).
 					Return(networkloadbalancer.CreateNetworkLoadBalancerResponse{
 						NetworkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
@@ -441,8 +443,8 @@ func TestLBReconciliation(t *testing.T) {
 			testSpecificSetup: func(clusterScope *ClusterScope, nlbClient *mock_nlb.MockNetworkLoadBalancerClient) {
 				clusterScope.OCICluster.Spec.NetworkSpec.APIServerLB.LoadBalancerId = common.String("nlb-id")
 				newtags := make(map[string]string)
-				newtags["CreatedBy"] = "OCIClusterAPIProvider"
-				newtags["ClusterUUID"] = "a"
+				newtags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+				newtags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 				newtags["newtag"] = "tagvalue"
 				clusterScope.OCICluster.Spec.FreeformTags = newtags
 				nlbClient.EXPECT().GetNetworkLoadBalancer(gomock.Any(), gomock.Eq(networkloadbalancer.GetNetworkLoadBalancerRequest{
@@ -655,7 +657,8 @@ func TestLBDeletion(t *testing.T) {
 				Name: "cluster",
 			},
 			Spec: infrastructurev1beta1.OCIClusterSpec{
-				CompartmentId: "compartment-id",
+				CompartmentId:         "compartment-id",
+				OCIResourceIdentifier: "resource_uid",
 			},
 		}
 		ociCluster.Spec.ControlPlaneEndpoint.Port = 6443
@@ -666,8 +669,8 @@ func TestLBDeletion(t *testing.T) {
 			Client:             client,
 		})
 		tags = make(map[string]string)
-		tags["CreatedBy"] = "OCIClusterAPIProvider"
-		tags["ClusterUUID"] = "a"
+		tags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+		tags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 		g.Expect(err).To(BeNil())
 	}
 	teardown := func(t *testing.T, g *WithT) {

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -262,7 +262,7 @@ func (m *MachineScope) GetOrCreateMachine(ctx context.Context) (*core.Instance, 
 }
 
 func (m *MachineScope) getFreeFormTags(ociCluster infrastructurev1beta1.OCICluster) map[string]string {
-	tags := ociutil.BuildClusterTags(string(ociCluster.UID))
+	tags := ociutil.BuildClusterTags(ociCluster.GetOCIResourceIdentifier())
 	// first use cluster level tags, then override with machine level tags
 	if ociCluster.Spec.FreeformTags != nil {
 		for k, v := range ociCluster.Spec.FreeformTags {
@@ -288,7 +288,7 @@ func (m *MachineScope) DeleteMachine(ctx context.Context) error {
 // IsResourceCreatedByClusterAPI determines if the instance was created by the cluster using the
 // tags created at instance launch.
 func (s *MachineScope) IsResourceCreatedByClusterAPI(resourceFreeFormTags map[string]string) bool {
-	tagsAddedByClusterAPI := ociutil.BuildClusterTags(string(s.OCICluster.UID))
+	tagsAddedByClusterAPI := ociutil.BuildClusterTags(string(s.OCICluster.GetOCIResourceIdentifier()))
 	for k, v := range tagsAddedByClusterAPI {
 		if resourceFreeFormTags[k] != v {
 			return false

--- a/cloud/scope/machine_test.go
+++ b/cloud/scope/machine_test.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"testing"
+
 	"github.com/oracle/cluster-api-provider-oci/cloud/services/networkloadbalancer/mock_nlb"
 	"github.com/oracle/oci-go-sdk/v63/networkloadbalancer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"testing"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
@@ -65,6 +66,9 @@ func TestInstanceReconciliation(t *testing.T) {
 		ociCluster = infrastructurev1beta1.OCICluster{
 			ObjectMeta: metav1.ObjectMeta{
 				UID: "uid",
+			},
+			Spec: infrastructurev1beta1.OCIClusterSpec{
+				OCIResourceIdentifier: "resource_uid",
 			},
 		}
 		ociCluster.Spec.ControlPlaneEndpoint.Port = 6443
@@ -147,8 +151,8 @@ func TestInstanceReconciliation(t *testing.T) {
 						{
 							Id: common.String("test"),
 							FreeformTags: map[string]string{
-								"CreatedBy":   "OCIClusterAPIProvider",
-								"ClusterUUID": "uid",
+								ociutil.CreatedBy:                 ociutil.OCIClusterAPIProvider,
+								ociutil.ClusterResourceIdentifier: "resource_uid",
 							},
 						},
 					},
@@ -341,8 +345,8 @@ func TestInstanceReconciliation(t *testing.T) {
 					IsPvEncryptionInTransitEnabled: common.Bool(true),
 					DefinedTags:                    map[string]map[string]interface{}{},
 					FreeformTags: map[string]string{
-						"CreatedBy":   "OCIClusterAPIProvider",
-						"ClusterUUID": "uid",
+						ociutil.CreatedBy:                 ociutil.OCIClusterAPIProvider,
+						ociutil.ClusterResourceIdentifier: "resource_uid",
 					},
 				}
 				computeClient.EXPECT().LaunchInstance(gomock.Any(), gomock.Eq(core.LaunchInstanceRequest{
@@ -379,8 +383,8 @@ func TestInstanceReconciliation(t *testing.T) {
 					IsPvEncryptionInTransitEnabled: common.Bool(true),
 					DefinedTags:                    map[string]map[string]interface{}{},
 					FreeformTags: map[string]string{
-						"CreatedBy":   "OCIClusterAPIProvider",
-						"ClusterUUID": "uid",
+						ociutil.CreatedBy:                 ociutil.OCIClusterAPIProvider,
+						ociutil.ClusterResourceIdentifier: "resource_uid",
 					},
 				}
 				computeClient.EXPECT().LaunchInstance(gomock.Any(), gomock.Eq(core.LaunchInstanceRequest{
@@ -425,8 +429,8 @@ func TestInstanceReconciliation(t *testing.T) {
 					IsPvEncryptionInTransitEnabled: common.Bool(true),
 					DefinedTags:                    map[string]map[string]interface{}{},
 					FreeformTags: map[string]string{
-						"CreatedBy":   "OCIClusterAPIProvider",
-						"ClusterUUID": "uid",
+						ociutil.CreatedBy:                 ociutil.OCIClusterAPIProvider,
+						ociutil.ClusterResourceIdentifier: "resource_uid",
 					},
 				}
 				computeClient.EXPECT().LaunchInstance(gomock.Any(), gomock.Eq(core.LaunchInstanceRequest{
@@ -473,8 +477,8 @@ func TestInstanceReconciliation(t *testing.T) {
 					IsPvEncryptionInTransitEnabled: common.Bool(true),
 					DefinedTags:                    map[string]map[string]interface{}{},
 					FreeformTags: map[string]string{
-						"CreatedBy":   "OCIClusterAPIProvider",
-						"ClusterUUID": "uid",
+						ociutil.CreatedBy:                 ociutil.OCIClusterAPIProvider,
+						ociutil.ClusterResourceIdentifier: "resource_uid",
 					},
 				}
 				computeClient.EXPECT().LaunchInstance(gomock.Any(), gomock.Eq(core.LaunchInstanceRequest{
@@ -525,8 +529,8 @@ func TestInstanceReconciliation(t *testing.T) {
 					IsPvEncryptionInTransitEnabled: common.Bool(true),
 					DefinedTags:                    map[string]map[string]interface{}{},
 					FreeformTags: map[string]string{
-						"CreatedBy":   "OCIClusterAPIProvider",
-						"ClusterUUID": "uid",
+						ociutil.CreatedBy:                 ociutil.OCIClusterAPIProvider,
+						ociutil.ClusterResourceIdentifier: "resource_uid",
 					},
 				}
 				computeClient.EXPECT().LaunchInstance(gomock.Any(), gomock.Eq(core.LaunchInstanceRequest{
@@ -578,8 +582,8 @@ func TestInstanceReconciliation(t *testing.T) {
 					IsPvEncryptionInTransitEnabled: common.Bool(true),
 					DefinedTags:                    map[string]map[string]interface{}{},
 					FreeformTags: map[string]string{
-						"CreatedBy":   "OCIClusterAPIProvider",
-						"ClusterUUID": "uid",
+						ociutil.CreatedBy:                 ociutil.OCIClusterAPIProvider,
+						ociutil.ClusterResourceIdentifier: "resource_uid",
 					},
 				}
 				computeClient.EXPECT().LaunchInstance(gomock.Any(), gomock.Eq(core.LaunchInstanceRequest{
@@ -1316,5 +1320,6 @@ func setupAllParams(ms *MachineScope) {
 		},
 	}
 	ms.OCICluster.UID = "uid"
+	ms.OCICluster.Spec.OCIResourceIdentifier = "resource_uid"
 	ms.OCIMachine.UID = "machineuid"
 }

--- a/cloud/scope/nat_gateway_reconciler_test.go
+++ b/cloud/scope/nat_gateway_reconciler_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	infrastructurev1beta1 "github.com/oracle/cluster-api-provider-oci/api/v1beta1"
+	"github.com/oracle/cluster-api-provider-oci/cloud/ociutil"
 	"github.com/oracle/cluster-api-provider-oci/cloud/services/vcn/mock_vcn"
 	"github.com/oracle/oci-go-sdk/v63/common"
 	"github.com/oracle/oci-go-sdk/v63/core"
@@ -37,8 +38,8 @@ func TestClusterScope_ReconcileNatGateway(t *testing.T) {
 	vcnClient := mock_vcn.NewMockClient(mockCtrl)
 
 	tags := make(map[string]string)
-	tags["CreatedBy"] = "OCIClusterAPIProvider"
-	tags["ClusterUUID"] = "a"
+	tags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+	tags[ociutil.ClusterResourceIdentifier] = "a"
 
 	definedTags := map[string]map[string]string{
 		"ns1": {
@@ -254,16 +255,17 @@ func TestClusterScope_ReconcileNatGateway(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ociCluster := infrastructurev1beta1.OCICluster{
 				ObjectMeta: metav1.ObjectMeta{
-					UID: "a",
+					UID: "cluster_uid",
 				},
 				Spec: tt.spec,
 			}
+			ociCluster.Spec.OCIResourceIdentifier = "a"
 			s := &ClusterScope{
 				VCNClient:  vcnClient,
 				OCICluster: &ociCluster,
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						UID: "a",
+						UID: "cluster_uid",
 					},
 				},
 				Logger: &l,
@@ -287,8 +289,8 @@ func TestClusterScope_DeleteNatGateway(t *testing.T) {
 	vcnClient := mock_vcn.NewMockClient(mockCtrl)
 
 	tags := make(map[string]string)
-	tags["CreatedBy"] = "OCIClusterAPIProvider"
-	tags["ClusterUUID"] = "a"
+	tags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+	tags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 	vcnClient.EXPECT().GetNatGateway(gomock.Any(), gomock.Eq(core.GetNatGatewayRequest{
 		NatGatewayId: common.String("normal_id"),
 	})).
@@ -381,9 +383,10 @@ func TestClusterScope_DeleteNatGateway(t *testing.T) {
 			ociCluster := infrastructurev1beta1.OCICluster{
 				Spec: tt.spec,
 				ObjectMeta: metav1.ObjectMeta{
-					UID: "a",
+					UID: "cluster_uid",
 				},
 			}
+			ociCluster.Spec.OCIResourceIdentifier = "resource_uid"
 			s := &ClusterScope{
 				VCNClient:  vcnClient,
 				OCICluster: &ociCluster,

--- a/cloud/scope/nsg_reconciler_test.go
+++ b/cloud/scope/nsg_reconciler_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	infrastructurev1beta1 "github.com/oracle/cluster-api-provider-oci/api/v1beta1"
+	"github.com/oracle/cluster-api-provider-oci/cloud/ociutil"
 	"github.com/oracle/cluster-api-provider-oci/cloud/services/vcn/mock_vcn"
 	"github.com/oracle/oci-go-sdk/v63/common"
 	"github.com/oracle/oci-go-sdk/v63/core"
@@ -766,15 +767,16 @@ func TestClusterScope_NSGSpec(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ociCluster := infrastructurev1beta1.OCICluster{
 				ObjectMeta: metav1.ObjectMeta{
-					UID: "a",
+					UID: "cluster_uid",
 				},
 				Spec: tt.spec,
 			}
+			ociCluster.Spec.OCIResourceIdentifier = "resource_uid"
 			s := &ClusterScope{
 				OCICluster: &ociCluster,
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						UID: "a",
+						UID: "cluster_uid",
 					},
 				},
 				Logger: &l,
@@ -801,8 +803,8 @@ func TestClusterScope_DeleteNSGs(t *testing.T) {
 	vcnClient := mock_vcn.NewMockClient(mockCtrl)
 
 	tags := make(map[string]string)
-	tags["CreatedBy"] = "OCIClusterAPIProvider"
-	tags["ClusterUUID"] = "a"
+	tags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+	tags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 	vcnClient.EXPECT().GetNetworkSecurityGroup(gomock.Any(), gomock.Eq(core.GetNetworkSecurityGroupRequest{
 		NetworkSecurityGroupId: common.String("nsg1"),
 	})).
@@ -929,9 +931,10 @@ func TestClusterScope_DeleteNSGs(t *testing.T) {
 			ociCluster := infrastructurev1beta1.OCICluster{
 				Spec: tt.spec,
 				ObjectMeta: metav1.ObjectMeta{
-					UID: "a",
+					UID: "cluster_uid",
 				},
 			}
+			ociCluster.Spec.OCIResourceIdentifier = "resource_uid"
 			s := &ClusterScope{
 				VCNClient:  vcnClient,
 				OCICluster: &ociCluster,
@@ -957,8 +960,8 @@ func TestClusterScope_ReconcileNSG(t *testing.T) {
 	vcnClient := mock_vcn.NewMockClient(mockCtrl)
 
 	tags := make(map[string]string)
-	tags["CreatedBy"] = "OCIClusterAPIProvider"
-	tags["ClusterUUID"] = "a"
+	tags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+	tags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 
 	definedTags := map[string]map[string]string{
 		"ns1": {
@@ -1563,16 +1566,17 @@ func TestClusterScope_ReconcileNSG(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ociCluster := infrastructurev1beta1.OCICluster{
 				ObjectMeta: metav1.ObjectMeta{
-					UID: "a",
+					UID: "cluster_uid",
 				},
 				Spec: tt.spec,
 			}
+			ociCluster.Spec.OCIResourceIdentifier = "resource_uid"
 			s := &ClusterScope{
 				VCNClient:  vcnClient,
 				OCICluster: &ociCluster,
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						UID: "a",
+						UID: "resource_uid",
 					},
 				},
 				Logger: &l,

--- a/cloud/scope/route_table_reconciler_test.go
+++ b/cloud/scope/route_table_reconciler_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	infrastructurev1beta1 "github.com/oracle/cluster-api-provider-oci/api/v1beta1"
+	"github.com/oracle/cluster-api-provider-oci/cloud/ociutil"
 	"github.com/oracle/cluster-api-provider-oci/cloud/services/identity/mock_identity"
 	"github.com/oracle/cluster-api-provider-oci/cloud/services/vcn/mock_vcn"
 	"github.com/oracle/oci-go-sdk/v63/common"
@@ -40,8 +41,8 @@ func TestClusterScope_ReconcileRouteTable(t *testing.T) {
 	identityClient := mock_identity.NewMockClient(mockCtrl)
 
 	tags := make(map[string]string)
-	tags["CreatedBy"] = "OCIClusterAPIProvider"
-	tags["ClusterUUID"] = "a"
+	tags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+	tags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 
 	definedTags := map[string]map[string]string{
 		"ns1": {
@@ -391,10 +392,11 @@ func TestClusterScope_ReconcileRouteTable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ociCluster := infrastructurev1beta1.OCICluster{
 				ObjectMeta: metav1.ObjectMeta{
-					UID: "a",
+					UID: "cluster_uid",
 				},
 				Spec: tt.spec,
 			}
+			ociCluster.Spec.OCIResourceIdentifier = "resource_uid"
 			s := &ClusterScope{
 				IdentityClient: identityClient,
 				Region:         "ashburn",
@@ -402,7 +404,7 @@ func TestClusterScope_ReconcileRouteTable(t *testing.T) {
 				OCICluster:     &ociCluster,
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						UID: "a",
+						UID: "cluster_uid",
 					},
 				},
 				Logger: &l,
@@ -426,8 +428,8 @@ func TestClusterScope_DeleteRouteTables(t *testing.T) {
 	vcnClient := mock_vcn.NewMockClient(mockCtrl)
 
 	tags := make(map[string]string)
-	tags["CreatedBy"] = "OCIClusterAPIProvider"
-	tags["ClusterUUID"] = "a"
+	tags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+	tags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 	vcnClient.EXPECT().GetRouteTable(gomock.Any(), gomock.Eq(core.GetRouteTableRequest{
 		RtId: common.String("private_id"),
 	})).
@@ -564,9 +566,10 @@ func TestClusterScope_DeleteRouteTables(t *testing.T) {
 			ociCluster := infrastructurev1beta1.OCICluster{
 				Spec: tt.spec,
 				ObjectMeta: metav1.ObjectMeta{
-					UID: "a",
+					UID: "cluster_uid",
 				},
 			}
+			ociCluster.Spec.OCIResourceIdentifier = "resource_uid"
 			s := &ClusterScope{
 				VCNClient:  vcnClient,
 				OCICluster: &ociCluster,

--- a/cloud/scope/security_list_reconciler_test.go
+++ b/cloud/scope/security_list_reconciler_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/oracle/cluster-api-provider-oci/cloud/ociutil"
 	"github.com/oracle/cluster-api-provider-oci/cloud/services/vcn/mock_vcn"
 	"github.com/oracle/oci-go-sdk/v63/common"
 	"github.com/oracle/oci-go-sdk/v63/core"
@@ -37,8 +38,8 @@ func TestClusterScope_DeleteSecurityLists(t *testing.T) {
 	vcnClient := mock_vcn.NewMockClient(mockCtrl)
 
 	tags := make(map[string]string)
-	tags["CreatedBy"] = "OCIClusterAPIProvider"
-	tags["ClusterUUID"] = "a"
+	tags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+	tags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 	vcnClient.EXPECT().GetSecurityList(gomock.Any(), gomock.Eq(core.GetSecurityListRequest{
 		SecurityListId: common.String("cp_endpoint_id"),
 	})).
@@ -181,9 +182,10 @@ func TestClusterScope_DeleteSecurityLists(t *testing.T) {
 			ociCluster := infrastructurev1beta1.OCICluster{
 				Spec: tt.spec,
 				ObjectMeta: metav1.ObjectMeta{
-					UID: "a",
+					UID: "cluster_uid",
 				},
 			}
+			ociCluster.Spec.OCIResourceIdentifier = "resource_uid"
 			s := &ClusterScope{
 				VCNClient:  vcnClient,
 				OCICluster: &ociCluster,

--- a/cloud/scope/service_gateway_reconciler_test.go
+++ b/cloud/scope/service_gateway_reconciler_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	infrastructurev1beta1 "github.com/oracle/cluster-api-provider-oci/api/v1beta1"
+	"github.com/oracle/cluster-api-provider-oci/cloud/ociutil"
 	"github.com/oracle/cluster-api-provider-oci/cloud/services/vcn/mock_vcn"
 	"github.com/oracle/oci-go-sdk/v63/common"
 	"github.com/oracle/oci-go-sdk/v63/core"
@@ -37,8 +38,8 @@ func TestClusterScope_ReconcileServiceGateway(t *testing.T) {
 	vcnClient := mock_vcn.NewMockClient(mockCtrl)
 
 	tags := make(map[string]string)
-	tags["CreatedBy"] = "OCIClusterAPIProvider"
-	tags["ClusterUUID"] = "a"
+	tags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+	tags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 
 	definedTags := map[string]map[string]string{
 		"ns1": {
@@ -275,10 +276,11 @@ func TestClusterScope_ReconcileServiceGateway(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ociCluster := infrastructurev1beta1.OCICluster{
 				ObjectMeta: metav1.ObjectMeta{
-					UID: "a",
+					UID: "cluster_uid",
 				},
 				Spec: tt.spec,
 			}
+			ociCluster.Spec.OCIResourceIdentifier = "resource_uid"
 			s := &ClusterScope{
 				VCNClient:  vcnClient,
 				OCICluster: &ociCluster,
@@ -303,8 +305,8 @@ func TestClusterScope_DeleteServiceGateway(t *testing.T) {
 	vcnClient := mock_vcn.NewMockClient(mockCtrl)
 
 	tags := make(map[string]string)
-	tags["CreatedBy"] = "OCIClusterAPIProvider"
-	tags["ClusterUUID"] = "a"
+	tags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+	tags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 	vcnClient.EXPECT().GetServiceGateway(gomock.Any(), gomock.Eq(core.GetServiceGatewayRequest{
 		ServiceGatewayId: common.String("normal_id"),
 	})).
@@ -397,15 +399,16 @@ func TestClusterScope_DeleteServiceGateway(t *testing.T) {
 			ociCluster := infrastructurev1beta1.OCICluster{
 				Spec: tt.spec,
 				ObjectMeta: metav1.ObjectMeta{
-					UID: "a",
+					UID: "cluster_uid",
 				},
 			}
+			ociCluster.Spec.OCIResourceIdentifier = "resource_uid"
 			s := &ClusterScope{
 				VCNClient:  vcnClient,
 				OCICluster: &ociCluster,
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						UID: "a",
+						UID: "resource_uid",
 					},
 				},
 				Logger: &l,

--- a/cloud/scope/subnet_reconciler_test.go
+++ b/cloud/scope/subnet_reconciler_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	infrastructurev1beta1 "github.com/oracle/cluster-api-provider-oci/api/v1beta1"
+	"github.com/oracle/cluster-api-provider-oci/cloud/ociutil"
 	"github.com/oracle/cluster-api-provider-oci/cloud/services/vcn/mock_vcn"
 	"github.com/oracle/oci-go-sdk/v63/common"
 	"github.com/oracle/oci-go-sdk/v63/core"
@@ -305,15 +306,16 @@ func TestClusterScope_SubnetSpec(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ociCluster := infrastructurev1beta1.OCICluster{
 				ObjectMeta: metav1.ObjectMeta{
-					UID: "a",
+					UID: "cluster_uid",
 				},
 				Spec: tt.spec,
 			}
+			ociCluster.Spec.OCIResourceIdentifier = "resource_uid"
 			s := &ClusterScope{
 				OCICluster: &ociCluster,
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						UID: "a",
+						UID: "resource_uid",
 					},
 				},
 				Logger: &l,
@@ -340,8 +342,8 @@ func TestClusterScope_ReconcileSubnet(t *testing.T) {
 	vcnClient := mock_vcn.NewMockClient(mockCtrl)
 
 	tags := make(map[string]string)
-	tags["CreatedBy"] = "OCIClusterAPIProvider"
-	tags["ClusterUUID"] = "a"
+	tags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+	tags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 
 	definedTags := map[string]map[string]string{
 		"ns1": {
@@ -906,16 +908,17 @@ func TestClusterScope_ReconcileSubnet(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ociCluster := infrastructurev1beta1.OCICluster{
 				ObjectMeta: metav1.ObjectMeta{
-					UID: "a",
+					UID: "cluster_uid",
 				},
 				Spec: tt.spec,
 			}
+			ociCluster.Spec.OCIResourceIdentifier = "resource_uid"
 			s := &ClusterScope{
 				VCNClient:  vcnClient,
 				OCICluster: &ociCluster,
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						UID: "a",
+						UID: "resource_uid",
 					},
 				},
 				Logger: &l,
@@ -939,8 +942,8 @@ func TestClusterScope_DeleteSubnets(t *testing.T) {
 	vcnClient := mock_vcn.NewMockClient(mockCtrl)
 
 	tags := make(map[string]string)
-	tags["CreatedBy"] = "OCIClusterAPIProvider"
-	tags["ClusterUUID"] = "a"
+	tags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+	tags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 	vcnClient.EXPECT().GetSubnet(gomock.Any(), gomock.Eq(core.GetSubnetRequest{
 		SubnetId: common.String("cp_endpoint_id"),
 	})).
@@ -1071,9 +1074,10 @@ func TestClusterScope_DeleteSubnets(t *testing.T) {
 			ociCluster := infrastructurev1beta1.OCICluster{
 				Spec: tt.spec,
 				ObjectMeta: metav1.ObjectMeta{
-					UID: "a",
+					UID: "cluster_uid",
 				},
 			}
+			ociCluster.Spec.OCIResourceIdentifier = "resource_uid"
 			s := &ClusterScope{
 				VCNClient:  vcnClient,
 				OCICluster: &ociCluster,

--- a/cloud/scope/vcn_reconciler.go
+++ b/cloud/scope/vcn_reconciler.go
@@ -138,7 +138,7 @@ func (s *ClusterScope) CreateVCN(ctx context.Context, spec infrastructurev1beta1
 	}
 	vcnResponse, err := s.VCNClient.CreateVcn(ctx, core.CreateVcnRequest{
 		CreateVcnDetails: vcnDetails,
-		OpcRetryToken:    ociutil.GetOPCRetryToken("%s-%s", "create-vcn", string(s.OCICluster.UID)),
+		OpcRetryToken:    ociutil.GetOPCRetryToken("%s-%s", "create-vcn", string(s.OCICluster.GetOCIResourceIdentifier())),
 	})
 	if err != nil {
 		s.Logger.Error(err, "failed create vcn")

--- a/cloud/scope/vcn_reconciler_test.go
+++ b/cloud/scope/vcn_reconciler_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	infrastructurev1beta1 "github.com/oracle/cluster-api-provider-oci/api/v1beta1"
+	"github.com/oracle/cluster-api-provider-oci/cloud/ociutil"
 	"github.com/oracle/cluster-api-provider-oci/cloud/services/vcn/mock_vcn"
 	"github.com/oracle/oci-go-sdk/v63/common"
 	"github.com/oracle/oci-go-sdk/v63/core"
@@ -88,12 +89,13 @@ func TestClusterScope_CreateVCN(t *testing.T) {
 			ociCluster := infrastructurev1beta1.OCICluster{
 				Spec: tt.spec,
 			}
+			tt.spec.OCIResourceIdentifier = "resource_uid"
 			s := &ClusterScope{
 				VCNClient:  vcnClient,
 				OCICluster: &ociCluster,
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						UID: "a",
+						UID: "cluster_uid",
 					},
 				},
 				Logger: &l,
@@ -117,8 +119,8 @@ func TestClusterScope_DeleteVCN(t *testing.T) {
 	vcnClient := mock_vcn.NewMockClient(mockCtrl)
 
 	tags := make(map[string]string)
-	tags["CreatedBy"] = "OCIClusterAPIProvider"
-	tags["ClusterUUID"] = "a"
+	tags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+	tags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 	vcnClient.EXPECT().GetVcn(gomock.Any(), gomock.Eq(core.GetVcnRequest{
 		VcnId: common.String("normal_id"),
 	})).
@@ -209,16 +211,17 @@ func TestClusterScope_DeleteVCN(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ociCluster := infrastructurev1beta1.OCICluster{
 				ObjectMeta: metav1.ObjectMeta{
-					UID: "a",
+					UID: "cluster_uid",
 				},
 				Spec: tt.spec,
 			}
+			ociCluster.Spec.OCIResourceIdentifier = "resource_uid"
 			s := &ClusterScope{
 				VCNClient:  vcnClient,
 				OCICluster: &ociCluster,
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						UID: "a",
+						UID: "cluster_uid",
 					},
 				},
 				Logger: &l,
@@ -243,8 +246,8 @@ func TestClusterScope_GetVCN(t *testing.T) {
 	vcnClient := mock_vcn.NewMockClient(mockCtrl)
 
 	tags := make(map[string]string)
-	tags["CreatedBy"] = "OCIClusterAPIProvider"
-	tags["ClusterUUID"] = "a"
+	tags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+	tags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 	vcnClient.EXPECT().ListVcns(gomock.Any(), gomock.Eq(core.ListVcnsRequest{
 		CompartmentId: common.String("bar"),
 		DisplayName:   common.String("foo"),
@@ -346,15 +349,16 @@ func TestClusterScope_GetVCN(t *testing.T) {
 			ociCluster := infrastructurev1beta1.OCICluster{
 				Spec: tt.spec,
 				ObjectMeta: metav1.ObjectMeta{
-					UID: "a",
+					UID: "cluster_uid",
 				},
 			}
+			ociCluster.Spec.OCIResourceIdentifier = "resource_uid"
 			s := &ClusterScope{
 				VCNClient:  vcnClient,
 				OCICluster: &ociCluster,
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						UID: "a",
+						UID: "resource_uid",
 					},
 				},
 				Logger: &l,
@@ -405,9 +409,10 @@ func TestClusterScope_GetVcnCidr(t *testing.T) {
 			ociCluster := infrastructurev1beta1.OCICluster{
 				Spec: tt.spec,
 				ObjectMeta: metav1.ObjectMeta{
-					UID: "a",
+					UID: "cluster_uid",
 				},
 			}
+			ociCluster.Spec.OCIResourceIdentifier = "resource_uid"
 			s := &ClusterScope{
 				OCICluster: &ociCluster,
 				Logger:     &l,
@@ -447,10 +452,11 @@ func TestClusterScope_GetVcnName(t *testing.T) {
 			ociCluster := infrastructurev1beta1.OCICluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "bar",
-					UID:  "a",
+					UID:  "cluster_uid",
 				},
 				Spec: tt.spec,
 			}
+			ociCluster.Spec.OCIResourceIdentifier = "resource_uid"
 			s := &ClusterScope{
 				OCICluster: &ociCluster,
 				Logger:     &l,
@@ -517,14 +523,15 @@ func TestClusterScope_IsVcnEquals(t *testing.T) {
 			ociCluster := infrastructurev1beta1.OCICluster{
 				Spec: tt.spec,
 				ObjectMeta: metav1.ObjectMeta{
-					UID: "a",
+					UID: "cluster_uid",
 				},
 			}
+			ociCluster.Spec.OCIResourceIdentifier = "resource_uid"
 			s := &ClusterScope{
 				OCICluster: &ociCluster,
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						UID: "a",
+						UID: "resource_uid",
 					},
 				},
 				Logger: &l,
@@ -542,8 +549,8 @@ func TestClusterScope_ReconcileVCN(t *testing.T) {
 	vcnClient := mock_vcn.NewMockClient(mockCtrl)
 
 	tags := make(map[string]string)
-	tags["CreatedBy"] = "OCIClusterAPIProvider"
-	tags["ClusterUUID"] = "a"
+	tags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
+	tags[ociutil.ClusterResourceIdentifier] = "resource_uid"
 
 	definedTags := map[string]map[string]string{
 		"ns1": {
@@ -693,15 +700,16 @@ func TestClusterScope_ReconcileVCN(t *testing.T) {
 			ociCluster := infrastructurev1beta1.OCICluster{
 				Spec: tt.spec,
 				ObjectMeta: metav1.ObjectMeta{
-					UID: "a",
+					UID: "cluster_uid",
 				},
 			}
+			ociCluster.Spec.OCIResourceIdentifier = "resource_uid"
 			s := &ClusterScope{
 				VCNClient:  vcnClient,
 				OCICluster: &ociCluster,
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						UID: "a",
+						UID: "resource_uid",
 					},
 				},
 				Logger: &l,

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclusters.yaml
@@ -932,6 +932,12 @@ spec:
                         type: array
                     type: object
                 type: object
+              ociResourceIdentifier:
+                description: The unique ID which will be used to tag all the resources
+                  created by this Cluster. The tag will be used to identify resources
+                  belonging to this cluster. this will be auto-generated and should
+                  not be set by the user.
+                type: string
               region:
                 description: Region the cluster operates in. It must be one of available
                   regions in Region Identifier format. See https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclustertemplates.yaml
@@ -1059,6 +1059,12 @@ spec:
                                 type: array
                             type: object
                         type: object
+                      ociResourceIdentifier:
+                        description: The unique ID which will be used to tag all the
+                          resources created by this Cluster. The tag will be used
+                          to identify resources belonging to this cluster. this will
+                          be auto-generated and should not be set by the user.
+                        type: string
                       region:
                         description: Region the cluster operates in. It must be one
                           of available regions in Region Identifier format. See https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -10,7 +10,7 @@ namePrefix: capoci-
 
 # Labels to add to all resources and selectors.
 commonLabels:
-  cluster.x-k8s.io/v1beta1: v1beta1
+  cluster.x-k8s.io/provider: "infrastructure-oci"
 
 resources:
   - credentials.yaml

--- a/config/default/manager_pull_policy.yaml
+++ b/config/default/manager_pull_policy.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
       - name: manager
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: 

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -1,14 +1,13 @@
 # This patch add annotation to admission webhook config and
 # the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
 
-# TODO: uncomment as part of https://github.com/oracle/cluster-api-provider-oci/issues/56
-#apiVersion: admissionregistration.k8s.io/v1
-#kind: MutatingWebhookConfiguration
-#metadata:
-#  name: mutating-webhook-configuration
-#  annotations:
-#    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-#---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:

--- a/config/webhook/kustomizeconfig.yaml
+++ b/config/webhook/kustomizeconfig.yaml
@@ -4,20 +4,18 @@ nameReference:
   - kind: Service
     version: v1
     fieldSpecs:
-# TODO: uncomment as part of https://github.com/oracle/cluster-api-provider-oci/issues/56
-#      - kind: MutatingWebhookConfiguration
-#        group: admissionregistration.k8s.io
-#        path: webhooks/clientConfig/service/name
+      - kind: MutatingWebhookConfiguration
+        group: admissionregistration.k8s.io
+        path: webhooks/clientConfig/service/name
       - kind: ValidatingWebhookConfiguration
         group: admissionregistration.k8s.io
         path: webhooks/clientConfig/service/name
 
 namespace:
-# TODO: uncomment as part of https://github.com/oracle/cluster-api-provider-oci/issues/56
-#  - kind: MutatingWebhookConfiguration
-#    group: admissionregistration.k8s.io
-#    path: webhooks/clientConfig/service/namespace
-#    create: true
+  - kind: MutatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/namespace
+    create: true
   - kind: ValidatingWebhookConfiguration
     group: admissionregistration.k8s.io
     path: webhooks/clientConfig/service/namespace

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,6 +1,36 @@
 
 ---
 apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1beta1-ocicluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.ocicluster.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ociclusters
+  sideEffects: None
+
+---
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null

--- a/controllers/ocicluster_controller.go
+++ b/controllers/ocicluster_controller.go
@@ -97,6 +97,14 @@ func (r *OCIClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		logger.Info("Cluster Controller has not yet set OwnerRef")
 		return ctrl.Result{}, nil
 	}
+
+	// Return early if the object or Cluster is paused.
+	if annotations.IsPaused(cluster, ociCluster) {
+		r.Recorder.Eventf(ociCluster, corev1.EventTypeNormal, "ClusterPaused", "Cluster is paused")
+		logger.Info("OCICluster or linked Cluster is marked as paused. Won't reconcile")
+		return ctrl.Result{}, nil
+	}
+
 	var clusterScope scope.ClusterScopeClient
 
 	clients, err := r.ClientProvider.GetOrBuildClient(regionOverride)

--- a/controllers/ocicluster_controller_test.go
+++ b/controllers/ocicluster_controller_test.go
@@ -55,6 +55,11 @@ func TestOCIClusterReconciler_Reconcile(t *testing.T) {
 			objects:       []client.Object{getSecret(), getOciClusterWithNoOwner()},
 			expectedEvent: "OwnerRefNotSet",
 		},
+		{
+			name:          "cluster is paused",
+			objects:       []client.Object{getSecret(), getOCIClusterWithOwner(), getPausedInfraCluster()},
+			expectedEvent: "ClusterPaused",
+		},
 	}
 
 	for _, tc := range tests {
@@ -663,4 +668,32 @@ func getOciClusterWithNoOwner() *infrastructurev1beta1.OCICluster {
 	}
 	ociCluster.OwnerReferences = []metav1.OwnerReference{}
 	return ociCluster
+}
+
+func getOCIClusterWithOwner() *infrastructurev1beta1.OCICluster {
+	ociCluster := getOciClusterWithNoOwner()
+	ociCluster.OwnerReferences = []metav1.OwnerReference{
+		{
+			Name:       "test-cluster",
+			Kind:       "Cluster",
+			APIVersion: clusterv1.GroupVersion.String(),
+		},
+	}
+	return ociCluster
+}
+
+func getPausedInfraCluster() *clusterv1.Cluster {
+	infraRef := corev1.ObjectReference{
+		Name: "oci-cluster",
+	}
+	return &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "test",
+		},
+		Spec: clusterv1.ClusterSpec{
+			InfrastructureRef: &infraRef,
+			Paused:            true,
+		},
+	}
 }


### PR DESCRIPTION
Fix bug where clusterctl move does not work, and add correct default label

**What this PR does / why we need it**:

clusterctl move was not working in CAPOCI. This was because CAPOCI used the cluster UID to tag all OCI resources created, and during reconciliation, made sure that the tags matched. But during move, the cluster UID changes. So we cannot use cluster UID as the tag. Instead what we will do is to generate UID in the defaulter and use that to tag the OCI resources. This UID will not changes as it is not the auto-generated tag.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #73 
