### PR TITLE
doc: Add simple OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - cluster-api-oci-maintainers
+
+reviewers:
+  - cluster-api-oci-maintainers
+  - cluster-api-oci-reviewers

--- a/OWNERS_ALIASES 
+++ b/OWNERS_ALIASES 
@@ -1,0 +1,11 @@
+# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#owners_aliases
+
+aliases:
+  cluster-api-oci-maintainers:
+    - shyamradhakrishnan
+    - arindam-bandyopadhyay
+    - joekr
+  cluster-api-oci-reviewers:
+    - shyamradhakrishnan
+    - arindam-bandyopadhyay
+    - joekr


### PR DESCRIPTION
**What this PR does / why we need it**:
The OWNERS file is needed to setup this repo with the [community](https://github.com/kubernetes/community) sig list for office hours.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
No open issue
