### PR TITLE
docs: Add kubernetes-template files before donating to kubernetes-sigs

### DIFF
--- a/ OWNERS 
+++ b/ OWNERS 
@@ -1,0 +1,11 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - sig-cluster-lifecycle-leads
+  - cluster-api-admins
+  - cluster-api-maintainers
+  - cluster-api-oci-maintainers
+
+reviewers:
+  - cluster-api-oci-maintainers
+  - cluster-api-oci-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,25 @@
+# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#owners_aliases
+
+aliases:
+  sig-cluster-lifecycle-leads:
+    - fabriziopandini
+    - justinsb
+    - neolit123
+    - timothysc
+  cluster-api-admins:
+    - CecileRobertMichon
+    - vincepri
+  cluster-api-maintainers:
+    - CecileRobertMichon
+    - enxebre
+    - fabriziopandini
+    - sbueringer
+    - vincepri
+  cluster-api-oci-maintainers:
+    - shyamradhakrishnan
+    - arindam-bandyopadhyay
+    - joekr
+  cluster-api-oci-reviewers:
+    - shyamradhakrishnan
+    - arindam-bandyopadhyay
+    - joekr

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+# Release Process
+
+The Kubernetes Template Project is released on an as-needed basis. The process is as follows:
+
+1. An issue is proposing a new release with a changelog since the last release
+1. All [OWNERS](OWNERS) must LGTM this release
+1. An OWNER runs `git tag -s $VERSION` and inserts the changelog and pushes the tag with `git push $VERSION`
+1. The release issue is closed
+1. An announcement email is sent to `kubernetes-dev@googlegroups.com` with the subject `[ANNOUNCE] kubernetes-template-project $VERSION is released`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,40 +1,22 @@
-# Reporting security vulnerabilities
+# Security Policy
 
-Oracle values the independent security research community and believes that
-responsible disclosure of security vulnerabilities helps us ensure the security
-and privacy of all our users.
+## Security Announcements
 
-Please do NOT raise a GitHub Issue to report a security vulnerability. If you
-believe you have found a security vulnerability, please submit a report to
-[secalert_us@oracle.com][1] preferably with a proof of concept. Please review
-some additional information on [how to report security vulnerabilities to Oracle][2].
-We encourage people who contact Oracle Security to use email encryption using
-[our encryption key][3].
+Join the [kubernetes-security-announce] group for security and vulnerability announcements.
 
-We ask that you do not use other channels or contact the project maintainers
-directly.
+You can also subscribe to an RSS feed of the above using [this link][kubernetes-security-announce-rss].
 
-Non-vulnerability related security issues including ideas for new or improved
-security features are welcome on GitHub Issues.
+## Reporting a Vulnerability
 
-## Security updates, alerts and bulletins
+Instructions for reporting a vulnerability can be found on the
+[Kubernetes Security and Disclosure Information] page.
 
-Security updates will be released on a regular cadence. Many of our projects
-will typically release security fixes in conjunction with the
-[Oracle Critical Patch Update][3] program. Security updates are released on the
-Tuesday closest to the 17th day of January, April, July and October. A pre-release
-announcement will be published on the Thursday preceding each release. Additional
-information, including past advisories, is available on our [security alerts][4]
-page.
+## Supported Versions
 
-## Security-related information
+Information about supported Kubernetes versions can be found on the
+[Kubernetes version and version skew support policy] page on the Kubernetes website.
 
-We will provide security related information such as a threat model, considerations
-for secure use, or any known security issues in our documentation. Please note
-that labs and sample code are intended to demonstrate a concept and may not be
-sufficiently hardened for production use.
-
-[1]: mailto:secalert_us@oracle.com
-[2]: https://www.oracle.com/corporate/security-practices/assurance/vulnerability/reporting.html
-[3]: https://www.oracle.com/security-alerts/encryptionkey.html
-[4]: https://www.oracle.com/security-alerts/
+[kubernetes-security-announce]: https://groups.google.com/forum/#!forum/kubernetes-security-announce
+[kubernetes-security-announce-rss]: https://groups.google.com/forum/feed/kubernetes-security-announce/msgs/rss_v2_0.xml?num=50
+[Kubernetes version and version skew support policy]: https://kubernetes.io/docs/setup/release/version-skew-policy/#supported-versions
+[Kubernetes Security and Disclosure Information]: https://kubernetes.io/docs/reference/issues-security/security/#report-a-vulnerability

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -1,0 +1,14 @@
+# Defined below are the security contacts for this repo.
+#
+# They are the contact point for the Security Response Committee to reach out
+# to for triaging and handling of incoming issues.
+#
+# The below names agree to abide by the
+# [Embargo Policy](https://git.k8s.io/security/private-distributors-list.md#embargo-policy)
+# and will be removed and replaced if they violate that agreement.
+#
+# DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
+# INSTRUCTIONS AT https://kubernetes.io/security/
+
+shyamradhakrishnan
+joekr

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Kubernetes Community Code of Conduct
+
+Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)


### PR DESCRIPTION
**What this PR does / why we need it**:
As part of https://github.com/kubernetes/community/blob/master/github-management/kubernetes-repositories.md#rules-for-donated-repositories
we need to make sure our project contains template files as per the
https://github.com/kubernetes/kubernetes-template-project

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
No currently opened issue
