### PR TITLE
Handle nil pointer in Lb delete

### DIFF
--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -608,6 +608,12 @@ func (m *MachineScope) ReconcileDeleteInstanceOnLB(ctx context.Context) error {
 			return err
 		}
 		backendSet := lb.BackendSets[APIServerLBBackendSetName]
+		// in case of delete from LB backend, if the instance does not have an IP, we consider
+		// the instance to not have been added in first place and hence return nil
+		if len(m.OCIMachine.Status.Addresses) <= 0 {
+			m.Logger.Info("Instance does not have IP Address, hence ignoring LBaaS reconciliation on delete")
+			return nil
+		}
 		instanceIp, err := m.GetMachineIPFromStatus()
 		if err != nil {
 			return err

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -608,10 +608,6 @@ func (m *MachineScope) ReconcileDeleteInstanceOnLB(ctx context.Context) error {
 			return err
 		}
 		backendSet := lb.BackendSets[APIServerLBBackendSetName]
-		if len(m.OCIMachine.Status.Addresses) <= 0 {
-			m.Logger.Info("Instance does not have IP Address, hence ignoring LBaaS reconciliation on delete")
-			return nil
-		}
 		instanceIp, err := m.GetMachineIPFromStatus()
 		if err != nil {
 			return err

--- a/cloud/scope/machine_test.go
+++ b/cloud/scope/machine_test.go
@@ -2072,8 +2072,7 @@ func TestLBReconciliationDeletion(t *testing.T) {
 		},
 		{
 			name:          "no ip",
-			errorExpected: true,
-			matchError:    errors.New("could not find machine IP Address in status object"),
+			errorExpected: false,
 			testSpecificSetup: func(machineScope *MachineScope, nlbClient *mock_lb.MockLoadBalancerClient) {
 				nlbClient.EXPECT().GetLoadBalancer(gomock.Any(), gomock.Eq(loadbalancer.GetLoadBalancerRequest{
 					LoadBalancerId: common.String("lbid"),

--- a/cloud/scope/machine_test.go
+++ b/cloud/scope/machine_test.go
@@ -2072,7 +2072,8 @@ func TestLBReconciliationDeletion(t *testing.T) {
 		},
 		{
 			name:          "no ip",
-			errorExpected: false,
+			errorExpected: true,
+			matchError:    errors.New("could not find machine IP Address in status object"),
 			testSpecificSetup: func(machineScope *MachineScope, nlbClient *mock_lb.MockLoadBalancerClient) {
 				nlbClient.EXPECT().GetLoadBalancer(gomock.Any(), gomock.Eq(loadbalancer.GetLoadBalancerRequest{
 					LoadBalancerId: common.String("lbid"),

--- a/cloud/scope/machine_test.go
+++ b/cloud/scope/machine_test.go
@@ -2071,6 +2071,16 @@ func TestLBReconciliationDeletion(t *testing.T) {
 			},
 		},
 		{
+			name:          "no ip",
+			errorExpected: false,
+			testSpecificSetup: func(machineScope *MachineScope, nlbClient *mock_lb.MockLoadBalancerClient) {
+				nlbClient.EXPECT().GetLoadBalancer(gomock.Any(), gomock.Eq(loadbalancer.GetLoadBalancerRequest{
+					LoadBalancerId: common.String("lbid"),
+				})).Return(loadbalancer.GetLoadBalancerResponse{
+					LoadBalancer: loadbalancer.LoadBalancer{}}, nil)
+			},
+		},
+		{
 			name:          "backend exists",
 			errorExpected: false,
 			matchError:    errors.New("could not get lb"),


### PR DESCRIPTION
**What this PR does / why we need it**:

Handle nil pointer in Lb backend delete. This happens when instance was created, but was not added to backend because the instance does not have IP address. Then when instance is deleted, we get the following stack trace.

```
panic: runtime error: index out of range [0] with length 0 [recovered]
        panic: runtime error: index out of range [0] with length 0

goroutine 553 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
        /workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:118 +0x1f4
panic({0x1dd91a0, 0xc0001c0b10})
        /usr/local/go/src/runtime/panic.go:884 +0x212
github.com/oracle/cluster-api-provider-oci/cloud/scope.(*MachineScope).IP(...)
        /workspace/cloud/scope/machine.go:402
github.com/oracle/cluster-api-provider-oci/cloud/scope.(*MachineScope).ReconcileDeleteInstanceOnLB(0xc000a02280, {0x2236998, 0xc000ce69c0})
        /workspace/cloud/scope/machine.go:621 +0xf49
github.com/oracle/cluster-api-provider-oci/controllers.(*OCIMachineReconciler).deleteInstanceFromControlPlaneLB(0xc0003b4ff0, {0x2236998, 0xc000ce69c0}, 0xc000a02280)
        /workspace/controllers/ocimachine_controller.go:376 +0x85
github.com/oracle/cluster-api-provider-oci/controllers.(*OCIMachineReconciler).reconcileDelete(0xc0003b4ff0, {0x2236998, 0xc000ce69c0}, 0xc000a02280)
        /workspace/controllers/ocimachine_controller.go:324 +0x54d
github.com/oracle/cluster-api-provider-oci/controllers.(*OCIMachineReconciler).Reconcile(0xc0003b4ff0, {0x2236998, 0xc000ce69c0}, {{{0xc0007b2020?, 0x10?}, {0xc000f19d00?, 0x40db67?}}})
        /workspace/controllers/ocimachine_controller.go:161 +0xada
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x22368f0?, {0x2236998?, 0xc000ce69c0?}, {{{0xc0007b2020?, 0x1e40220?}, {0xc000f19d00?, 0x4045d4?}}})
        /workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:121 +0xc8
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000196820, {0x22368f0, 0xc00020b500}, {0x1cdf440?, 0xc0001bb340?})
        /workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:320 +0x33c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000196820, {0x22368f0, 0xc00020b500})
        /workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:273 +0x1d9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
        /workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:234 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
        /workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:230 +0x333
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #275 
