### PR TITLE
Use externally managed replicas annotation and remove the CAPOCI specific flag which was introduced

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimanagedmachinepools.yaml
@@ -156,17 +156,6 @@ spec:
                           type: string
                       type: object
                     type: array
-                  updateNodePoolSize:
-                    description: UpdateNodePoolSize defines whether the node pool
-                      size should be updated when there is a spec change. By default
-                      the value is false, which means that on machine pool update,
-                      the node pool size is not updated. This is to make sure the
-                      provider reconciliation of node pool does not overwrite any
-                      changes done by an external system, most probably Kubernetes
-                      Cluster Autoscaler. This property can be set ot true if CAPI
-                      based cluster auto scaler is used rather than the cloud provider
-                      specific one.
-                    type: boolean
                 type: object
               nodeShape:
                 description: NodeShape defines the name of the node shape of the nodes

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimanagedmachinepooltemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimanagedmachinepooltemplates.yaml
@@ -173,18 +173,6 @@ spec:
                                   type: string
                               type: object
                             type: array
-                          updateNodePoolSize:
-                            description: UpdateNodePoolSize defines whether the node
-                              pool size should be updated when there is a spec change.
-                              By default the value is false, which means that on machine
-                              pool update, the node pool size is not updated. This
-                              is to make sure the provider reconciliation of node
-                              pool does not overwrite any changes done by an external
-                              system, most probably Kubernetes Cluster Autoscaler.
-                              This property can be set ot true if CAPI based cluster
-                              auto scaler is used rather than the cloud provider specific
-                              one.
-                            type: boolean
                         type: object
                       nodeShape:
                         description: NodeShape defines the name of the node shape

--- a/exp/api/v1beta1/ocimanagedmachinepool_types.go
+++ b/exp/api/v1beta1/ocimanagedmachinepool_types.go
@@ -88,14 +88,6 @@ type NodePoolNodeConfig struct {
 	// NodePoolPodNetworkOptionDetails defines the pod networking details of the node pool
 	// +optional
 	NodePoolPodNetworkOptionDetails *NodePoolPodNetworkOptionDetails `json:"nodePoolPodNetworkOptionDetails,omitempty"`
-
-	// UpdateNodePoolSize defines whether the node pool size should be updated when there is a spec change.
-	// By default the value is false, which means that on machine pool update, the node pool size is not updated.
-	// This is to make sure the provider reconciliation of node pool does not overwrite any changes done by an external system,
-	// most probably Kubernetes Cluster Autoscaler. This property can be set ot true if CAPI based cluster auto scaler is used
-	// rather than the cloud provider specific one.
-	// +optional
-	UpdateNodePoolSize bool `json:"updateNodePoolSize,omitempty"`
 }
 
 const (

--- a/templates/cluster-template-managed-private.yaml
+++ b/templates/cluster-template-managed-private.yaml
@@ -58,6 +58,8 @@ kind: MachinePool
 metadata:
   name: ${CLUSTER_NAME}-mp-0
   namespace: default
+  annotations:
+    "cluster.x-k8s.io/replicas-managed-by": ""
 spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${NODE_MACHINE_COUNT}

--- a/templates/cluster-template-managed.yaml
+++ b/templates/cluster-template-managed.yaml
@@ -39,6 +39,8 @@ kind: MachinePool
 metadata:
   name: ${CLUSTER_NAME}-mp-0
   namespace: default
+  annotations:
+    "cluster.x-k8s.io/replicas-managed-by": ""
 spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${NODE_MACHINE_COUNT}

--- a/test/e2e/data/infrastructure-oci/v1beta1/cluster-template-managed/machine-pool.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta1/cluster-template-managed/machine-pool.yaml
@@ -35,6 +35,4 @@ spec:
   nodeShapeConfig:
     memoryInGBs: "16"
     ocpus: "1"
-  nodePoolNodeConfig:
-    updateNodePoolSize: true
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:
Use externally managed replicas annotation and remove the CAPOCI specific flag which was introduced

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #201 
