### PR TITLE
Do not sent fault domain if failure domain is set as empty

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -47,3 +47,6 @@ releaseSeries:
   - major: 0
     minor: 14
     contract: v1beta1
+  - major: 0
+    minor: 15
+    contract: v1beta1


### PR DESCRIPTION
**What this PR does / why we need it**:
Do not sent fault domain if failure domain is set as empty. OCI Compute will select the right fault domain based on various factors.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #351 
