### PR TITLE
Update the CAPI version in the e2e_conf.yaml

### DIFF
--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -8,7 +8,7 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-      - name: v1.2.6
+      - name: v1.3.0
         value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.6/core-components.yaml
         type: url
         files:
@@ -21,7 +21,7 @@ providers:
   - name: kubeadm
     type: BootstrapProvider
     versions:
-      - name: v1.2.6
+      - name: v1.3.0
         value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.6/bootstrap-components.yaml
         type: url
         files:
@@ -34,7 +34,7 @@ providers:
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-      - name: v1.2.6
+      - name: v1.3.0
         value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.6/control-plane-components.yaml
         type: url
         files:


### PR DESCRIPTION
**What this PR does / why we need it**:
bumped to [1.3.0 release](https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.3.0) 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
no open issue
