### PR TITLE
Handle machine deletion when NLB/LB has been deleted

### DIFF
--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -609,6 +609,10 @@ func (m *MachineScope) ReconcileDeleteInstanceOnLB(ctx context.Context) error {
 			LoadBalancerId: loadbalancerId,
 		})
 		if err != nil {
+			if ociutil.IsNotFound(err) {
+				m.Logger.Info("LB has been deleted")
+				return nil
+			}
 			return err
 		}
 		backendSet := lb.BackendSets[APIServerLBBackendSetName]
@@ -658,6 +662,10 @@ func (m *MachineScope) ReconcileDeleteInstanceOnLB(ctx context.Context) error {
 			NetworkLoadBalancerId: loadbalancerId,
 		})
 		if err != nil {
+			if ociutil.IsNotFound(err) {
+				m.Logger.Info("NLB has been deleted")
+				return nil
+			}
 			return err
 		}
 		backendSet := lb.BackendSets[APIServerLBBackendSetName]

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -610,7 +610,7 @@ func (m *MachineScope) ReconcileDeleteInstanceOnLB(ctx context.Context) error {
 		})
 		if err != nil {
 			if ociutil.IsNotFound(err) {
-				m.Logger.Info("LB has been deleted")
+				m.Logger.Info("LB has been deleted", "lb", *loadbalancerId)
 				return nil
 			}
 			return err
@@ -663,7 +663,7 @@ func (m *MachineScope) ReconcileDeleteInstanceOnLB(ctx context.Context) error {
 		})
 		if err != nil {
 			if ociutil.IsNotFound(err) {
-				m.Logger.Info("NLB has been deleted")
+				m.Logger.Info("NLB has been deleted", "nlb", *loadbalancerId)
 				return nil
 			}
 			return err

--- a/cloud/scope/machine_test.go
+++ b/cloud/scope/machine_test.go
@@ -1567,6 +1567,16 @@ func TestNLBReconciliationDeletion(t *testing.T) {
 			},
 		},
 		{
+			name:          "get nlb error, not found",
+			errorExpected: false,
+			testSpecificSetup: func(machineScope *MachineScope, nlbClient *mock_nlb.MockNetworkLoadBalancerClient) {
+				nlbClient.EXPECT().GetNetworkLoadBalancer(gomock.Any(), gomock.Eq(networkloadbalancer.GetNetworkLoadBalancerRequest{
+					NetworkLoadBalancerId: common.String("nlbid"),
+				})).Return(networkloadbalancer.GetNetworkLoadBalancerResponse{
+					NetworkLoadBalancer: networkloadbalancer.NetworkLoadBalancer{}}, ociutil.ErrNotFound)
+			},
+		},
+		{
 			name:          "backend exists",
 			errorExpected: false,
 			matchError:    errors.New("could not get nlb"),
@@ -2108,6 +2118,22 @@ func TestLBReconciliationDeletion(t *testing.T) {
 		errorSubStringMatch bool
 		testSpecificSetup   func(machineScope *MachineScope, lbClient *mock_lb.MockLoadBalancerClient)
 	}{
+		{
+			name:          "get lb error",
+			errorExpected: false,
+			testSpecificSetup: func(machineScope *MachineScope, nlbClient *mock_lb.MockLoadBalancerClient) {
+				machineScope.OCIMachine.Status.Addresses = []clusterv1.MachineAddress{
+					{
+						Type:    clusterv1.MachineInternalIP,
+						Address: "1.1.1.1",
+					},
+				}
+				nlbClient.EXPECT().GetLoadBalancer(gomock.Any(), gomock.Eq(loadbalancer.GetLoadBalancerRequest{
+					LoadBalancerId: common.String("lbid"),
+				})).Return(loadbalancer.GetLoadBalancerResponse{
+					LoadBalancer: loadbalancer.LoadBalancer{}}, ociutil.ErrNotFound)
+			},
+		},
 		{
 			name:          "get lb error",
 			errorExpected: true,


### PR DESCRIPTION
**What this PR does / why we need it**:
Handle machine deletion when NLB/LB has been deleted

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #347 
