### PR TITLE
Use 1.8.0 version of mdbook admonish to fix book publish errors

### DIFF
--- a/.github/workflows/build-cluster-api-provider-book.yaml
+++ b/.github/workflows/build-cluster-api-provider-book.yaml
@@ -18,7 +18,7 @@ jobs:
         mkdir mdbook
         curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.21/mdbook-v0.4.21-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
         echo `pwd`/mdbook >> $GITHUB_PATH
-        cargo install mdbook-admonish
+        cargo install --version 1.8.0 mdbook-admonish
     - name: Deploy Book to GitHub Pages
       run: |
         # Build the HTML content


### PR DESCRIPTION
**What this PR does / why we need it**:
Use 1.8.0 version of mdbook admonish to fix book publish errors - https://github.com/oracle/cluster-api-provider-oci/actions/runs/5758083686/job/15610077049

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
