### PR TITLE
WIP - DRAFT - Fix merge strategy for NSG/Subnet and remove usage of ID for NSG secl…

### DIFF
--- a/api/v1beta1/ocicluster_webhook.go
+++ b/api/v1beta1/ocicluster_webhook.go
@@ -44,6 +44,11 @@ func (c *OCICluster) Default() {
 	if c.Spec.OCIResourceIdentifier == "" {
 		c.Spec.OCIResourceIdentifier = string(uuid.NewUUID())
 	}
+	for _, subnet := range c.Spec.NetworkSpec.Vcn.Subnets {
+		if subnet.UID == "" {
+			subnet.UID = string(uuid.NewUUID())
+		}
+	}
 }
 
 func (c *OCICluster) SetupWebhookWithManager(mgr ctrl.Manager) error {

--- a/api/v1beta1/ociclustertemplate_webhook.go
+++ b/api/v1beta1/ociclustertemplate_webhook.go
@@ -1,0 +1,65 @@
+/*
+ *
+ * Copyright (c) 2022, Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ *
+ */
+
+package v1beta1
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+var (
+	_ webhook.Defaulter = &OCIClusterTemplate{}
+	_ webhook.Validator = &OCIClusterTemplate{}
+)
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-ociclustertemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=ociclustertemplates,versions=v1beta1,name=validation.ociclustertemplate.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/mutate-infrastructure-cluster-x-k8s-io-v1beta1-ociclustertemplate,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=ociclustertemplates,versions=v1beta1,name=default.ociclustertemplate.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+
+func (c *OCIClusterTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(c).
+		Complete()
+}
+
+func (c *OCIClusterTemplate) Default() {
+	clusterSpec := c.Spec.Template.Spec
+	for _, subnet := range clusterSpec.NetworkSpec.Vcn.Subnets {
+		if subnet.UID == "empty" {
+			subnet.UID = string(uuid.NewUUID())
+		}
+	}
+}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
+func (c *OCIClusterTemplate) ValidateCreate() error {
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
+func (c *OCIClusterTemplate) ValidateDelete() error {
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
+func (c *OCIClusterTemplate) ValidateUpdate(old runtime.Object) error {
+	return nil
+}

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -147,14 +147,16 @@ type IngressSecurityRule struct {
 type IngressSecurityRuleForNSG struct {
 	//IngressSecurityRule ID for NSG.
 	// +optional
+	// Deprecated: this field is not populated and used during reconciliation
 	ID                  *string `json:"id,omitempty"`
 	IngressSecurityRule `json:"ingressRule,omitempty"`
 }
 
 // EgressSecurityRuleForNSG is EgressSecurityRule for NSG.
 type EgressSecurityRuleForNSG struct {
-	//EgressSecurityRule ID for NSG.
+	// EgressSecurityRule ID for NSG.
 	// +optional
+	// Deprecated: this field is not populated and used during reconciliation
 	ID                 *string `json:"id,omitempty"`
 	EgressSecurityRule `json:"egressRule,omitempty"`
 }
@@ -249,9 +251,11 @@ type Subnet struct {
 	Role Role `json:"role"`
 	// Subnet OCID.
 	// +optional
+	// +kubebuilder:default=""
 	ID *string `json:"id,omitempty"`
 	// Subnet Name.
 	// +optional
+	// +kubebuilder:default=""
 	Name string `json:"name"`
 	// Subnet CIDR.
 	// +optional
@@ -262,6 +266,10 @@ type Subnet struct {
 	// The security list associated with Subnet.
 	// +optional
 	SecurityList *SecurityList `json:"securityList,omitempty"`
+	// Subnet UID.
+	// +optional
+	// +kubebuilder:default="empty"
+	UID string `json:"uid,omitempty"`
 }
 
 // NSG defines configuration for a Network Security Group.
@@ -269,9 +277,11 @@ type Subnet struct {
 type NSG struct {
 	// NSG OCID.
 	// +optional
+	// +kubebuilder:default=""
 	ID *string `json:"id,omitempty"`
 	// NSG Name.
 	// +optional
+	// +kubebuilder:default=""
 	Name string `json:"name"`
 	// Role defines the NSG role (eg. control-plane, control-plane-endpoint, service-lb, worker).
 	Role Role `json:"role,omitempty"`
@@ -318,10 +328,15 @@ type VCN struct {
 
 	// Subnets is the configuration for subnets required in the VCN.
 	// +optional
+	// +listType=map
+	// +listMapKey=uid
 	Subnets []*Subnet `json:"subnets,omitempty"`
 
 	// NetworkSecurityGroups is the configuration for the Network Security Groups required in the VCN.
 	// +optional
+	// +listType=map
+	// +listMapKey=name
+	// +listMapKey=id
 	NetworkSecurityGroups []*NSG `json:"networkSecurityGroups,omitempty"`
 }
 

--- a/cloud/scope/subnet_reconciler.go
+++ b/cloud/scope/subnet_reconciler.go
@@ -177,7 +177,7 @@ func (s *ClusterScope) DeleteSubnets(ctx context.Context) error {
 
 func (s *ClusterScope) GetSubnet(ctx context.Context, spec infrastructurev1beta1.Subnet) (*core.Subnet, error) {
 	subnetOcid := spec.ID
-	if subnetOcid != nil {
+	if subnetOcid != nil && *subnetOcid != "" {
 		resp, err := s.VCNClient.GetSubnet(ctx, core.GetSubnetRequest{
 			SubnetId: subnetOcid,
 		})

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclusters.yaml
@@ -282,11 +282,14 @@ spec:
                                         type: object
                                     type: object
                                   id:
-                                    description: EgressSecurityRule ID for NSG.
+                                    description: 'EgressSecurityRule ID for NSG. Deprecated:
+                                      this field is not populated and used during
+                                      reconciliation'
                                     type: string
                                 type: object
                               type: array
                             id:
+                              default: ""
                               description: NSG OCID.
                               type: string
                             ingressRules:
@@ -296,7 +299,9 @@ spec:
                                   for NSG
                                 properties:
                                   id:
-                                    description: IngressSecurityRule ID for NSG.
+                                    description: 'IngressSecurityRule ID for NSG.
+                                      Deprecated: this field is not populated and
+                                      used during reconciliation'
                                     type: string
                                   ingressRule:
                                     description: IngressSecurityRule A rule for allowing
@@ -463,6 +468,7 @@ spec:
                                 type: object
                               type: array
                             name:
+                              default: ""
                               description: NSG Name.
                               type: string
                             role:
@@ -471,6 +477,10 @@ spec:
                               type: string
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        - id
+                        x-kubernetes-list-type: map
                       privateRouteTableId:
                         description: ID of Private Route Table.
                         type: string
@@ -491,9 +501,11 @@ spec:
                               description: Subnet CIDR.
                               type: string
                             id:
+                              default: ""
                               description: Subnet OCID.
                               type: string
                             name:
+                              default: ""
                               description: Subnet Name.
                               type: string
                             role:
@@ -845,10 +857,17 @@ spec:
                               description: Type defines the subnet type (e.g. public,
                                 private).
                               type: string
+                            uid:
+                              default: empty
+                              description: Subnet UID.
+                              type: string
                           required:
                           - role
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - uid
+                        x-kubernetes-list-type: map
                     type: object
                   vcnPeering:
                     description: VCNPeering configuration.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclustertemplates.yaml
@@ -320,12 +320,14 @@ spec:
                                                 type: object
                                             type: object
                                           id:
-                                            description: EgressSecurityRule ID for
-                                              NSG.
+                                            description: 'EgressSecurityRule ID for
+                                              NSG. Deprecated: this field is not populated
+                                              and used during reconciliation'
                                             type: string
                                         type: object
                                       type: array
                                     id:
+                                      default: ""
                                       description: NSG OCID.
                                       type: string
                                     ingressRules:
@@ -335,8 +337,9 @@ spec:
                                           IngressSecurityRule for NSG
                                         properties:
                                           id:
-                                            description: IngressSecurityRule ID for
-                                              NSG.
+                                            description: 'IngressSecurityRule ID for
+                                              NSG. Deprecated: this field is not populated
+                                              and used during reconciliation'
                                             type: string
                                           ingressRule:
                                             description: IngressSecurityRule A rule
@@ -529,6 +532,7 @@ spec:
                                         type: object
                                       type: array
                                     name:
+                                      default: ""
                                       description: NSG Name.
                                       type: string
                                     role:
@@ -538,6 +542,10 @@ spec:
                                       type: string
                                   type: object
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                - id
+                                x-kubernetes-list-type: map
                               privateRouteTableId:
                                 description: ID of Private Route Table.
                                 type: string
@@ -558,9 +566,11 @@ spec:
                                       description: Subnet CIDR.
                                       type: string
                                     id:
+                                      default: ""
                                       description: Subnet OCID.
                                       type: string
                                     name:
+                                      default: ""
                                       description: Subnet Name.
                                       type: string
                                     role:
@@ -965,10 +975,17 @@ spec:
                                       description: Type defines the subnet type (e.g.
                                         public, private).
                                       type: string
+                                    uid:
+                                      default: empty
+                                      description: Subnet UID.
+                                      type: string
                                   required:
                                   - role
                                   type: object
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                - uid
+                                x-kubernetes-list-type: map
                             type: object
                           vcnPeering:
                             description: VCNPeering configuration.

--- a/config/crd/patches/cainjection_in_ociclustertemplates.yaml
+++ b/config/crd/patches/cainjection_in_ociclustertemplates.yaml
@@ -1,0 +1,7 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: ociclustertemplates.infrastructure.cluster.x-k8s.io

--- a/config/crd/patches/webhook_in_ociclustertemplates.yaml
+++ b/config/crd/patches/webhook_in_ociclustertemplates.yaml
@@ -1,0 +1,17 @@
+# The following patch enables a conversion webhook for the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ociclustertemplates.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert
+      conversionReviewVersions:
+        - v1
+        - v1beta1

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -28,6 +28,28 @@ webhooks:
     resources:
     - ociclusters
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1beta1-ociclustertemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.ociclustertemplate.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ociclustertemplates
+  sideEffects: None
 
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -56,6 +78,27 @@ webhooks:
     - UPDATE
     resources:
     - ociclusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-ociclustertemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.ociclustertemplate.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ociclustertemplates
   sideEffects: None
 - admissionReviewVersions:
   - v1beta1

--- a/main.go
+++ b/main.go
@@ -194,6 +194,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = (&infrastructurev1beta1.OCIClusterTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "OCIClusterTemplate")
+		os.Exit(1)
+	}
+
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/templates/cluster-template-cluster-class.yaml
+++ b/templates/cluster-template-cluster-class.yaml
@@ -26,3 +26,11 @@ spec:
         value: ${OCI_COMPARTMENT_ID}
       - name: imageId
         value: ${OCI_IMAGE_ID}
+      - name: subnets
+        value:
+        - id: ocid1.subnet.oc1.phx.aaaaaaaa7gyvlsu2vxtpiydb5iu5vg3v3cdb63ayavalabcidbh3sjilm5qq
+          role: control-plane-endpoint
+        - id: ocid1.subnet.oc1.phx.aaaaaaaayou22cspyzamn227zqh3i4wqkv3lk57gaaa2zvd7ahiq2hrabm7q
+          role: worker
+        - id: ocid1.subnet.oc1.phx.aaaaaaaab2uqa5425ljx6sqdecmdbxkf2lgcvfevcsbsfrkwh5wwgxd6ccta
+          role: control-plane

--- a/templates/clusterclass-example.yaml
+++ b/templates/clusterclass-example.yaml
@@ -33,6 +33,18 @@ spec:
             kind: OCIMachineTemplate
             name: worker-machine-template
   variables:
+  - name: subnets
+    required: true
+    schema:
+      openAPIV3Schema:
+        type: array
+        items:
+          type: object
+          properties:
+            id:
+              type: string
+            role:
+              type: string
   - name: ssh_authorized_keys
     required: false
     schema:
@@ -68,6 +80,18 @@ spec:
         type: boolean
         default: true
   patches:
+  - name: subnets
+    definitions:
+      - selector:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+          kind: OCIClusterTemplate
+          matchResources:
+            infrastructureCluster: true
+        jsonPatches:
+          - op: add
+            path: "/spec/template/spec/networkSpec/vcn/subnets"
+            valueFrom:
+              variable: subnets
   - name: compartmentId
     definitions:
       - selector:
@@ -162,7 +186,17 @@ metadata:
   name: ocicluster
 spec:
   template:
-    spec: {}
+    spec:
+      compartmentId: ocid1.compartment.oc1..aaaaaaaaq6ucotbu72r32xznh5fnh2f77vfk2i35lwazp7gazk6lkzluvwqa
+      networkSpec:
+        apiServerLoadBalancer:
+        skipNetworkManagement: true
+        vcn:
+          id: ocid1.vcn.oc1.phx.amaaaaaah4gjgpyatwtoroz5puimmtqtdy4ggrqbmvldfebxwi5otax24f7a
+          subnets:
+            - name: control-plane-endpoint
+              role: control-plane-endpoint
+              type: private
 ---
 kind: KubeadmControlPlaneTemplate
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
Fix merge strategy for NSG/Subnet and remove usage of ID for NSG seclist reconciliation

**What this PR does / why we need it**:

* NSG/Subnet lists are hitting the issue mentioned https://main.cluster-api.sigs.k8s.io/developer/providers/v1.1-to-v1.2.html#required-api-changes-for-providers . Fix is as per the suggestion in the doc
* NSG Security rules has a similar problem but cant be fixed in a similar way because ID is generated and hence cannot be used in ClusterClass Server side patching. The ClusterClass template will not have the ID. Also, ideally, the NSG Seclist rules should just be  based on the actual rule comparison and not ID comparison. So we have changed code to use rule comparison.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #113 
