### PR TITLE
feat: update OCICluster webhook validations

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -25,6 +25,9 @@ const (
 	Public                   = "public"
 )
 
+// SubnetRoles a slice of all the subnet roles
+var SubnetRoles = [...]Role{ControlPlaneRole, ControlPlaneEndpointRole, WorkerRole, ServiceLoadBalancerRole}
+
 // NetworkDetails defines the configuration options for the network
 type NetworkDetails struct {
 	SubnetId       *string `json:"subnetId,omitempty"`

--- a/cloud/ociutil/ociutil.go
+++ b/cloud/ociutil/ociutil.go
@@ -116,3 +116,12 @@ func BuildClusterTags(ClusterResourceUID string) map[string]string {
 	tags[ClusterResourceIdentifier] = ClusterResourceUID
 	return tags
 }
+
+// DerefString returns the string value if the pointer isn't nil, otherwise returns empty string
+func DerefString(s *string) string {
+	if s != nil {
+		return *s
+	}
+
+	return ""
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This expands on the OCICluster webhook adding some more validation during cluster creation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #70 
