### PR TITLE
Set instance in moving state to be not ready, but dont throw error

### DIFF
--- a/controllers/ocimachine_controller.go
+++ b/controllers/ocimachine_controller.go
@@ -326,8 +326,9 @@ func (r *OCIMachineReconciler) reconcileNormal(ctx context.Context, logger logr.
 		machineScope.Info("Instance is pending")
 		conditions.MarkFalse(machineScope.OCIMachine, infrastructurev1beta2.InstanceReadyCondition, infrastructurev1beta2.InstanceNotReadyReason, clusterv1.ConditionSeverityInfo, "")
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
-	case core.InstanceLifecycleStateStopping, core.InstanceLifecycleStateStopped:
+	case core.InstanceLifecycleStateStopping, core.InstanceLifecycleStateStopped, core.InstanceLifecycleStateMoving:
 		machineScope.SetNotReady()
+		machineScope.Info(fmt.Sprintf("Instance is in %s state and not ready", instance.LifecycleState))
 		conditions.MarkFalse(machineScope.OCIMachine, infrastructurev1beta2.InstanceReadyCondition, infrastructurev1beta2.InstanceNotReadyReason, clusterv1.ConditionSeverityInfo, "")
 		return reconcile.Result{}, nil
 	case core.InstanceLifecycleStateRunning:

--- a/controllers/ocimachine_controller_test.go
+++ b/controllers/ocimachine_controller_test.go
@@ -335,6 +335,22 @@ func TestNormalReconciliationFunction(t *testing.T) {
 			},
 		},
 		{
+			name:               "instance in moving state",
+			errorExpected:      false,
+			conditionAssertion: []conditionAssertion{{infrastructurev1beta2.InstanceReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrastructurev1beta2.InstanceNotReadyReason}},
+			testSpecificSetup: func(t *test, machineScope *scope.MachineScope, computeClient *mock_compute.MockComputeClient, vcnClient *mock_vcn.MockClient, nlbclient *mock_nlb.MockNetworkLoadBalancerClient) {
+				computeClient.EXPECT().GetInstance(gomock.Any(), gomock.Eq(core.GetInstanceRequest{
+					InstanceId: common.String("test"),
+				})).
+					Return(core.GetInstanceResponse{
+						Instance: core.Instance{
+							Id:             common.String("test"),
+							LifecycleState: core.InstanceLifecycleStateMoving,
+						},
+					}, nil)
+			},
+		},
+		{
 			name:               "instance in terminated state",
 			errorExpected:      true,
 			expectedEvent:      "invalid lifecycle state TERMINATED",


### PR DESCRIPTION
**What this PR does / why we need it**:

Set instance in moving state to be not ready, but dont throw error

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #366 
