### PR TITLE
 Misc fixes in makefile to use go install tool and use a separarte met…

### DIFF
--- a/test/e2e/ccm_helpers.go
+++ b/test/e2e/ccm_helpers.go
@@ -88,6 +88,9 @@ func createService(svcName string, svcNamespace string, labels map[string]string
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: svcNamespace,
 			Name:      svcName,
+			Annotations: map[string]string{
+				"service.beta.kubernetes.io/oci-load-balancer-internal": "true",
+			},
 		},
 		Spec: serviceSpec,
 	}

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -8,7 +8,7 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-      - name: v1.0.2
+      - name: v1.1.0
         value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.0/core-components.yaml
         type: url
         files:
@@ -21,7 +21,7 @@ providers:
   - name: kubeadm
     type: BootstrapProvider
     versions:
-      - name: v1.0.0
+      - name: v1.1.0
         value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.0/bootstrap-components.yaml
         type: url
         files:
@@ -34,7 +34,7 @@ providers:
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-      - name: v1.0.0
+      - name: v1.1.0
         value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.0/control-plane-components.yaml
         type: url
         files:
@@ -70,8 +70,7 @@ providers:
           - sourcePath: "../data/infrastructure-oci/v1beta1/cluster-template-remote-vcn-peering.yaml"
           - sourcePath: "../data/infrastructure-oci/v1beta1/cluster-template-externally-managed-vcn.yaml"
           - sourcePath: "../data/infrastructure-oci/v1beta1/cluster-template-machine-pool.yaml"
-          - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-
+          - sourcePath: "../data/infrastructure-oci/v1beta1/metadata.yaml"
 
 variables:
   KUBERNETES_VERSION: "v1.22.5"

--- a/test/e2e/data/infrastructure-oci/v1beta1/metadata.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta1/metadata.yaml
@@ -2,5 +2,5 @@ apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
   - major: 1
-    minor: 1
+    minor: 0
     contract: v1beta1


### PR DESCRIPTION

**What this PR does / why we need it**:
Misc fixes to use the go install tool instead of go get, go install is recommended to build and in stall commands. Also use the correct version in capi components metadata, and use a separate metadata for oci.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
