### PR TITLE
Add instanceprincipal clusteridentity support

### DIFF
--- a/api/v1beta2/ociclusteridentity_types.go
+++ b/api/v1beta2/ociclusteridentity_types.go
@@ -27,6 +27,8 @@ type PrincipalType string
 const (
 	// UserPrincipal represents a user principal.
 	UserPrincipal PrincipalType = "UserPrincipal"
+	// InstancePrincipal represents a instabce principal.
+	InstancePrincipal PrincipalType = "InstancePrincipal"
 )
 
 // OCIClusterIdentitySpec defines the parameters that are used to create an OCIClusterIdentity.

--- a/api/v1beta2/ociclusteridentity_types.go
+++ b/api/v1beta2/ociclusteridentity_types.go
@@ -27,7 +27,7 @@ type PrincipalType string
 const (
 	// UserPrincipal represents a user principal.
 	UserPrincipal PrincipalType = "UserPrincipal"
-	// InstancePrincipal represents a instabce principal.
+	// InstancePrincipal represents a instance principal.
 	InstancePrincipal PrincipalType = "InstancePrincipal"
 )
 

--- a/cloud/util/util.go
+++ b/cloud/util/util.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
-	"github.com/oracle/oci-go-sdk/v65/common/auth"
 	"reflect"
 
 	"github.com/go-logr/logr"
@@ -29,6 +28,7 @@ import (
 	"github.com/oracle/cluster-api-provider-oci/cloud/scope"
 	infrav2exp "github.com/oracle/cluster-api-provider-oci/exp/api/v1beta2"
 	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/common/auth"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/cloud/util/util.go
+++ b/cloud/util/util.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common/auth"
 	"reflect"
 
 	"github.com/go-logr/logr"
@@ -134,6 +135,24 @@ func GetOrBuildClientFromIdentity(ctx context.Context, c client.Client, identity
 		clientProvider, err := scope.NewClientProvider(scope.ClientProviderParams{
 			CertOverride:          pool,
 			OciAuthConfigProvider: conf,
+			ClientOverrides:       clientOverrides})
+
+		if err != nil {
+			return nil, err
+		}
+		return clientProvider, nil
+	} else if identity.Spec.Type == infrastructurev1beta2.InstancePrincipal {
+		provider, err := auth.InstancePrincipalConfigurationProvider()
+		if err != nil {
+			return nil, err
+		}
+		pool, err := getOCIClientCertPool(ctx, c, namespace, clientOverrides)
+		if err != nil {
+			return nil, err
+		}
+		clientProvider, err := scope.NewClientProvider(scope.ClientProviderParams{
+			CertOverride:          pool,
+			OciAuthConfigProvider: provider,
 			ClientOverrides:       clientOverrides})
 
 		if err != nil {

--- a/docs/src/gs/multi-tenancy.md
+++ b/docs/src/gs/multi-tenancy.md
@@ -67,4 +67,21 @@ An empty `allowedNamespaces` object indicates that `OCIClusters` can use this id
 If this object is `nil`, no namespaces will be allowed, which is the default behavior of the field if not specified.
 > Note: NamespaceList will take precedence over Selector if both are set.
 
+## Cluster Identity using Instance Principals
+
+Cluster Identity also supports [Instance Principals][instance-principals]. The example `OCIClusterIdentity`
+spec shown below uses Instance Principals.
+
+```yaml
+---
+kind: OCIClusterIdentity
+metadata:
+  name: cluster-identity
+  namespace: default
+spec:
+  type: InstancePrincipal
+  allowedNamespaces: {}
+```
+
 [iam-user]: https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#Required_Keys_and_OCIDs
+[instance-principals]: https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/callingservicesfrominstances.htm

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-virtual/cluster-identity.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-virtual/cluster-identity.yaml
@@ -1,0 +1,8 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: OCIClusterIdentity
+metadata:
+  name: cluster-identity-instance-principal
+spec:
+  type: InstancePrincipal
+  allowedNamespaces: {}
+---

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-virtual/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-virtual/cluster.yaml
@@ -25,6 +25,11 @@ metadata:
   name: "${CLUSTER_NAME}"
 spec:
   compartmentId: "${OCI_COMPARTMENT_ID}"
+  identityRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    kind: OCIClusterIdentity
+    name: cluster-identity-instance-principal
+    namespace: "${NAMESPACE}"
 ---
 kind: OCIManagedControlPlane
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-virtual/kustomization.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-virtual/kustomization.yaml
@@ -1,5 +1,6 @@
-bases:
+resources:
   - ./cluster.yaml
   - ./machine-pool.yaml
+  - ./cluster-identity.yaml
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Add InstancePrincipal support to ClusterIdentity. 

Just as an add on, some other cloud provider are also moving away from env variable based identity to use Cluster Identity. So this will help us to be on par.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #314 
