### PR TITLE
test: ignore more e2e templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ test/e2e/data/infrastructure-oci/v1beta1/cluster-template-local-vcn-peering.yaml
 test/e2e/data/infrastructure-oci/v1beta1/cluster-template-cluster-class.yaml
 test/e2e/data/infrastructure-oci/v1beta1/cluster-template-remote-vcn-peering.yaml
 test/e2e/data/infrastructure-oci/v1beta1/cluster-template-externally-managed-vcn.yaml
+test/e2e/data/infrastructure-oci/v1beta1/cluster-template-alternative-region.yaml
+test/e2e/data/infrastructure-oci/v1beta1/cluster-template-machine-pool.yaml
 
 # tilt
 tilt-settings.json


### PR DESCRIPTION
**What this PR does / why we need it**:
after running `make generate-e2e-templates` I notice two templates weren't ignored like our other ones.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
No open issues for this.
