### PR TITLE
Tags should not be sent in update API calls

### DIFF
--- a/cloud/scope/drg_reconciler.go
+++ b/cloud/scope/drg_reconciler.go
@@ -46,12 +46,6 @@ func (s *ClusterScope) ReconcileDRG(ctx context.Context) error {
 	}
 	if drg != nil {
 		s.getDRG().ID = drg.Id
-		if !s.IsTagsEqual(drg.FreeformTags, drg.DefinedTags) {
-			_, err := s.updateDRG(ctx)
-			if err != nil {
-				return err
-			}
-		}
 		s.Logger.Info("No Reconciliation Required for DRG", "drg", drg.Id)
 		return nil
 	}
@@ -124,20 +118,6 @@ func (s *ClusterScope) createDRG(ctx context.Context) (*core.Drg, error) {
 			DisplayName:   common.String(s.GetDRGName()),
 		},
 		OpcRetryToken: ociutil.GetOPCRetryToken("%s-%s", "create-drg", string(s.OCICluster.GetOCIResourceIdentifier())),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return &response.Drg, nil
-}
-
-func (s *ClusterScope) updateDRG(ctx context.Context) (*core.Drg, error) {
-	response, err := s.VCNClient.UpdateDrg(ctx, core.UpdateDrgRequest{
-		DrgId: s.getDRG().ID,
-		UpdateDrgDetails: core.UpdateDrgDetails{
-			FreeformTags: s.GetFreeFormTags(),
-			DefinedTags:  s.GetDefinedTags(),
-		},
 	})
 	if err != nil {
 		return nil, err

--- a/cloud/scope/drg_reconciler_test.go
+++ b/cloud/scope/drg_reconciler_test.go
@@ -161,38 +161,6 @@ func TestDRGReconciliation(t *testing.T) {
 			},
 		},
 		{
-			name:          "drg update",
-			errorExpected: false,
-			testSpecificSetup: func(clusterScope *ClusterScope, vcnClient *mock_vcn.MockClient) {
-				vcnPeering.DRG = &infrastructurev1beta1.DRG{}
-				vcnPeering.DRG.Manage = true
-				vcnPeering.DRG.ID = common.String("drg-id")
-				existingTags := make(map[string]string)
-				existingTags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
-				existingTags[ociutil.ClusterResourceIdentifier] = "resource_uid"
-				existingTags["test"] = "test"
-				clusterScope.OCICluster.Spec.NetworkSpec.VCNPeering = &vcnPeering
-				vcnClient.EXPECT().GetDrg(gomock.Any(), gomock.Eq(core.GetDrgRequest{
-					DrgId: common.String("drg-id"),
-				})).
-					Return(core.GetDrgResponse{
-						Drg: core.Drg{
-							Id:           common.String("drg-id"),
-							FreeformTags: existingTags,
-							DefinedTags:  make(map[string]map[string]interface{}),
-						},
-					}, nil)
-				vcnClient.EXPECT().UpdateDrg(gomock.Any(), gomock.Eq(core.UpdateDrgRequest{
-					DrgId: common.String("drg-id"),
-					UpdateDrgDetails: core.UpdateDrgDetails{
-						FreeformTags: tags,
-						DefinedTags:  make(map[string]map[string]interface{}),
-					},
-				})).
-					Return(core.UpdateDrgResponse{}, nil)
-			},
-		},
-		{
 			name:          "drg create",
 			errorExpected: false,
 			testSpecificSetup: func(clusterScope *ClusterScope, vcnClient *mock_vcn.MockClient) {

--- a/cloud/scope/drg_rpc_attachment_reconciler.go
+++ b/cloud/scope/drg_rpc_attachment_reconciler.go
@@ -55,13 +55,6 @@ func (s *ClusterScope) ReconcileDRGRPCAttachment(ctx context.Context) error {
 		if localRpc != nil {
 			rpcSpec.RPCConnectionId = localRpc.Id
 			s.Logger.Info("Local RPC exists", "rpcId", localRpc.Id)
-			if !s.IsTagsEqual(localRpc.FreeformTags, localRpc.DefinedTags) {
-				_, err := s.updateDRGRpc(ctx, localRpc.Id, s.VCNClient)
-				if err != nil {
-					return err
-				}
-				s.Logger.Info("Local RPC has been updated", "rpcId", localRpc.Id)
-			}
 		} else {
 			localRpc, err = s.createRPC(ctx, s.getDrgID(), s.OCICluster.Name, s.VCNClient)
 			if err != nil {
@@ -91,13 +84,6 @@ func (s *ClusterScope) ReconcileDRGRPCAttachment(ctx context.Context) error {
 				s.Logger.Info("Remote RPC exists", "rpcId", localRpc.Id)
 				s.Logger.Info("Connection status of 2 peered RPCs", "status", localRpc.PeeringStatus)
 				rpcSpec.PeerRPCConnectionId = remoteRpc.Id
-				if !s.IsTagsEqual(remoteRpc.FreeformTags, remoteRpc.DefinedTags) {
-					_, err := s.updateDRGRpc(ctx, remoteRpc.Id, clientProvider.VCNClient)
-					if err != nil {
-						return err
-					}
-					s.Logger.Info("Remote RPC has been updated", "rpcId", remoteRpc.Id)
-				}
 			} else {
 				remoteRpc, err = s.createRPC(ctx, rpcSpec.PeerDRGId, s.OCICluster.Name, clientProvider.VCNClient)
 				if err != nil {

--- a/cloud/scope/drg_vcn_attachment_reconciler.go
+++ b/cloud/scope/drg_vcn_attachment_reconciler.go
@@ -43,12 +43,6 @@ func (s *ClusterScope) ReconcileDRGVCNAttachment(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		if !s.IsTagsEqual(attachment.FreeformTags, attachment.DefinedTags) {
-			_, err := s.UpdateDRGAttachment(ctx)
-			if err != nil {
-				return err
-			}
-		}
 		return nil
 	}
 

--- a/cloud/scope/drg_vcn_attachment_reconciler_test.go
+++ b/cloud/scope/drg_vcn_attachment_reconciler_test.go
@@ -131,39 +131,6 @@ func TestDRGVCNAttachmentReconciliation(t *testing.T) {
 			},
 		},
 		{
-			name:          "drg attachment update",
-			errorExpected: false,
-			testSpecificSetup: func(clusterScope *ClusterScope, vcnClient *mock_vcn.MockClient) {
-				vcnPeering.DRG = &infrastructurev1beta1.DRG{}
-				vcnPeering.DRG.Manage = true
-				vcnPeering.DRG.ID = common.String("drg-id")
-				vcnPeering.DRG.VcnAttachmentId = common.String("attachment-id")
-				clusterScope.OCICluster.Spec.NetworkSpec.VCNPeering = &vcnPeering
-				existingTags := make(map[string]string)
-				existingTags[ociutil.CreatedBy] = ociutil.OCIClusterAPIProvider
-				existingTags[ociutil.ClusterResourceIdentifier] = "resource_uid"
-				existingTags["test"] = "test"
-				vcnClient.EXPECT().GetDrgAttachment(gomock.Any(), gomock.Eq(core.GetDrgAttachmentRequest{
-					DrgAttachmentId: common.String("attachment-id"),
-				})).
-					Return(core.GetDrgAttachmentResponse{
-						DrgAttachment: core.DrgAttachment{
-							Id:           common.String("attachment-id"),
-							FreeformTags: existingTags,
-							DefinedTags:  make(map[string]map[string]interface{}),
-						},
-					}, nil)
-				vcnClient.EXPECT().UpdateDrgAttachment(gomock.Any(), gomock.Eq(core.UpdateDrgAttachmentRequest{
-					DrgAttachmentId: common.String("attachment-id"),
-					UpdateDrgAttachmentDetails: core.UpdateDrgAttachmentDetails{
-						FreeformTags: tags,
-						DefinedTags:  make(map[string]map[string]interface{}),
-					},
-				})).
-					Return(core.UpdateDrgAttachmentResponse{}, nil)
-			},
-		},
-		{
 			name:          "drg attachment create",
 			errorExpected: false,
 			testSpecificSetup: func(clusterScope *ClusterScope, vcnClient *mock_vcn.MockClient) {

--- a/cloud/scope/internet_gateway_reconciler.go
+++ b/cloud/scope/internet_gateway_reconciler.go
@@ -38,9 +38,6 @@ func (s *ClusterScope) ReconcileInternetGateway(ctx context.Context) error {
 	}
 	if igw != nil {
 		s.OCICluster.Spec.NetworkSpec.Vcn.InternetGatewayId = igw.Id
-		if !s.IsTagsEqual(igw.FreeformTags, igw.DefinedTags) {
-			return s.UpdateInternetGateway(ctx)
-		}
 		s.Logger.Info("No Reconciliation Required for Internet Gateway", "internet_gateway", igw.Id)
 		return nil
 	}
@@ -88,24 +85,6 @@ func (s *ClusterScope) GetInternetGateway(ctx context.Context) (*core.InternetGa
 		}
 	}
 	return nil, nil
-}
-
-// UpdateInternetGateway updates the FreeFormTags and DefinedTags
-func (s *ClusterScope) UpdateInternetGateway(ctx context.Context) error {
-	updateIGWDetails := core.UpdateInternetGatewayDetails{
-		FreeformTags: s.GetFreeFormTags(),
-		DefinedTags:  s.GetDefinedTags(),
-	}
-	igwResponse, err := s.VCNClient.UpdateInternetGateway(ctx, core.UpdateInternetGatewayRequest{
-		IgId:                         s.OCICluster.Spec.NetworkSpec.Vcn.InternetGatewayId,
-		UpdateInternetGatewayDetails: updateIGWDetails,
-	})
-	if err != nil {
-		s.Logger.Error(err, "failed to reconcile the internet gateway, failed to update")
-		return errors.Wrap(err, "failed to reconcile the internet gateway, failed to update")
-	}
-	s.Logger.Info("successfully updated the internet gateway", "internet_gateway", *igwResponse.Id)
-	return nil
 }
 
 // CreateInternetGateway creates the Internet Gateway for the cluster based on the ClusterScope

--- a/cloud/scope/internet_gateway_reconciler_test.go
+++ b/cloud/scope/internet_gateway_reconciler_test.go
@@ -70,34 +70,13 @@ func TestClusterScope_ReconcileInternetGateway(t *testing.T) {
 				FreeformTags: tags,
 				DefinedTags:  definedTagsInterface,
 			},
-		}, nil).Times(2)
+		}, nil)
 
 	updatedTags := make(map[string]string)
 	for k, v := range tags {
 		updatedTags[k] = v
 	}
 	updatedTags["foo"] = "bar"
-	vcnClient.EXPECT().UpdateInternetGateway(gomock.Any(), gomock.Eq(core.UpdateInternetGatewayRequest{
-		IgId: common.String("foo"),
-		UpdateInternetGatewayDetails: core.UpdateInternetGatewayDetails{
-			FreeformTags: updatedTags,
-			DefinedTags:  definedTagsInterface,
-		},
-	})).
-		Return(core.UpdateInternetGatewayResponse{
-			InternetGateway: core.InternetGateway{
-				Id:           common.String("foo"),
-				FreeformTags: tags,
-			},
-		}, nil)
-	vcnClient.EXPECT().UpdateInternetGateway(gomock.Any(), gomock.Eq(core.UpdateInternetGatewayRequest{
-		IgId: common.String("igw_id"),
-		UpdateInternetGatewayDetails: core.UpdateInternetGatewayDetails{
-			FreeformTags: updatedTags,
-			DefinedTags:  definedTagsInterface,
-		},
-	})).
-		Return(core.UpdateInternetGatewayResponse{}, errors.New("some error"))
 	vcnClient.EXPECT().ListInternetGateways(gomock.Any(), gomock.Eq(core.ListInternetGatewaysRequest{
 		CompartmentId: common.String("foo"),
 		DisplayName:   common.String("internet-gateway"),
@@ -190,22 +169,7 @@ func TestClusterScope_ReconcileInternetGateway(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "update needed",
-			spec: infrastructurev1beta1.OCIClusterSpec{
-				FreeformTags: map[string]string{
-					"foo": "bar",
-				},
-				DefinedTags: definedTags,
-				NetworkSpec: infrastructurev1beta1.NetworkSpec{
-					Vcn: infrastructurev1beta1.VCN{
-						InternetGatewayId: common.String("foo"),
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "id not present in spec but found by name and update needed but error out",
+			name: "id not present in spec but found by name and no update needed",
 			spec: infrastructurev1beta1.OCIClusterSpec{
 				CompartmentId: "foo",
 				FreeformTags: map[string]string{
@@ -218,8 +182,7 @@ func TestClusterScope_ReconcileInternetGateway(t *testing.T) {
 					},
 				},
 			},
-			wantErr:       true,
-			expectedError: "failed to reconcile the internet gateway, failed to update: some error",
+			wantErr: false,
 		},
 		{
 			name: "creation needed",

--- a/cloud/scope/load_balancer_reconciler.go
+++ b/cloud/scope/load_balancer_reconciler.go
@@ -112,9 +112,7 @@ func (s *ClusterScope) GetControlPlaneLoadBalancerName() string {
 func (s *ClusterScope) UpdateLB(ctx context.Context, lb infrastructurev1beta1.LoadBalancer) error {
 	lbId := s.OCICluster.Spec.NetworkSpec.APIServerLB.LoadBalancerId
 	updateLBDetails := networkloadbalancer.UpdateNetworkLoadBalancerDetails{
-		DisplayName:  common.String(lb.Name),
-		FreeformTags: s.GetFreeFormTags(),
-		DefinedTags:  s.GetDefinedTags(),
+		DisplayName: common.String(lb.Name),
 	}
 	lbResponse, err := s.LoadBalancerClient.UpdateNetworkLoadBalancer(ctx, networkloadbalancer.UpdateNetworkLoadBalancerRequest{
 		UpdateNetworkLoadBalancerDetails: updateLBDetails,
@@ -244,12 +242,12 @@ func (s *ClusterScope) getLoadbalancerIp(nlb networkloadbalancer.NetworkLoadBala
 }
 
 // IsLBEqual determines if the actual networkloadbalancer.NetworkLoadBalancer is equal to the desired.
-// Equality is determined by DisplayName, FreeformTags and DefinedTags matching.
+// Equality is determined by DisplayName
 func (s *ClusterScope) IsLBEqual(actual *networkloadbalancer.NetworkLoadBalancer, desired infrastructurev1beta1.LoadBalancer) bool {
 	if desired.Name != *actual.DisplayName {
 		return false
 	}
-	return s.IsTagsEqual(actual.FreeformTags, actual.DefinedTags)
+	return true
 }
 
 // GetLoadBalancer retrieves the Cluster's networkloadbalancer.NetworkLoadBalancer using the one of the following methods

--- a/cloud/scope/nat_gateway_reconciler.go
+++ b/cloud/scope/nat_gateway_reconciler.go
@@ -38,9 +38,6 @@ func (s *ClusterScope) ReconcileNatGateway(ctx context.Context) error {
 	}
 	if ngw != nil {
 		s.OCICluster.Spec.NetworkSpec.Vcn.NatGatewayId = ngw.Id
-		if !s.IsTagsEqual(ngw.FreeformTags, ngw.DefinedTags) {
-			return s.UpdateNatGateway(ctx)
-		}
 		s.Logger.Info("No Reconciliation Required for Nat Gateway", "nat_gateway", ngw.Id)
 		return nil
 	}

--- a/cloud/scope/nat_gateway_reconciler_test.go
+++ b/cloud/scope/nat_gateway_reconciler_test.go
@@ -77,27 +77,6 @@ func TestClusterScope_ReconcileNatGateway(t *testing.T) {
 		updatedTags[k] = v
 	}
 	updatedTags["foo"] = "bar"
-	vcnClient.EXPECT().UpdateNatGateway(gomock.Any(), gomock.Eq(core.UpdateNatGatewayRequest{
-		NatGatewayId: common.String("foo"),
-		UpdateNatGatewayDetails: core.UpdateNatGatewayDetails{
-			FreeformTags: updatedTags,
-			DefinedTags:  definedTagsInterface,
-		},
-	})).
-		Return(core.UpdateNatGatewayResponse{
-			NatGateway: core.NatGateway{
-				Id:           common.String("foo"),
-				FreeformTags: tags,
-			},
-		}, nil)
-	vcnClient.EXPECT().UpdateNatGateway(gomock.Any(), gomock.Eq(core.UpdateNatGatewayRequest{
-		NatGatewayId: common.String("ngw_id"),
-		UpdateNatGatewayDetails: core.UpdateNatGatewayDetails{
-			FreeformTags: updatedTags,
-			DefinedTags:  definedTagsInterface,
-		},
-	})).
-		Return(core.UpdateNatGatewayResponse{}, errors.New("some error"))
 	vcnClient.EXPECT().ListNatGateways(gomock.Any(), gomock.Eq(core.ListNatGatewaysRequest{
 		CompartmentId: common.String("foo"),
 		DisplayName:   common.String("nat-gateway"),
@@ -188,7 +167,7 @@ func TestClusterScope_ReconcileNatGateway(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "update needed",
+			name: "no update needed",
 			spec: infrastructurev1beta1.OCIClusterSpec{
 				DefinedTags: definedTags,
 				FreeformTags: map[string]string{
@@ -203,7 +182,7 @@ func TestClusterScope_ReconcileNatGateway(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "id not present in spec but found by name and update needed but error out",
+			name: "id not present in spec but found by name and no update needed",
 			spec: infrastructurev1beta1.OCIClusterSpec{
 				CompartmentId: "foo",
 				FreeformTags: map[string]string{
@@ -216,8 +195,7 @@ func TestClusterScope_ReconcileNatGateway(t *testing.T) {
 					},
 				},
 			},
-			wantErr:       true,
-			expectedError: "failed to reconcile the nat gateway, failed to update: some error",
+			wantErr: false,
 		},
 		{
 			name: "creation needed",

--- a/cloud/scope/nsg_reconciler.go
+++ b/cloud/scope/nsg_reconciler.go
@@ -180,12 +180,12 @@ func (s *ClusterScope) IsNSGExitsByRole(role infrastructurev1beta1.Role) bool {
 	return false
 }
 
-// IsNSGEqual compares the actual and desired NSG using name/freeform tags and defined tags.
+// IsNSGEqual compares the actual and desired NSG using name.
 func (s *ClusterScope) IsNSGEqual(actual *core.NetworkSecurityGroup, desired infrastructurev1beta1.NSG) bool {
 	if *actual.DisplayName != desired.Name {
 		return false
 	}
-	return s.IsTagsEqual(actual.FreeformTags, actual.DefinedTags)
+	return true
 }
 
 // UpdateNSGSecurityRulesIfNeeded updates NSG rules if required by comparing actual and desired.
@@ -295,9 +295,7 @@ func (s *ClusterScope) UpdateNSGSecurityRulesIfNeeded(ctx context.Context, desir
 
 func (s *ClusterScope) UpdateNSG(ctx context.Context, nsgSpec infrastructurev1beta1.NSG) error {
 	updateNSGDetails := core.UpdateNetworkSecurityGroupDetails{
-		DisplayName:  common.String(nsgSpec.Name),
-		FreeformTags: s.GetFreeFormTags(),
-		DefinedTags:  s.GetDefinedTags(),
+		DisplayName: common.String(nsgSpec.Name),
 	}
 	nsgResponse, err := s.VCNClient.UpdateNetworkSecurityGroup(ctx, core.UpdateNetworkSecurityGroupRequest{
 		NetworkSecurityGroupId:            nsgSpec.ID,

--- a/cloud/scope/nsg_reconciler_test.go
+++ b/cloud/scope/nsg_reconciler_test.go
@@ -1172,9 +1172,7 @@ func TestClusterScope_ReconcileNSG(t *testing.T) {
 	vcnClient.EXPECT().UpdateNetworkSecurityGroup(gomock.Any(), gomock.Eq(core.UpdateNetworkSecurityGroupRequest{
 		NetworkSecurityGroupId: common.String("update-id"),
 		UpdateNetworkSecurityGroupDetails: core.UpdateNetworkSecurityGroupDetails{
-			FreeformTags: tags,
-			DefinedTags:  definedTagsInterface,
-			DisplayName:  common.String("update-nsg"),
+			DisplayName: common.String("update-nsg"),
 		},
 	})).
 		Return(core.UpdateNetworkSecurityGroupResponse{
@@ -1187,9 +1185,7 @@ func TestClusterScope_ReconcileNSG(t *testing.T) {
 	vcnClient.EXPECT().UpdateNetworkSecurityGroup(gomock.Any(), gomock.Eq(core.UpdateNetworkSecurityGroupRequest{
 		NetworkSecurityGroupId: common.String("update-id"),
 		UpdateNetworkSecurityGroupDetails: core.UpdateNetworkSecurityGroupDetails{
-			FreeformTags: tags,
-			DefinedTags:  definedTagsInterface,
-			DisplayName:  common.String("update-nsg-error"),
+			DisplayName: common.String("update-nsg-error"),
 		},
 	})).
 		Return(core.UpdateNetworkSecurityGroupResponse{}, errors.New("some error"))

--- a/cloud/scope/route_table_reconciler_test.go
+++ b/cloud/scope/route_table_reconciler_test.go
@@ -122,27 +122,6 @@ func TestClusterScope_ReconcileRouteTable(t *testing.T) {
 		updatedTags[k] = v
 	}
 	updatedTags["foo"] = "bar"
-	vcnClient.EXPECT().UpdateRouteTable(gomock.Any(), gomock.Eq(core.UpdateRouteTableRequest{
-		RtId: common.String("private"),
-		UpdateRouteTableDetails: core.UpdateRouteTableDetails{
-			FreeformTags: updatedTags,
-			DefinedTags:  definedTagsInterface,
-		},
-	})).
-		Return(core.UpdateRouteTableResponse{
-			RouteTable: core.RouteTable{
-				Id:           common.String("private"),
-				FreeformTags: updatedTags,
-			},
-		}, nil)
-	vcnClient.EXPECT().UpdateRouteTable(gomock.Any(), gomock.Eq(core.UpdateRouteTableRequest{
-		RtId: common.String("rt_id"),
-		UpdateRouteTableDetails: core.UpdateRouteTableDetails{
-			FreeformTags: updatedTags,
-			DefinedTags:  definedTagsInterface,
-		},
-	})).
-		Return(core.UpdateRouteTableResponse{}, errors.New("some error"))
 	vcnClient.EXPECT().ListRouteTables(gomock.Any(), gomock.Eq(core.ListRouteTablesRequest{
 		CompartmentId: common.String("foo"),
 		DisplayName:   common.String("private-route-table"),
@@ -334,7 +313,7 @@ func TestClusterScope_ReconcileRouteTable(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "id not present in spec but found by name and update needed but error out",
+			name: "id not present in spec but found by name and no update",
 			spec: infrastructurev1beta1.OCIClusterSpec{
 				CompartmentId: "foo",
 				FreeformTags: map[string]string{
@@ -357,8 +336,7 @@ func TestClusterScope_ReconcileRouteTable(t *testing.T) {
 					},
 				},
 			},
-			wantErr:       true,
-			expectedError: "failed to reconcile the route table, failed to update: some error",
+			wantErr: false,
 		},
 		{
 			name: "creation failed",

--- a/cloud/scope/security_list_reconciler.go
+++ b/cloud/scope/security_list_reconciler.go
@@ -123,7 +123,7 @@ func (s *ClusterScope) IsSecurityListEqual(actual core.SecurityList, desired inf
 			return false
 		}
 	}
-	return s.IsTagsEqual(actual.FreeformTags, actual.DefinedTags)
+	return true
 }
 
 func (s *ClusterScope) UpdateSecurityList(ctx context.Context, securityListSpec infrastructurev1beta1.SecurityList) error {
@@ -145,8 +145,6 @@ func (s *ClusterScope) UpdateSecurityList(ctx context.Context, securityListSpec 
 		DisplayName:          common.String(securityListSpec.Name),
 		EgressSecurityRules:  egressRules,
 		IngressSecurityRules: ingressRules,
-		FreeformTags:         s.GetFreeFormTags(),
-		DefinedTags:          s.GetDefinedTags(),
 	}
 	securityListResponse, err := s.VCNClient.UpdateSecurityList(ctx, core.UpdateSecurityListRequest{
 		UpdateSecurityListDetails: updateSecurityListDetails,

--- a/cloud/scope/service_gateway_reconciler.go
+++ b/cloud/scope/service_gateway_reconciler.go
@@ -38,32 +38,12 @@ func (s *ClusterScope) ReconcileServiceGateway(ctx context.Context) error {
 	}
 	if sgw != nil {
 		s.OCICluster.Spec.NetworkSpec.Vcn.ServiceGatewayId = sgw.Id
-		if !s.IsTagsEqual(sgw.FreeformTags, sgw.DefinedTags) {
-			return s.UpdateServiceGateway(ctx)
-		}
 		s.Logger.Info("No Reconciliation Required for Service Gateway", "service_gateway", sgw.Id)
 		return nil
 	}
 	serviceGateway, err := s.CreateServiceGateway(ctx)
 	s.OCICluster.Spec.NetworkSpec.Vcn.ServiceGatewayId = serviceGateway
 	return err
-}
-
-func (s *ClusterScope) UpdateServiceGateway(ctx context.Context) error {
-	updateSGWDetails := core.UpdateServiceGatewayDetails{
-		FreeformTags: s.GetFreeFormTags(),
-		DefinedTags:  s.GetDefinedTags(),
-	}
-	sgwResponse, err := s.VCNClient.UpdateServiceGateway(ctx, core.UpdateServiceGatewayRequest{
-		ServiceGatewayId:            s.OCICluster.Spec.NetworkSpec.Vcn.ServiceGatewayId,
-		UpdateServiceGatewayDetails: updateSGWDetails,
-	})
-	if err != nil {
-		s.Logger.Error(err, "failed to reconcile the service gateway, failed to update")
-		return errors.Wrap(err, "failed to reconcile the service gateway, failed to update")
-	}
-	s.Logger.Info("successfully updated the service gateway", "service_gateway", *sgwResponse.Id)
-	return nil
 }
 
 func (s *ClusterScope) CreateServiceGateway(ctx context.Context) (*string, error) {

--- a/cloud/scope/service_gateway_reconciler_test.go
+++ b/cloud/scope/service_gateway_reconciler_test.go
@@ -70,35 +70,14 @@ func TestClusterScope_ReconcileServiceGateway(t *testing.T) {
 				FreeformTags: tags,
 				DefinedTags:  definedTagsInterface,
 			},
-		}, nil).Times(2)
+		}, nil)
 
 	updatedTags := make(map[string]string)
 	for k, v := range tags {
 		updatedTags[k] = v
 	}
 	updatedTags["foo"] = "bar"
-	vcnClient.EXPECT().UpdateServiceGateway(gomock.Any(), gomock.Eq(core.UpdateServiceGatewayRequest{
-		ServiceGatewayId: common.String("foo"),
-		UpdateServiceGatewayDetails: core.UpdateServiceGatewayDetails{
-			FreeformTags: updatedTags,
-			DefinedTags:  definedTagsInterface,
-		},
-	})).
-		Return(core.UpdateServiceGatewayResponse{
-			ServiceGateway: core.ServiceGateway{
-				Id:           common.String("foo"),
-				FreeformTags: tags,
-				DefinedTags:  definedTagsInterface,
-			},
-		}, nil)
-	vcnClient.EXPECT().UpdateServiceGateway(gomock.Any(), gomock.Eq(core.UpdateServiceGatewayRequest{
-		ServiceGatewayId: common.String("sgw_id"),
-		UpdateServiceGatewayDetails: core.UpdateServiceGatewayDetails{
-			FreeformTags: updatedTags,
-			DefinedTags:  definedTagsInterface,
-		},
-	})).
-		Return(core.UpdateServiceGatewayResponse{}, errors.New("some error"))
+
 	vcnClient.EXPECT().ListServiceGateways(gomock.Any(), gomock.Eq(core.ListServiceGatewaysRequest{
 		CompartmentId: common.String("foo"),
 		VcnId:         common.String("vcn"),
@@ -209,22 +188,7 @@ func TestClusterScope_ReconcileServiceGateway(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "update needed",
-			spec: infrastructurev1beta1.OCIClusterSpec{
-				FreeformTags: map[string]string{
-					"foo": "bar",
-				},
-				DefinedTags: definedTags,
-				NetworkSpec: infrastructurev1beta1.NetworkSpec{
-					Vcn: infrastructurev1beta1.VCN{
-						ServiceGatewayId: common.String("foo"),
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "id not present in spec but found by name and update needed but error out",
+			name: "id not present in spec but found by name and no update",
 			spec: infrastructurev1beta1.OCIClusterSpec{
 				CompartmentId: "foo",
 				FreeformTags: map[string]string{
@@ -237,8 +201,7 @@ func TestClusterScope_ReconcileServiceGateway(t *testing.T) {
 					},
 				},
 			},
-			wantErr:       true,
-			expectedError: "failed to reconcile the service gateway, failed to update: some error",
+			wantErr: false,
 		},
 		{
 			name: "creation needed",

--- a/cloud/scope/subnet_reconciler.go
+++ b/cloud/scope/subnet_reconciler.go
@@ -132,10 +132,8 @@ func (s *ClusterScope) CreateSubnet(ctx context.Context, spec infrastructurev1be
 
 func (s *ClusterScope) UpdateSubnet(ctx context.Context, spec infrastructurev1beta1.Subnet) error {
 	updateSubnetDetails := core.UpdateSubnetDetails{
-		DisplayName:  common.String(spec.Name),
-		CidrBlock:    common.String(spec.CIDR),
-		FreeformTags: s.GetFreeFormTags(),
-		DefinedTags:  s.GetDefinedTags(),
+		DisplayName: common.String(spec.Name),
+		CidrBlock:   common.String(spec.CIDR),
 	}
 	if spec.SecurityList != nil {
 		updateSubnetDetails.SecurityListIds = []string{*spec.SecurityList.ID}
@@ -344,7 +342,7 @@ func (s *ClusterScope) IsSubnetsEqual(actual *core.Subnet, desired infrastructur
 			return false
 		}
 	}
-	return s.IsTagsEqual(actual.FreeformTags, actual.DefinedTags)
+	return true
 }
 
 func (s *ClusterScope) isControlPlaneEndpointSubnetPrivate() bool {

--- a/cloud/scope/subnet_reconciler_test.go
+++ b/cloud/scope/subnet_reconciler_test.go
@@ -515,10 +515,8 @@ func TestClusterScope_ReconcileSubnet(t *testing.T) {
 	vcnClient.EXPECT().UpdateSubnet(gomock.Any(), gomock.Eq(core.UpdateSubnetRequest{
 		SubnetId: common.String("update_needed_id"),
 		UpdateSubnetDetails: core.UpdateSubnetDetails{
-			DefinedTags:  definedTagsInterface,
-			DisplayName:  common.String("update_needed"),
-			FreeformTags: tags,
-			CidrBlock:    common.String(ServiceLoadBalancerDefaultCIDR),
+			DisplayName: common.String("update_needed"),
+			CidrBlock:   common.String(ServiceLoadBalancerDefaultCIDR),
 		},
 	})).
 		Return(core.UpdateSubnetResponse{
@@ -530,9 +528,7 @@ func TestClusterScope_ReconcileSubnet(t *testing.T) {
 	vcnClient.EXPECT().UpdateSubnet(gomock.Any(), gomock.Eq(core.UpdateSubnetRequest{
 		SubnetId: common.String("sec_list_added_id"),
 		UpdateSubnetDetails: core.UpdateSubnetDetails{
-			DefinedTags:     definedTagsInterface,
 			DisplayName:     common.String("sec_list_added"),
-			FreeformTags:    tags,
 			CidrBlock:       common.String(WorkerSubnetDefaultCIDR),
 			SecurityListIds: []string{"sec_list_id"},
 		},
@@ -545,10 +541,8 @@ func TestClusterScope_ReconcileSubnet(t *testing.T) {
 	vcnClient.EXPECT().UpdateSubnet(gomock.Any(), gomock.Eq(core.UpdateSubnetRequest{
 		SubnetId: common.String("update_subnet_error"),
 		UpdateSubnetDetails: core.UpdateSubnetDetails{
-			DefinedTags:  definedTagsInterface,
-			DisplayName:  common.String("update"),
-			FreeformTags: tags,
-			CidrBlock:    common.String("2.2.2.2/1"),
+			DisplayName: common.String("update"),
+			CidrBlock:   common.String("2.2.2.2/1"),
 		},
 	})).
 		Return(core.UpdateSubnetResponse{}, errors.New("some error"))
@@ -603,9 +597,7 @@ func TestClusterScope_ReconcileSubnet(t *testing.T) {
 	vcnClient.EXPECT().UpdateSecurityList(gomock.Any(), gomock.Eq(core.UpdateSecurityListRequest{
 		SecurityListId: common.String("seclist_id"),
 		UpdateSecurityListDetails: core.UpdateSecurityListDetails{
-			DefinedTags:  definedTagsInterface,
-			DisplayName:  common.String("update_seclist"),
-			FreeformTags: tags,
+			DisplayName: common.String("update_seclist"),
 			EgressSecurityRules: []core.EgressSecurityRule{
 				{
 					Description: common.String("test-egress"),
@@ -646,9 +638,7 @@ func TestClusterScope_ReconcileSubnet(t *testing.T) {
 	vcnClient.EXPECT().UpdateSecurityList(gomock.Any(), gomock.Eq(core.UpdateSecurityListRequest{
 		SecurityListId: common.String("seclist_id"),
 		UpdateSecurityListDetails: core.UpdateSecurityListDetails{
-			DefinedTags:  definedTagsInterface,
-			DisplayName:  common.String("bar"),
-			FreeformTags: tags,
+			DisplayName: common.String("bar"),
 			EgressSecurityRules: []core.EgressSecurityRule{
 				{
 					Description: common.String("test-egress"),

--- a/cloud/scope/vcn_reconciler.go
+++ b/cloud/scope/vcn_reconciler.go
@@ -49,10 +49,10 @@ func (s *ClusterScope) ReconcileVCN(ctx context.Context) error {
 }
 
 func (s *ClusterScope) IsVcnEquals(actual *core.Vcn, desired infrastructurev1beta1.VCN) bool {
-	if *actual.DisplayName == desired.Name && s.IsTagsEqual(actual.FreeformTags, actual.DefinedTags) {
-		return true
+	if *actual.DisplayName != desired.Name {
+		return false
 	}
-	return false
+	return true
 }
 
 func (s *ClusterScope) GetVcnName() string {
@@ -112,9 +112,7 @@ func (s *ClusterScope) GetVCN(ctx context.Context) (*core.Vcn, error) {
 
 func (s *ClusterScope) UpdateVCN(ctx context.Context, vcn infrastructurev1beta1.VCN) error {
 	updateVCNDetails := core.UpdateVcnDetails{
-		DisplayName:  common.String(vcn.Name),
-		DefinedTags:  s.GetDefinedTags(),
-		FreeformTags: s.GetFreeFormTags(),
+		DisplayName: common.String(vcn.Name),
 	}
 	vcnResponse, err := s.VCNClient.UpdateVcn(ctx, core.UpdateVcnRequest{
 		UpdateVcnDetails: updateVCNDetails,

--- a/cloud/scope/vcn_reconciler_test.go
+++ b/cloud/scope/vcn_reconciler_test.go
@@ -469,21 +469,6 @@ func TestClusterScope_GetVcnName(t *testing.T) {
 }
 
 func TestClusterScope_IsVcnEquals(t *testing.T) {
-
-	freeFormTags := map[string]string{
-		"tag1": "foo",
-		"tag2": "bar",
-	}
-	definedTags := map[string]map[string]string{
-		"ns1": {
-			"tag1": "foo",
-			"tag2": "bar",
-		},
-		"ns2": {
-			"tag1": "foo1",
-			"tag2": "bar1",
-		},
-	}
 	tests := []struct {
 		name    string
 		spec    infrastructurev1beta1.OCIClusterSpec
@@ -498,21 +483,6 @@ func TestClusterScope_IsVcnEquals(t *testing.T) {
 			},
 			desired: infrastructurev1beta1.VCN{
 				Name: "bar",
-			},
-			want: false,
-		},
-		{
-			name: "name same tag different",
-			actual: &core.Vcn{
-				DisplayName:  common.String("foo"),
-				FreeformTags: freeFormTags,
-			},
-			desired: infrastructurev1beta1.VCN{
-				Name: "foo",
-			},
-			spec: infrastructurev1beta1.OCIClusterSpec{
-				FreeformTags: freeFormTags,
-				DefinedTags:  definedTags,
 			},
 			want: false,
 		},
@@ -587,9 +557,7 @@ func TestClusterScope_ReconcileVCN(t *testing.T) {
 	vcnClient.EXPECT().UpdateVcn(gomock.Any(), gomock.Eq(core.UpdateVcnRequest{
 		VcnId: common.String("normal_id"),
 		UpdateVcnDetails: core.UpdateVcnDetails{
-			DisplayName:  common.String("foo1"),
-			FreeformTags: tags,
-			DefinedTags:  definedTagsInterface,
+			DisplayName: common.String("foo1"),
 		},
 	})).
 		Return(core.UpdateVcnResponse{
@@ -603,9 +571,7 @@ func TestClusterScope_ReconcileVCN(t *testing.T) {
 	vcnClient.EXPECT().UpdateVcn(gomock.Any(), gomock.Eq(core.UpdateVcnRequest{
 		VcnId: common.String("normal_id"),
 		UpdateVcnDetails: core.UpdateVcnDetails{
-			DisplayName:  common.String("foo2"),
-			FreeformTags: tags,
-			DefinedTags:  definedTagsInterface,
+			DisplayName: common.String("foo2"),
 		},
 	})).
 		Return(core.UpdateVcnResponse{
@@ -655,7 +621,6 @@ func TestClusterScope_ReconcileVCN(t *testing.T) {
 		{
 			name: "vcn update needed",
 			spec: infrastructurev1beta1.OCIClusterSpec{
-				DefinedTags: definedTags,
 				NetworkSpec: infrastructurev1beta1.NetworkSpec{
 					Vcn: infrastructurev1beta1.VCN{
 						ID:   common.String("normal_id"),
@@ -669,7 +634,6 @@ func TestClusterScope_ReconcileVCN(t *testing.T) {
 		{
 			name: "vcn update needed but error out",
 			spec: infrastructurev1beta1.OCIClusterSpec{
-				DefinedTags: definedTags,
 				NetworkSpec: infrastructurev1beta1.NetworkSpec{
 					Vcn: infrastructurev1beta1.VCN{
 						ID:   common.String("normal_id"),


### PR DESCRIPTION
**What this PR does / why we need it**:

Ignore sending freeform and defined tags during update of resources

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #130 
