### PR TITLE
feat: add MachineExternalIP to status

### DIFF
--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -464,7 +464,8 @@ func (m *MachineScope) GetMachineIPFromStatus() (string, error) {
 // GetInstanceIp returns the OCIMachine's instance IP from its primary VNIC attachment.
 //
 // See https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingVNICs.htm for more on VNICs
-func (m *MachineScope) GetInstanceIp(ctx context.Context) (*string, error) {
+func (m *MachineScope) GetInstanceIPs(ctx context.Context) ([]clusterv1.MachineAddress, error) {
+	addresses := []clusterv1.MachineAddress{}
 	var page *string
 	for {
 		resp, err := m.ComputeClient.ListVnicAttachments(ctx, core.ListVnicAttachmentsRequest{
@@ -495,7 +496,20 @@ func (m *MachineScope) GetInstanceIp(ctx context.Context) (*string, error) {
 				return nil, err
 			}
 			if vnic.IsPrimary != nil && *vnic.IsPrimary {
-				return vnic.PrivateIp, nil
+				if vnic.PublicIp != nil {
+					publicIP := clusterv1.MachineAddress{
+						Address: *vnic.PublicIp,
+						Type:    clusterv1.MachineExternalIP,
+					}
+					addresses = append(addresses, publicIP)
+					return addresses, nil
+				}
+				privateIP := clusterv1.MachineAddress{
+					Address: *vnic.PrivateIp,
+					Type:    clusterv1.MachineInternalIP,
+				}
+				addresses = append(addresses, privateIP)
+				return addresses, nil
 			}
 		}
 

--- a/controllers/ocimachine_controller.go
+++ b/controllers/ocimachine_controller.go
@@ -335,18 +335,13 @@ func (r *OCIMachineReconciler) reconcileNormal(ctx context.Context, logger logr.
 		machineScope.Info("Instance is active")
 		if machine.Status.Addresses == nil || len(machine.Status.Addresses) == 0 {
 			machineScope.Info("IP address is not set on the instance, looking up the address")
-			ipAddress, err := machineScope.GetInstanceIp(ctx)
+			ipAddresses, err := machineScope.GetInstanceIPs(ctx)
 			if err != nil {
 				r.Recorder.Event(machine, corev1.EventTypeWarning, "ReconcileError", errors.Wrapf(err, "failed to reconcile OCIMachine").Error())
 				conditions.MarkFalse(machineScope.OCIMachine, infrastructurev1beta2.InstanceReadyCondition, infrastructurev1beta2.InstanceIPAddressNotFound, clusterv1.ConditionSeverityError, "")
 				return ctrl.Result{}, err
 			}
-			machine.Status.Addresses = []clusterv1.MachineAddress{
-				{
-					Address: *ipAddress,
-					Type:    clusterv1.MachineInternalIP,
-				},
-			}
+			machine.Status.Addresses = ipAddresses
 		}
 		if machineScope.IsControlPlane() {
 			err := machineScope.ReconcileCreateInstanceOnLB(ctx)


### PR DESCRIPTION
add MachineExternalIP address to OCIMachine status

<!-- please add a type to the title of this PR (see https://www.conventionalcommits.org/en/v1.0.0/#summary), and delete this line and similar ones -->
<!-- the type will be either fix:, feat:, docs:, test: see https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional for a more exhaustive list -->

**What this PR does / why we need it**:

when available, writes the public machine IP address to the status along with the private IP address.

Resolves usage with Talos bootstrap+controlplane cluster-api provider.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #379 
