### PR TITLE
Retry on delete backend failure

### DIFF
--- a/cloud/scope/load_balancer_reconciler.go
+++ b/cloud/scope/load_balancer_reconciler.go
@@ -38,7 +38,7 @@ func (s *ClusterScope) ReconcileApiServerLB(ctx context.Context) error {
 	}
 	if lb != nil {
 		if lb.LifecycleState != loadbalancer.LoadBalancerLifecycleStateActive {
-			return errors.New("load balancer is not in active state, hence reconciliation cannot happen")
+			return errors.New(fmt.Sprintf("load balancer is in %s state. Waiting for ACTIVE state.", lb.LifecycleState))
 		}
 		lbIP, err := s.getLoadbalancerIp(*lb)
 		if err != nil {

--- a/cloud/scope/load_balancer_reconciler.go
+++ b/cloud/scope/load_balancer_reconciler.go
@@ -37,6 +37,9 @@ func (s *ClusterScope) ReconcileApiServerLB(ctx context.Context) error {
 		return err
 	}
 	if lb != nil {
+		if lb.LifecycleState != loadbalancer.LoadBalancerLifecycleStateActive {
+			return errors.New("load balancer is not in active state, hence reconciliation cannot happen")
+		}
 		lbIP, err := s.getLoadbalancerIp(*lb)
 		if err != nil {
 			return err

--- a/cloud/scope/load_balancer_reconciler_test.go
+++ b/cloud/scope/load_balancer_reconciler_test.go
@@ -579,7 +579,7 @@ func TestLBReconciliation(t *testing.T) {
 			name:                "lb not active",
 			errorExpected:       true,
 			errorSubStringMatch: true,
-			matchError:          errors.New("load balancer is not in active state, hence reconciliation cannot happen"),
+			matchError:          errors.New(fmt.Sprintf("load balancer is in %s state. Waiting for ACTIVE state.", loadbalancer.LoadBalancerLifecycleStateCreating)),
 			testSpecificSetup: func(clusterScope *ClusterScope, lbClient *mock_lb.MockLoadBalancerClient) {
 				ociClusterAccessor.OCICluster.Spec.NetworkSpec.APIServerLB.LoadBalancerId = common.String("lb-id")
 				lbClient.EXPECT().GetLoadBalancer(gomock.Any(), gomock.Eq(loadbalancer.GetLoadBalancerRequest{

--- a/cloud/scope/load_balancer_reconciler_test.go
+++ b/cloud/scope/load_balancer_reconciler_test.go
@@ -97,11 +97,12 @@ func TestLBReconciliation(t *testing.T) {
 				})).
 					Return(loadbalancer.GetLoadBalancerResponse{
 						LoadBalancer: loadbalancer.LoadBalancer{
-							Id:           common.String("lb-id"),
-							FreeformTags: tags,
-							DefinedTags:  make(map[string]map[string]interface{}),
-							IsPrivate:    common.Bool(false),
-							DisplayName:  common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver")),
+							Id:             common.String("lb-id"),
+							LifecycleState: loadbalancer.LoadBalancerLifecycleStateActive,
+							FreeformTags:   tags,
+							DefinedTags:    make(map[string]map[string]interface{}),
+							IsPrivate:      common.Bool(false),
+							DisplayName:    common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver")),
 							IpAddresses: []loadbalancer.IpAddress{
 								{
 									IpAddress: common.String("2.2.2.2"),
@@ -123,11 +124,12 @@ func TestLBReconciliation(t *testing.T) {
 				})).
 					Return(loadbalancer.GetLoadBalancerResponse{
 						LoadBalancer: loadbalancer.LoadBalancer{
-							Id:           common.String("lb-id"),
-							FreeformTags: tags,
-							DefinedTags:  make(map[string]map[string]interface{}),
-							IsPrivate:    common.Bool(false),
-							DisplayName:  common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver")),
+							Id:             common.String("lb-id"),
+							LifecycleState: loadbalancer.LoadBalancerLifecycleStateActive,
+							FreeformTags:   tags,
+							DefinedTags:    make(map[string]map[string]interface{}),
+							IsPrivate:      common.Bool(false),
+							DisplayName:    common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver")),
 						},
 					}, nil)
 			},
@@ -143,11 +145,12 @@ func TestLBReconciliation(t *testing.T) {
 				})).
 					Return(loadbalancer.GetLoadBalancerResponse{
 						LoadBalancer: loadbalancer.LoadBalancer{
-							Id:           common.String("lb-id"),
-							FreeformTags: tags,
-							DefinedTags:  make(map[string]map[string]interface{}),
-							IsPrivate:    common.Bool(false),
-							DisplayName:  common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver")),
+							Id:             common.String("lb-id"),
+							LifecycleState: loadbalancer.LoadBalancerLifecycleStateActive,
+							FreeformTags:   tags,
+							DefinedTags:    make(map[string]map[string]interface{}),
+							IsPrivate:      common.Bool(false),
+							DisplayName:    common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver")),
 							IpAddresses: []loadbalancer.IpAddress{
 								{
 									IpAddress: common.String("2.2.2.2"),
@@ -189,11 +192,12 @@ func TestLBReconciliation(t *testing.T) {
 				})).
 					Return(loadbalancer.GetLoadBalancerResponse{
 						LoadBalancer: loadbalancer.LoadBalancer{
-							Id:           common.String("lb-id"),
-							FreeformTags: tags,
-							DefinedTags:  make(map[string]map[string]interface{}),
-							IsPrivate:    common.Bool(false),
-							DisplayName:  common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver")),
+							Id:             common.String("lb-id"),
+							LifecycleState: loadbalancer.LoadBalancerLifecycleStateActive,
+							FreeformTags:   tags,
+							DefinedTags:    make(map[string]map[string]interface{}),
+							IsPrivate:      common.Bool(false),
+							DisplayName:    common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver")),
 							IpAddresses: []loadbalancer.IpAddress{
 								{
 									IpAddress: common.String("2.2.2.2"),
@@ -537,11 +541,12 @@ func TestLBReconciliation(t *testing.T) {
 				})).
 					Return(loadbalancer.GetLoadBalancerResponse{
 						LoadBalancer: loadbalancer.LoadBalancer{
-							Id:           common.String("lb-id"),
-							FreeformTags: tags,
-							DefinedTags:  make(map[string]map[string]interface{}),
-							IsPrivate:    common.Bool(false),
-							DisplayName:  common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver-test")),
+							Id:             common.String("lb-id"),
+							LifecycleState: loadbalancer.LoadBalancerLifecycleStateActive,
+							FreeformTags:   tags,
+							DefinedTags:    make(map[string]map[string]interface{}),
+							IsPrivate:      common.Bool(false),
+							DisplayName:    common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver-test")),
 							IpAddresses: []loadbalancer.IpAddress{
 								{
 									IpAddress: common.String("2.2.2.2"),
@@ -571,6 +576,34 @@ func TestLBReconciliation(t *testing.T) {
 			},
 		},
 		{
+			name:                "lb not active",
+			errorExpected:       true,
+			errorSubStringMatch: true,
+			matchError:          errors.New("load balancer is not in active state, hence reconciliation cannot happen"),
+			testSpecificSetup: func(clusterScope *ClusterScope, lbClient *mock_lb.MockLoadBalancerClient) {
+				ociClusterAccessor.OCICluster.Spec.NetworkSpec.APIServerLB.LoadBalancerId = common.String("lb-id")
+				lbClient.EXPECT().GetLoadBalancer(gomock.Any(), gomock.Eq(loadbalancer.GetLoadBalancerRequest{
+					LoadBalancerId: common.String("lb-id"),
+				})).
+					Return(loadbalancer.GetLoadBalancerResponse{
+						LoadBalancer: loadbalancer.LoadBalancer{
+							Id:             common.String("lb-id"),
+							LifecycleState: loadbalancer.LoadBalancerLifecycleStateCreating,
+							FreeformTags:   tags,
+							DefinedTags:    make(map[string]map[string]interface{}),
+							IsPrivate:      common.Bool(false),
+							DisplayName:    common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver-test")),
+							IpAddresses: []loadbalancer.IpAddress{
+								{
+									IpAddress: common.String("2.2.2.2"),
+									IsPublic:  common.Bool(true),
+								},
+							},
+						},
+					}, nil)
+			},
+		},
+		{
 			name:                "lb update request failed",
 			errorExpected:       true,
 			errorSubStringMatch: true,
@@ -582,11 +615,12 @@ func TestLBReconciliation(t *testing.T) {
 				})).
 					Return(loadbalancer.GetLoadBalancerResponse{
 						LoadBalancer: loadbalancer.LoadBalancer{
-							Id:           common.String("lb-id"),
-							FreeformTags: tags,
-							DefinedTags:  make(map[string]map[string]interface{}),
-							IsPrivate:    common.Bool(false),
-							DisplayName:  common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver-test")),
+							Id:             common.String("lb-id"),
+							LifecycleState: loadbalancer.LoadBalancerLifecycleStateActive,
+							FreeformTags:   tags,
+							DefinedTags:    make(map[string]map[string]interface{}),
+							IsPrivate:      common.Bool(false),
+							DisplayName:    common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver-test")),
 							IpAddresses: []loadbalancer.IpAddress{
 								{
 									IpAddress: common.String("2.2.2.2"),

--- a/cloud/scope/machine_test.go
+++ b/cloud/scope/machine_test.go
@@ -1642,7 +1642,7 @@ func TestNLBReconciliationDeletion(t *testing.T) {
 			},
 		},
 		{
-			name:          "work request exists",
+			name:          "work request exists, still delete should be called",
 			errorExpected: false,
 			matchError:    errors.New("could not get nlb"),
 			testSpecificSetup: func(machineScope *MachineScope, nlbClient *mock_nlb.MockNetworkLoadBalancerClient) {
@@ -1663,6 +1663,14 @@ func TestNLBReconciliationDeletion(t *testing.T) {
 						},
 					},
 				}, nil)
+				nlbClient.EXPECT().DeleteBackend(gomock.Any(), gomock.Eq(networkloadbalancer.DeleteBackendRequest{
+					NetworkLoadBalancerId: common.String("nlbid"),
+					BackendSetName:        common.String(APIServerLBBackendSetName),
+					BackendName:           common.String("test"),
+				})).Return(networkloadbalancer.DeleteBackendResponse{
+					OpcWorkRequestId: common.String("wrid"),
+				}, nil)
+
 				nlbClient.EXPECT().GetWorkRequest(gomock.Any(), gomock.Eq(
 					networkloadbalancer.GetWorkRequestRequest{
 						WorkRequestId: common.String("wrid"),
@@ -2235,7 +2243,7 @@ func TestLBReconciliationDeletion(t *testing.T) {
 			},
 		},
 		{
-			name:          "work request exists",
+			name:          "work request exists, still delete should be called",
 			errorExpected: false,
 			matchError:    errors.New("could not get lb"),
 			testSpecificSetup: func(machineScope *MachineScope, lbClient *mock_lb.MockLoadBalancerClient) {
@@ -2262,6 +2270,14 @@ func TestLBReconciliationDeletion(t *testing.T) {
 						},
 					},
 				}, nil)
+				lbClient.EXPECT().DeleteBackend(gomock.Any(), gomock.Eq(loadbalancer.DeleteBackendRequest{
+					LoadBalancerId: common.String("lbid"),
+					BackendSetName: common.String(APIServerLBBackendSetName),
+					BackendName:    common.String("1.1.1.1%3A6443"),
+				})).Return(loadbalancer.DeleteBackendResponse{
+					OpcWorkRequestId: common.String("wrid"),
+				}, nil)
+
 				lbClient.EXPECT().GetWorkRequest(gomock.Any(), gomock.Eq(
 					loadbalancer.GetWorkRequestRequest{
 						WorkRequestId: common.String("wrid"),

--- a/cloud/scope/network_load_balancer_reconciler.go
+++ b/cloud/scope/network_load_balancer_reconciler.go
@@ -37,7 +37,7 @@ func (s *ClusterScope) ReconcileApiServerNLB(ctx context.Context) error {
 	}
 	if nlb != nil {
 		if nlb.LifecycleState != networkloadbalancer.LifecycleStateActive {
-			return errors.New("network load balancer is not in active state, hence reconciliation cannot happen")
+			return errors.New(fmt.Sprintf("network load balancer is in %s state. Waiting for ACTIVE state.", nlb.LifecycleState))
 		}
 		lbIP, err := s.getNetworkLoadbalancerIp(*nlb)
 		if err != nil {

--- a/cloud/scope/network_load_balancer_reconciler.go
+++ b/cloud/scope/network_load_balancer_reconciler.go
@@ -19,7 +19,6 @@ package scope
 import (
 	"context"
 	"fmt"
-
 	infrastructurev1beta2 "github.com/oracle/cluster-api-provider-oci/api/v1beta2"
 	"github.com/oracle/cluster-api-provider-oci/cloud/ociutil"
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -37,6 +36,9 @@ func (s *ClusterScope) ReconcileApiServerNLB(ctx context.Context) error {
 		return err
 	}
 	if nlb != nil {
+		if nlb.LifecycleState != networkloadbalancer.LifecycleStateActive {
+			return errors.New("network load balancer is not in active state, hence reconciliation cannot happen")
+		}
 		lbIP, err := s.getNetworkLoadbalancerIp(*nlb)
 		if err != nil {
 			return err

--- a/cloud/scope/network_load_balancer_reconciler_test.go
+++ b/cloud/scope/network_load_balancer_reconciler_test.go
@@ -506,7 +506,7 @@ func TestNLBReconciliation(t *testing.T) {
 			name:                "nlb not active",
 			errorExpected:       true,
 			errorSubStringMatch: true,
-			matchError:          errors.New("network load balancer is not in active state, hence reconciliation cannot happen"),
+			matchError:          errors.New(fmt.Sprintf("network load balancer is in %s state. Waiting for ACTIVE state.", networkloadbalancer.LifecycleStateCreating)),
 			testSpecificSetup: func(clusterScope *ClusterScope, nlbClient *mock_nlb.MockNetworkLoadBalancerClient) {
 				ociClusterAccessor.OCICluster.Spec.NetworkSpec.APIServerLB.LoadBalancerId = common.String("nlb-id")
 				nlbClient.EXPECT().GetNetworkLoadBalancer(gomock.Any(), gomock.Eq(networkloadbalancer.GetNetworkLoadBalancerRequest{

--- a/cloud/scope/network_load_balancer_reconciler_test.go
+++ b/cloud/scope/network_load_balancer_reconciler_test.go
@@ -97,11 +97,12 @@ func TestNLBReconciliation(t *testing.T) {
 				})).
 					Return(networkloadbalancer.GetNetworkLoadBalancerResponse{
 						NetworkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
-							Id:           common.String("nlb-id"),
-							FreeformTags: tags,
-							DefinedTags:  make(map[string]map[string]interface{}),
-							IsPrivate:    common.Bool(false),
-							DisplayName:  common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver")),
+							LifecycleState: networkloadbalancer.LifecycleStateActive,
+							Id:             common.String("nlb-id"),
+							FreeformTags:   tags,
+							DefinedTags:    make(map[string]map[string]interface{}),
+							IsPrivate:      common.Bool(false),
+							DisplayName:    common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver")),
 							IpAddresses: []networkloadbalancer.IpAddress{
 								{
 									IpAddress: common.String("2.2.2.2"),
@@ -123,11 +124,12 @@ func TestNLBReconciliation(t *testing.T) {
 				})).
 					Return(networkloadbalancer.GetNetworkLoadBalancerResponse{
 						NetworkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
-							Id:           common.String("nlb-id"),
-							FreeformTags: tags,
-							DefinedTags:  make(map[string]map[string]interface{}),
-							IsPrivate:    common.Bool(false),
-							DisplayName:  common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver")),
+							LifecycleState: networkloadbalancer.LifecycleStateActive,
+							Id:             common.String("nlb-id"),
+							FreeformTags:   tags,
+							DefinedTags:    make(map[string]map[string]interface{}),
+							IsPrivate:      common.Bool(false),
+							DisplayName:    common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver")),
 						},
 					}, nil)
 			},
@@ -143,11 +145,12 @@ func TestNLBReconciliation(t *testing.T) {
 				})).
 					Return(networkloadbalancer.GetNetworkLoadBalancerResponse{
 						NetworkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
-							Id:           common.String("nlb-id"),
-							FreeformTags: tags,
-							DefinedTags:  make(map[string]map[string]interface{}),
-							IsPrivate:    common.Bool(false),
-							DisplayName:  common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver")),
+							LifecycleState: networkloadbalancer.LifecycleStateActive,
+							Id:             common.String("nlb-id"),
+							FreeformTags:   tags,
+							DefinedTags:    make(map[string]map[string]interface{}),
+							IsPrivate:      common.Bool(false),
+							DisplayName:    common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver")),
 							IpAddresses: []networkloadbalancer.IpAddress{
 								{
 									IpAddress: common.String("2.2.2.2"),
@@ -191,11 +194,12 @@ func TestNLBReconciliation(t *testing.T) {
 				})).
 					Return(networkloadbalancer.GetNetworkLoadBalancerResponse{
 						NetworkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
-							Id:           common.String("nlb-id"),
-							FreeformTags: tags,
-							DefinedTags:  make(map[string]map[string]interface{}),
-							IsPrivate:    common.Bool(false),
-							DisplayName:  common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver")),
+							LifecycleState: networkloadbalancer.LifecycleStateActive,
+							Id:             common.String("nlb-id"),
+							FreeformTags:   tags,
+							DefinedTags:    make(map[string]map[string]interface{}),
+							IsPrivate:      common.Bool(false),
+							DisplayName:    common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver")),
 							IpAddresses: []networkloadbalancer.IpAddress{
 								{
 									IpAddress: common.String("2.2.2.2"),
@@ -466,11 +470,12 @@ func TestNLBReconciliation(t *testing.T) {
 				})).
 					Return(networkloadbalancer.GetNetworkLoadBalancerResponse{
 						NetworkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
-							Id:           common.String("nlb-id"),
-							FreeformTags: tags,
-							DefinedTags:  make(map[string]map[string]interface{}),
-							IsPrivate:    common.Bool(false),
-							DisplayName:  common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver-test")),
+							LifecycleState: networkloadbalancer.LifecycleStateActive,
+							Id:             common.String("nlb-id"),
+							FreeformTags:   tags,
+							DefinedTags:    make(map[string]map[string]interface{}),
+							IsPrivate:      common.Bool(false),
+							DisplayName:    common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver-test")),
 							IpAddresses: []networkloadbalancer.IpAddress{
 								{
 									IpAddress: common.String("2.2.2.2"),
@@ -498,6 +503,34 @@ func TestNLBReconciliation(t *testing.T) {
 			},
 		},
 		{
+			name:                "nlb not active",
+			errorExpected:       true,
+			errorSubStringMatch: true,
+			matchError:          errors.New("network load balancer is not in active state, hence reconciliation cannot happen"),
+			testSpecificSetup: func(clusterScope *ClusterScope, nlbClient *mock_nlb.MockNetworkLoadBalancerClient) {
+				ociClusterAccessor.OCICluster.Spec.NetworkSpec.APIServerLB.LoadBalancerId = common.String("nlb-id")
+				nlbClient.EXPECT().GetNetworkLoadBalancer(gomock.Any(), gomock.Eq(networkloadbalancer.GetNetworkLoadBalancerRequest{
+					NetworkLoadBalancerId: common.String("nlb-id"),
+				})).
+					Return(networkloadbalancer.GetNetworkLoadBalancerResponse{
+						NetworkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
+							LifecycleState: networkloadbalancer.LifecycleStateCreating,
+							Id:             common.String("nlb-id"),
+							FreeformTags:   tags,
+							DefinedTags:    make(map[string]map[string]interface{}),
+							IsPrivate:      common.Bool(false),
+							DisplayName:    common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver-test")),
+							IpAddresses: []networkloadbalancer.IpAddress{
+								{
+									IpAddress: common.String("2.2.2.2"),
+									IsPublic:  common.Bool(true),
+								},
+							},
+						},
+					}, nil)
+			},
+		},
+		{
 			name:                "nlb update request failed",
 			errorExpected:       true,
 			errorSubStringMatch: true,
@@ -509,11 +542,12 @@ func TestNLBReconciliation(t *testing.T) {
 				})).
 					Return(networkloadbalancer.GetNetworkLoadBalancerResponse{
 						NetworkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{
-							Id:           common.String("nlb-id"),
-							FreeformTags: tags,
-							DefinedTags:  make(map[string]map[string]interface{}),
-							IsPrivate:    common.Bool(false),
-							DisplayName:  common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver-test")),
+							LifecycleState: networkloadbalancer.LifecycleStateActive,
+							Id:             common.String("nlb-id"),
+							FreeformTags:   tags,
+							DefinedTags:    make(map[string]map[string]interface{}),
+							IsPrivate:      common.Bool(false),
+							DisplayName:    common.String(fmt.Sprintf("%s-%s", "cluster", "apiserver-test")),
 							IpAddresses: []networkloadbalancer.IpAddress{
 								{
 									IpAddress: common.String("2.2.2.2"),


### PR DESCRIPTION
**What this PR does / why we need it**:
* Retry on create/delete backend failure
* Check for LB/NLB status before reconciliation. This is to make sure that CAPOCI do not proceed with machine creation if the LB creation fails.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #331 , #332 
