### PR TITLE
feat: update releases workflow to update crds docs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,11 @@ jobs:
       - name: Build Release Artifacts
         run: RELEASE_TAG="${{ github.ref_name }}" make release
 
+      - name: Update crds docs
+        run: |
+          echo "Release Tag: ${{ github.ref_name }}" 
+          curl -sSL https://doc.crds.dev/github.com/oracle/cluster-api-provider-oci@${{ github.ref_name }}
+
       - uses: actions/upload-artifact@v2
         with:
           name: CAPOCI Artifacts


### PR DESCRIPTION
**What this PR does / why we need it**:
When we cut a new release we need to call [crds](https://doc.crds.dev/github.com/oracle/cluster-api-provider-oci) with the new tag. If we don't then crds won't index the new tag.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
No open issues
