### PR TITLE
Add doc for instance principal based e2e and fix empty subnet cidr bug

### DIFF
--- a/api/v1beta1/ocicluster_webhook_test.go
+++ b/api/v1beta1/ocicluster_webhook_test.go
@@ -43,6 +43,12 @@ func TestOCICluster_ValidateCreate(t *testing.T) {
 			CIDR: "10.1.0.0/16",
 		},
 	}
+	emptySubnetCidr := []*Subnet{
+		&Subnet{
+			Role: ControlPlaneRole,
+			Name: "test-subnet",
+		},
+	}
 	badSubnetCidrFormat := []*Subnet{
 		&Subnet{
 			Name: "test-subnet",
@@ -59,10 +65,11 @@ func TestOCICluster_ValidateCreate(t *testing.T) {
 			CIDR: "10.0.0.0/16",
 		},
 	}
-	badSubnetName := []*Subnet{
+	emptySubnetName := []*Subnet{
 		&Subnet{
 			Name: "",
 			CIDR: "10.0.0.0/16",
+			Role: ControlPlaneEndpointRole,
 		},
 	}
 	badSubnetRole := []*Subnet{
@@ -151,6 +158,23 @@ func TestOCICluster_ValidateCreate(t *testing.T) {
 			expectErr:             true,
 		},
 		{
+			name: "should allow empty subnet cidr",
+			c: &OCICluster{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: OCIClusterSpec{
+					CompartmentId:         "ocid",
+					OCIResourceIdentifier: "uuid",
+					NetworkSpec: NetworkSpec{
+						Vcn: VCN{
+							CIDR:    "10.0.0.0/16",
+							Subnets: emptySubnetCidr,
+						},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
 			name: "shouldn't allow subnet bad cidr format",
 			c: &OCICluster{
 				ObjectMeta: metav1.ObjectMeta{},
@@ -199,20 +223,21 @@ func TestOCICluster_ValidateCreate(t *testing.T) {
 			expectErr:             true,
 		},
 		{
-			name: "shouldn't allow invalid subnet name",
+			name: "should allow empty subnet name",
 			c: &OCICluster{
 				ObjectMeta: metav1.ObjectMeta{},
 				Spec: OCIClusterSpec{
+					CompartmentId:         "ocid",
+					OCIResourceIdentifier: "uuid",
 					NetworkSpec: NetworkSpec{
 						Vcn: VCN{
 							CIDR:    "10.0.0.0/16",
-							Subnets: badSubnetName,
+							Subnets: emptySubnetName,
 						},
 					},
 				},
 			},
-			errorMgsShouldContain: "subnet name invalid",
-			expectErr:             true,
+			expectErr: false,
 		},
 		{
 			name: "shouldn't allow bad NSG egress cidr",

--- a/cloud/scope/subnet_reconciler.go
+++ b/cloud/scope/subnet_reconciler.go
@@ -252,21 +252,26 @@ func (s *ClusterScope) GetSubnetsSpec() []*infrastructurev1beta1.Subnet {
 func (s *ClusterScope) SubnetSpec() ([]*infrastructurev1beta1.Subnet, error) {
 	var subnets []*infrastructurev1beta1.Subnet
 	var cidr string
+	var name string
 	var subnetType infrastructurev1beta1.SubnetType
 	for _, subnet := range s.GetSubnetsSpec() {
 		switch subnet.Role {
 		case infrastructurev1beta1.ControlPlaneEndpointRole:
 			subnetType = infrastructurev1beta1.Public
 			cidr = ControlPlaneEndpointSubnetDefaultCIDR
+			name = ControlPlaneEndpointDefaultName
 		case infrastructurev1beta1.ControlPlaneRole:
 			subnetType = infrastructurev1beta1.Private
 			cidr = ControlPlaneMachineSubnetDefaultCIDR
+			name = ControlPlaneDefaultName
 		case infrastructurev1beta1.ServiceLoadBalancerRole:
 			subnetType = infrastructurev1beta1.Public
 			cidr = ServiceLoadBalancerDefaultCIDR
+			name = ServiceLBDefaultName
 		case infrastructurev1beta1.WorkerRole:
 			subnetType = infrastructurev1beta1.Private
 			cidr = WorkerSubnetDefaultCIDR
+			name = WorkerDefaultName
 		default:
 			return nil, errors.New("invalid subnet role")
 		}
@@ -276,9 +281,12 @@ func (s *ClusterScope) SubnetSpec() ([]*infrastructurev1beta1.Subnet, error) {
 		if subnet.Type != "" {
 			subnetType = subnet.Type
 		}
+		if subnet.Name != "" {
+			name = subnet.Name
+		}
 		subnets = append(subnets, &infrastructurev1beta1.Subnet{
 			Role:         subnet.Role,
-			Name:         subnet.Name,
+			Name:         name,
 			CIDR:         cidr,
 			Type:         subnetType,
 			SecurityList: subnet.SecurityList,

--- a/cloud/scope/subnet_reconciler_test.go
+++ b/cloud/scope/subnet_reconciler_test.go
@@ -300,6 +300,56 @@ func TestClusterScope_SubnetSpec(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:    "default names",
+			wantErr: false,
+			spec: infrastructurev1beta1.OCIClusterSpec{
+				NetworkSpec: infrastructurev1beta1.NetworkSpec{
+					Vcn: infrastructurev1beta1.VCN{
+						Subnets: []*infrastructurev1beta1.Subnet{
+							{
+								Role: infrastructurev1beta1.ControlPlaneRole,
+							},
+							{
+								Role: infrastructurev1beta1.WorkerRole,
+							},
+							{
+								Role: infrastructurev1beta1.ServiceLoadBalancerRole,
+							},
+							{
+								Role: infrastructurev1beta1.ControlPlaneEndpointRole,
+							},
+						},
+					},
+				},
+			},
+			want: []*infrastructurev1beta1.Subnet{
+				{
+					Role: infrastructurev1beta1.ControlPlaneEndpointRole,
+					Name: ControlPlaneEndpointDefaultName,
+					CIDR: ControlPlaneEndpointSubnetDefaultCIDR,
+					Type: infrastructurev1beta1.Public,
+				},
+				{
+					Role: infrastructurev1beta1.ControlPlaneRole,
+					Name: ControlPlaneDefaultName,
+					CIDR: ControlPlaneMachineSubnetDefaultCIDR,
+					Type: infrastructurev1beta1.Private,
+				},
+				{
+					Role: infrastructurev1beta1.WorkerRole,
+					Name: WorkerDefaultName,
+					CIDR: WorkerSubnetDefaultCIDR,
+					Type: infrastructurev1beta1.Private,
+				},
+				{
+					Role: infrastructurev1beta1.ServiceLoadBalancerRole,
+					Name: ServiceLBDefaultName,
+					CIDR: ServiceLoadBalancerDefaultCIDR,
+					Type: infrastructurev1beta1.Public,
+				},
+			},
+		},
 	}
 	l := log.FromContext(context.Background())
 	for _, tt := range tests {

--- a/test/README.md
+++ b/test/README.md
@@ -3,7 +3,7 @@
 - Install `kustomize`
 - If you have a running `kind` cluster, please delete the `kind` cluster
 
-# Export the following auth settings
+# Export the following auth settings if user principal is used as credential
    ```bash
    export OCI_TENANCY_ID=<tenancy-id>
    export OCI_USER_ID=<use-id>
@@ -17,9 +17,15 @@
    export OCI_REGION_B64="$(echo -n "$OCI_REGION" | base64 | tr -d '\n')"
    export OCI_CREDENTIALS_KEY_B64=$( cat <path-to-api-private-key-file> | base64 | tr -d '\n' )
    # if Passphrase is present
-   export OCI_CREDENTIALS_PASSPHRASE_B64="$(echo -n "OCI_CREDENTIALS_PASSPHRASE" | base64 | tr -d '\n')"
-
+   export OCI_CREDENTIALS_PASSPHRASE_B64="$(echo -n "$OCI_CREDENTIALS_PASSPHRASE" | base64 | tr -d '\n')"
    ```
+
+# Export the following auth settings if instance principal has to be used
+   ```bash
+   export USE_INSTANCE_PRINCIPAL_B64="$(echo -n "true" | base64 | tr -d '\n')"
+   ```
+
+
 
 # Export the following test settings
    ```bash


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR adds the following

- Doc to supports instance principal based e2e testing
- Minor changes for instance principal based e2e testing
- Fix the empty subnet name and CIDR bug, CAPOCI should allow empty values

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #83 , Fixes #47 
