### PR TITLE
test: Update the `cloud-provider-oci` image for e2e tests

### DIFF
--- a/templates/cluster-template-oci-addons.yaml
+++ b/templates/cluster-template-oci-addons.yaml
@@ -231,7 +231,7 @@ data:
                 path: /etc/kubernetes
           containers:
             - name: oci-cloud-controller-manager
-              image: ghcr.io/oracle/cloud-provider-oci:v1.19.12
+              image: ghcr.io/oracle/cloud-provider-oci:v1.23.0
               command: ["/usr/local/bin/oci-cloud-controller-manager"]
               args:
                 - --cloud-config=/etc/oci/cloud-provider.yaml
@@ -489,7 +489,7 @@ data:
                 - --endpoint=unix://var/run/shared-tmpfs/csi.sock
               command:
                 - /usr/local/bin/oci-csi-controller-driver
-              image: ghcr.io/oracle/cloud-provider-oci:v1.19.12
+              image: ghcr.io/oracle/cloud-provider-oci:v1.23.0
               imagePullPolicy: IfNotPresent
               volumeMounts:
                 - name: config
@@ -633,7 +633,7 @@ data:
                       fieldPath: spec.nodeName
                 - name: PATH
                   value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/host/usr/bin:/host/sbin
-              image: ghcr.io/oracle/cloud-provider-oci:v1.19.12
+              image: ghcr.io/oracle/cloud-provider-oci:v1.23.0
               securityContext:
                 privileged: true
               volumeMounts:

--- a/test/e2e/data/ccm/ccm.yaml
+++ b/test/e2e/data/ccm/ccm.yaml
@@ -60,7 +60,7 @@ spec:
             path: /etc/kubernetes
       containers:
         - name: oci-cloud-controller-manager
-          image: ghcr.io/oracle/cloud-provider-oci:v1.19.12
+          image: ghcr.io/oracle/cloud-provider-oci:v1.23.0
           command: ["/usr/local/bin/oci-cloud-controller-manager"]
           args:
             - --cloud-config=/etc/oci/cloud-provider.yaml
@@ -310,7 +310,7 @@ spec:
             - --endpoint=unix://var/run/shared-tmpfs/csi.sock
           command:
             - /usr/local/bin/oci-csi-controller-driver
-          image: ghcr.io/oracle/cloud-provider-oci:v1.19.12
+          image: ghcr.io/oracle/cloud-provider-oci:v1.23.0
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config
@@ -454,7 +454,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: PATH
               value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/host/usr/bin:/host/sbin
-          image: ghcr.io/oracle/cloud-provider-oci:v1.19.12
+          image: ghcr.io/oracle/cloud-provider-oci:v1.23.0
           securityContext:
             privileged: true
           volumeMounts:


### PR DESCRIPTION
**What this PR does / why we need it**:
Version 1.23.0 of CCM was just released. We need to stay up-to-date
https://github.com/oracle/oci-cloud-controller-manager/releases/tag/v1.23.0

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #106 
