### PR TITLE
fix: Machinepool should use OCI_MANAGED_KUBERNETES_VERSION ENV

### DIFF
--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed/machine-pool.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed/machine-pool.yaml
@@ -16,7 +16,7 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: OCIManagedMachinePool
         name: ${CLUSTER_NAME}-mp-0
-      version: ${KUBERNETES_VERSION}
+      version: ${OCI_MANAGED_KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIManagedMachinePool
@@ -52,7 +52,7 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: OCIManagedMachinePool
         name: ${CLUSTER_NAME}-mp-1
-      version: ${KUBERNETES_VERSION}
+      version: ${OCI_MANAGED_KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIManagedMachinePool


### PR DESCRIPTION
**What this PR does / why we need it**:
Using KUBERNETES_VERSION instead of OCI_MANAGED_KUBERNETES_VERSION will have a version mismatch and the managed nodes will fail to join.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
Before this the `Managed Cluster - Simple` was not passing for me. I'm not sure how it was for others. This basically makes sure the cluster and the machine pool are using the same K8s version.