### PR TITLE
Update cluster-api e2e config

### DIFF
--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -8,8 +8,8 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-      - name: v1.1.0
-        value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.0/core-components.yaml
+      - name: v1.1.5
+        value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.5/core-components.yaml
         type: url
         files:
           - sourcePath: "../data/shared/v1beta1/metadata.yaml"


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump the cluster-api version to 1.1.5

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #109
