### PR TITLE
Fix Oracle Linux Template for multi node control plane

### DIFF
--- a/templates/cluster-template-oraclelinux.yaml
+++ b/templates/cluster-template-oraclelinux.yaml
@@ -69,6 +69,7 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           cloud-provider: external
+          provider-id: oci://{{ ds["id"] }}
     preKubeadmCommands:
       - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
       - swapoff -a


### PR DESCRIPTION

**What this PR does / why we need it**:
Multi-node control plane wont come up if the oracle linux template is used as the second node did not have the provider id set in the kubelet arguments.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #190 
