### PR TITLE
feat: Add work request errors in events/logs when work-request is failed for LB/NLB

### DIFF
--- a/cloud/ociutil/ociutil.go
+++ b/cloud/ociutil/ociutil.go
@@ -24,13 +24,11 @@ import (
 
 	lb "github.com/oracle/cluster-api-provider-oci/cloud/services/loadbalancer"
 	nlb "github.com/oracle/cluster-api-provider-oci/cloud/services/networkloadbalancer"
-	wrs "github.com/oracle/cluster-api-provider-oci/cloud/services/workrequests"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/core"
 	"github.com/oracle/oci-go-sdk/v65/loadbalancer"
 	"github.com/oracle/oci-go-sdk/v65/networkloadbalancer"
-	"github.com/oracle/oci-go-sdk/v65/workrequests"
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -63,22 +61,8 @@ func IsNotFound(err error) bool {
 	return ok && serviceErr.GetHTTPStatusCode() == http.StatusNotFound
 }
 
-func FetchErrorsOnFailedWorkRequest(ctx context.Context, workRequestClient wrs.Client, workRequestId *string) (done bool, err error) {
-	resp, err := workRequestClient.ListWorkRequestErrors(ctx, workrequests.ListWorkRequestErrorsRequest{
-		WorkRequestId: workRequestId,
-	})
-	if err != nil {
-		return false, errors.Wrapf(err, "Failed to fetch work-request-errors for failed workrequest: %s", *workRequestId)
-	}
-	final_err := errors.Errorf("WorkRequest %s failed", *workRequestId)
-	for _, wr_err := range resp.Items {
-		final_err = errors.Errorf("%s, %s", *wr_err.Message, final_err.Error())
-	}
-	return false, final_err
-}
-
 // AwaitNLBWorkRequest waits for the LB work request to either succeed, fail. See k8s.io/apimachinery/pkg/util/wait
-func AwaitNLBWorkRequest(ctx context.Context, networkLoadBalancerClient nlb.NetworkLoadBalancerClient, workRequestClient wrs.Client, workRequestId *string) (*networkloadbalancer.WorkRequest, error) {
+func AwaitNLBWorkRequest(ctx context.Context, networkLoadBalancerClient nlb.NetworkLoadBalancerClient, workRequestId *string) (*networkloadbalancer.WorkRequest, error) {
 	var wr *networkloadbalancer.WorkRequest
 	immediate := true
 	err := wait.PollUntilContextTimeout(ctx, WorkRequestPollInterval, WorkRequestTimeout, immediate, func(ctx context.Context) (done bool, err error) {
@@ -93,7 +77,19 @@ func AwaitNLBWorkRequest(ctx context.Context, networkLoadBalancerClient nlb.Netw
 			wr = &twr.WorkRequest
 			return true, nil
 		case networkloadbalancer.OperationStatusFailed:
-			return FetchErrorsOnFailedWorkRequest(ctx, workRequestClient, workRequestId)
+			wreq := networkloadbalancer.ListWorkRequestErrorsRequest{
+				WorkRequestId: workRequestId,
+				CompartmentId: twr.CompartmentId,
+			}
+			final_err := errors.Errorf("WorkRequest %s failed", *workRequestId)
+			wresp, err := networkLoadBalancerClient.ListWorkRequestErrors(ctx, wreq)
+			if err != nil {
+				return false, errors.Wrap(final_err, "Failed to fetch the work-request-errors using nlb client")
+			}
+			for _, wr_err := range wresp.WorkRequestErrorCollection.Items {
+				final_err = errors.Wrapf(final_err, "%s: %s", *wr_err.Code, *wr_err.Message)
+			}
+			return false, final_err
 		}
 		return false, nil
 	})
@@ -101,7 +97,7 @@ func AwaitNLBWorkRequest(ctx context.Context, networkLoadBalancerClient nlb.Netw
 }
 
 // AwaitLBWorkRequest waits for the LBaaS work request to either succeed, fail. See k8s.io/apimachinery/pkg/util/wait
-func AwaitLBWorkRequest(ctx context.Context, loadBalancerClient lb.LoadBalancerClient, workRequestClient wrs.Client, workRequestId *string) (*loadbalancer.WorkRequest, error) {
+func AwaitLBWorkRequest(ctx context.Context, loadBalancerClient lb.LoadBalancerClient, workRequestId *string) (*loadbalancer.WorkRequest, error) {
 	var wr *loadbalancer.WorkRequest
 	immediate := true
 	err := wait.PollUntilContextTimeout(ctx, WorkRequestPollInterval, WorkRequestTimeout, immediate, func(ctx context.Context) (done bool, err error) {
@@ -116,7 +112,11 @@ func AwaitLBWorkRequest(ctx context.Context, loadBalancerClient lb.LoadBalancerC
 			wr = &twr.WorkRequest
 			return true, nil
 		case loadbalancer.WorkRequestLifecycleStateFailed:
-			return FetchErrorsOnFailedWorkRequest(ctx, workRequestClient, workRequestId)
+			final_err := errors.Errorf("WorkRequest %s failed", *workRequestId)
+			for _, wreq := range twr.WorkRequest.ErrorDetails {
+				final_err = errors.Wrapf(final_err, "%s: %s", wreq.ErrorCode, *wreq.Message)
+			}
+			return false, final_err
 		}
 		return false, nil
 	})

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -29,7 +29,6 @@ import (
 	lb "github.com/oracle/cluster-api-provider-oci/cloud/services/loadbalancer"
 	nlb "github.com/oracle/cluster-api-provider-oci/cloud/services/networkloadbalancer"
 	"github.com/oracle/cluster-api-provider-oci/cloud/services/vcn"
-	wr "github.com/oracle/cluster-api-provider-oci/cloud/services/workrequests"
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/identity"
 	"github.com/pkg/errors"
@@ -56,7 +55,6 @@ type ClusterScopeParams struct {
 	NetworkLoadBalancerClient nlb.NetworkLoadBalancerClient
 	LoadBalancerClient        lb.LoadBalancerClient
 	IdentityClient            identityClient.Client
-	WorkRequestClient         wr.Client
 	// RegionIdentifier Identifier as specified here https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm
 	RegionIdentifier      string
 	OCIAuthConfigProvider common.ConfigurationProvider
@@ -75,7 +73,6 @@ type ClusterScope struct {
 	NetworkLoadBalancerClient nlb.NetworkLoadBalancerClient
 	LoadBalancerClient        lb.LoadBalancerClient
 	IdentityClient            identityClient.Client
-	WorkRequestClient         wr.Client
 	// RegionIdentifier Identifier as specified here https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm
 	RegionIdentifier   string
 	ClientProvider     *ClientProvider
@@ -107,7 +104,6 @@ func NewClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 		NetworkLoadBalancerClient: params.NetworkLoadBalancerClient,
 		LoadBalancerClient:        params.LoadBalancerClient,
 		IdentityClient:            params.IdentityClient,
-		WorkRequestClient:         params.WorkRequestClient,
 		RegionIdentifier:          params.RegionIdentifier,
 		ClientProvider:            params.ClientProvider,
 		OCIClusterAccessor:        params.OCIClusterAccessor,

--- a/cloud/scope/load_balancer_reconciler.go
+++ b/cloud/scope/load_balancer_reconciler.go
@@ -88,7 +88,7 @@ func (s *ClusterScope) DeleteApiServerLB(ctx context.Context) error {
 		s.Logger.Error(err, "failed to delete apiserver lb")
 		return errors.Wrap(err, "failed to delete apiserver lb")
 	}
-	_, err = ociutil.AwaitLBWorkRequest(ctx, s.LoadBalancerClient, s.WorkRequestClient, lbResponse.OpcWorkRequestId)
+	_, err = ociutil.AwaitLBWorkRequest(ctx, s.LoadBalancerClient, lbResponse.OpcWorkRequestId)
 	if err != nil {
 		return errors.Wrap(err, "work request to delete lb failed")
 	}
@@ -129,7 +129,7 @@ func (s *ClusterScope) UpdateLB(ctx context.Context, lb infrastructurev1beta2.Lo
 		s.Logger.Error(err, "failed to reconcile the apiserver LB, failed to generate update lb workrequest")
 		return errors.Wrap(err, "failed to reconcile the apiserver LB, failed to generate update lb workrequest")
 	}
-	_, err = ociutil.AwaitLBWorkRequest(ctx, s.LoadBalancerClient, s.WorkRequestClient, lbResponse.OpcWorkRequestId)
+	_, err = ociutil.AwaitLBWorkRequest(ctx, s.LoadBalancerClient, lbResponse.OpcWorkRequestId)
 	if err != nil {
 		s.Logger.Error(err, "failed to reconcile the apiserver LB, failed to update lb")
 		return errors.Wrap(err, "failed to reconcile the apiserver LB, failed to update lb")
@@ -202,7 +202,7 @@ func (s *ClusterScope) CreateLB(ctx context.Context, lb infrastructurev1beta2.Lo
 		return nil, nil, errors.Wrap(err, "failed to create apiserver lb, failed to create work request")
 	}
 
-	wr, err := ociutil.AwaitLBWorkRequest(ctx, s.LoadBalancerClient, s.WorkRequestClient, lbResponse.OpcWorkRequestId)
+	wr, err := ociutil.AwaitLBWorkRequest(ctx, s.LoadBalancerClient, lbResponse.OpcWorkRequestId)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "awaiting load balancer")
 	}

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -560,7 +560,7 @@ func (m *MachineScope) ReconcileCreateInstanceOnLB(ctx context.Context) error {
 			m.OCIMachine.Status.CreateBackendWorkRequestId = *resp.OpcWorkRequestId
 			logger.Info("Add instance to LB backend-set", "WorkRequestId", resp.OpcWorkRequestId)
 			logger.Info("Waiting for LB work request to be complete")
-			_, err = ociutil.AwaitLBWorkRequest(ctx, m.LoadBalancerClient, m.WorkRequestsClient, resp.OpcWorkRequestId)
+			_, err = ociutil.AwaitLBWorkRequest(ctx, m.LoadBalancerClient, resp.OpcWorkRequestId)
 			if err != nil {
 				return err
 			}
@@ -597,7 +597,7 @@ func (m *MachineScope) ReconcileCreateInstanceOnLB(ctx context.Context) error {
 			m.OCIMachine.Status.CreateBackendWorkRequestId = *resp.OpcWorkRequestId
 			logger.Info("Add instance to NLB backend-set", "WorkRequestId", resp.OpcWorkRequestId)
 			logger.Info("Waiting for NLB work request to be complete")
-			_, err = ociutil.AwaitNLBWorkRequest(ctx, m.NetworkLoadBalancerClient, m.WorkRequestsClient, resp.OpcWorkRequestId)
+			_, err = ociutil.AwaitNLBWorkRequest(ctx, m.NetworkLoadBalancerClient, resp.OpcWorkRequestId)
 			if err != nil {
 				return err
 			}
@@ -665,7 +665,7 @@ func (m *MachineScope) ReconcileDeleteInstanceOnLB(ctx context.Context) error {
 			m.OCIMachine.Status.DeleteBackendWorkRequestId = *resp.OpcWorkRequestId
 			logger.Info("Delete instance from LB backend-set", "WorkRequestId", resp.OpcWorkRequestId)
 			logger.Info("Waiting for LB work request to be complete")
-			_, err = ociutil.AwaitLBWorkRequest(ctx, m.LoadBalancerClient, m.WorkRequestsClient, resp.OpcWorkRequestId)
+			_, err = ociutil.AwaitLBWorkRequest(ctx, m.LoadBalancerClient, resp.OpcWorkRequestId)
 			if err != nil {
 				return err
 			}
@@ -700,7 +700,7 @@ func (m *MachineScope) ReconcileDeleteInstanceOnLB(ctx context.Context) error {
 			m.OCIMachine.Status.DeleteBackendWorkRequestId = *resp.OpcWorkRequestId
 			logger.Info("Delete instance from LB backend-set", "WorkRequestId", resp.OpcWorkRequestId)
 			logger.Info("Waiting for LB work request to be complete")
-			_, err = ociutil.AwaitNLBWorkRequest(ctx, m.NetworkLoadBalancerClient, m.WorkRequestsClient, resp.OpcWorkRequestId)
+			_, err = ociutil.AwaitNLBWorkRequest(ctx, m.NetworkLoadBalancerClient, resp.OpcWorkRequestId)
 			if err != nil {
 				return err
 			}

--- a/cloud/scope/machine_test.go
+++ b/cloud/scope/machine_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/oracle/cluster-api-provider-oci/cloud/services/workrequests/mock_workrequests"
 	"github.com/oracle/oci-go-sdk/v65/loadbalancer"
 	"github.com/oracle/oci-go-sdk/v65/networkloadbalancer"
-	"github.com/oracle/oci-go-sdk/v65/workrequests"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/golang/mock/gomock"
@@ -1577,20 +1576,22 @@ func TestNLBReconciliationCreation(t *testing.T) {
 						WorkRequestId: common.String("wrid"),
 					})).Return(networkloadbalancer.GetWorkRequestResponse{
 					WorkRequest: networkloadbalancer.WorkRequest{
-						Status: networkloadbalancer.OperationStatusFailed,
+						CompartmentId: common.String("compartment-id"),
+						Status:        networkloadbalancer.OperationStatusFailed,
 					}}, nil)
-
-				wrClient.EXPECT().ListWorkRequestErrors(gomock.Any(), gomock.Eq(workrequests.ListWorkRequestErrorsRequest{
+				nlbClient.EXPECT().ListWorkRequestErrors(gomock.Any(), gomock.Eq(networkloadbalancer.ListWorkRequestErrorsRequest{
 					WorkRequestId: common.String("wrid"),
-				})).
-					Return(workrequests.ListWorkRequestErrorsResponse{
-						Items: []workrequests.WorkRequestError{
+					CompartmentId: common.String("compartment-id"),
+				})).Return(networkloadbalancer.ListWorkRequestErrorsResponse{
+					WorkRequestErrorCollection: networkloadbalancer.WorkRequestErrorCollection{
+						Items: []networkloadbalancer.WorkRequestError{
 							{
-								Code:    common.String("InternalServerError"),
-								Message: common.String("Failed due to Unknown error"),
+								Code:    common.String("OKE-001"),
+								Message: common.String("No more Ip available in CIDR 1.1.1.1/1"),
 							},
 						},
-					}, nil)
+					},
+				}, nil)
 			},
 		},
 	}
@@ -1822,20 +1823,23 @@ func TestNLBReconciliationDeletion(t *testing.T) {
 						WorkRequestId: common.String("wrid"),
 					})).Return(networkloadbalancer.GetWorkRequestResponse{
 					WorkRequest: networkloadbalancer.WorkRequest{
-						Status: networkloadbalancer.OperationStatusFailed,
+						CompartmentId: common.String("compartment-id"),
+						Status:        networkloadbalancer.OperationStatusFailed,
 					}}, nil)
 
-				wrClient.EXPECT().ListWorkRequestErrors(gomock.Any(), gomock.Eq(workrequests.ListWorkRequestErrorsRequest{
+				nlbClient.EXPECT().ListWorkRequestErrors(gomock.Any(), gomock.Eq(networkloadbalancer.ListWorkRequestErrorsRequest{
 					WorkRequestId: common.String("wrid"),
-				})).
-					Return(workrequests.ListWorkRequestErrorsResponse{
-						Items: []workrequests.WorkRequestError{
+					CompartmentId: common.String("compartment-id"),
+				})).Return(networkloadbalancer.ListWorkRequestErrorsResponse{
+					WorkRequestErrorCollection: networkloadbalancer.WorkRequestErrorCollection{
+						Items: []networkloadbalancer.WorkRequestError{
 							{
-								Code:    common.String("InternalServerError"),
+								Code:    common.String("OKE-001"),
 								Message: common.String("Failed due to unknown error"),
 							},
 						},
-					}, nil)
+					},
+				}, nil)
 			},
 		},
 		{
@@ -2171,19 +2175,12 @@ func TestLBReconciliationCreation(t *testing.T) {
 					})).Return(loadbalancer.GetWorkRequestResponse{
 					WorkRequest: loadbalancer.WorkRequest{
 						LifecycleState: loadbalancer.WorkRequestLifecycleStateFailed,
-					}}, nil)
-
-				wrClient.EXPECT().ListWorkRequestErrors(gomock.Any(), gomock.Eq(workrequests.ListWorkRequestErrorsRequest{
-					WorkRequestId: common.String("wrid"),
-				})).
-					Return(workrequests.ListWorkRequestErrorsResponse{
-						Items: []workrequests.WorkRequestError{
+						ErrorDetails: []loadbalancer.WorkRequestError{
 							{
-								Code:    common.String("InternalServerError"),
-								Message: common.String("Failed due to Unknown error"),
+								Message: common.String("Internal server error to create lb"),
 							},
 						},
-					}, nil)
+					}}, nil)
 			},
 		},
 	}
@@ -2464,19 +2461,12 @@ func TestLBReconciliationDeletion(t *testing.T) {
 					})).Return(loadbalancer.GetWorkRequestResponse{
 					WorkRequest: loadbalancer.WorkRequest{
 						LifecycleState: loadbalancer.WorkRequestLifecycleStateFailed,
-					}}, nil)
-
-				wrClient.EXPECT().ListWorkRequestErrors(gomock.Any(), gomock.Eq(workrequests.ListWorkRequestErrorsRequest{
-					WorkRequestId: common.String("wrid"),
-				})).
-					Return(workrequests.ListWorkRequestErrorsResponse{
-						Items: []workrequests.WorkRequestError{
+						ErrorDetails: []loadbalancer.WorkRequestError{
 							{
-								Code:    common.String("InternalServerError"),
-								Message: common.String("Failed due to Unknown error"),
+								Message: common.String("Internal Server error to delete lb"),
 							},
 						},
-					}, nil)
+					}}, nil)
 			},
 		},
 		{

--- a/cloud/scope/network_load_balancer_reconciler.go
+++ b/cloud/scope/network_load_balancer_reconciler.go
@@ -88,7 +88,7 @@ func (s *ClusterScope) DeleteApiServerNLB(ctx context.Context) error {
 		s.Logger.Error(err, "failed to delete apiserver nlb")
 		return errors.Wrap(err, "failed to delete apiserver nlb")
 	}
-	_, err = ociutil.AwaitNLBWorkRequest(ctx, s.NetworkLoadBalancerClient, s.WorkRequestClient, lbResponse.OpcWorkRequestId)
+	_, err = ociutil.AwaitNLBWorkRequest(ctx, s.NetworkLoadBalancerClient, lbResponse.OpcWorkRequestId)
 	if err != nil {
 		return errors.Wrap(err, "work request to delete nlb failed")
 	}
@@ -128,7 +128,7 @@ func (s *ClusterScope) UpdateNLB(ctx context.Context, nlb infrastructurev1beta2.
 		s.Logger.Error(err, "failed to reconcile the apiserver NLB, failed to generate update nlb workrequest")
 		return errors.Wrap(err, "failed to reconcile the apiserver NLB, failed to generate update nlb workrequest")
 	}
-	_, err = ociutil.AwaitNLBWorkRequest(ctx, s.NetworkLoadBalancerClient, s.WorkRequestClient, nlbResponse.OpcWorkRequestId)
+	_, err = ociutil.AwaitNLBWorkRequest(ctx, s.NetworkLoadBalancerClient, nlbResponse.OpcWorkRequestId)
 	if err != nil {
 		s.Logger.Error(err, "failed to reconcile the apiserver NLB, failed to update nlb")
 		return errors.Wrap(err, "failed to reconcile the apiserver NLB, failed to update nlb")
@@ -218,7 +218,7 @@ func (s *ClusterScope) CreateNLB(ctx context.Context, lb infrastructurev1beta2.L
 		s.Logger.Error(err, "failed to create apiserver nlb, failed to create work request")
 		return nil, nil, errors.Wrap(err, "failed to create apiserver nlb, failed to create work request")
 	}
-	_, err = ociutil.AwaitNLBWorkRequest(ctx, s.NetworkLoadBalancerClient, s.WorkRequestClient, nlbResponse.OpcWorkRequestId)
+	_, err = ociutil.AwaitNLBWorkRequest(ctx, s.NetworkLoadBalancerClient, nlbResponse.OpcWorkRequestId)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "awaiting network load balancer")
 	}

--- a/cloud/services/networkloadbalancer/client.go
+++ b/cloud/services/networkloadbalancer/client.go
@@ -18,6 +18,7 @@ package nlb
 
 import (
 	"context"
+
 	"github.com/oracle/oci-go-sdk/v65/networkloadbalancer"
 )
 
@@ -28,6 +29,7 @@ type NetworkLoadBalancerClient interface {
 	CreateNetworkLoadBalancer(ctx context.Context, request networkloadbalancer.CreateNetworkLoadBalancerRequest) (response networkloadbalancer.CreateNetworkLoadBalancerResponse, err error)
 	DeleteBackend(ctx context.Context, request networkloadbalancer.DeleteBackendRequest) (response networkloadbalancer.DeleteBackendResponse, err error)
 	GetWorkRequest(ctx context.Context, request networkloadbalancer.GetWorkRequestRequest) (response networkloadbalancer.GetWorkRequestResponse, err error)
+	ListWorkRequestErrors(ctx context.Context, request networkloadbalancer.ListWorkRequestErrorsRequest) (response networkloadbalancer.ListWorkRequestErrorsResponse, err error)
 	UpdateNetworkLoadBalancer(ctx context.Context, request networkloadbalancer.UpdateNetworkLoadBalancerRequest) (response networkloadbalancer.UpdateNetworkLoadBalancerResponse, err error)
 	DeleteNetworkLoadBalancer(ctx context.Context, request networkloadbalancer.DeleteNetworkLoadBalancerRequest) (response networkloadbalancer.DeleteNetworkLoadBalancerResponse, err error)
 }

--- a/cloud/services/networkloadbalancer/mock_nlb/client_mock.go
+++ b/cloud/services/networkloadbalancer/mock_nlb/client_mock.go
@@ -125,6 +125,21 @@ func (mr *MockNetworkLoadBalancerClientMockRecorder) GetWorkRequest(ctx, request
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkRequest", reflect.TypeOf((*MockNetworkLoadBalancerClient)(nil).GetWorkRequest), ctx, request)
 }
 
+// ListWorkRequestErrors mocks base method.
+func (m *MockNetworkLoadBalancerClient) ListWorkRequestErrors(ctx context.Context, request networkloadbalancer.ListWorkRequestErrorsRequest) (networkloadbalancer.ListWorkRequestErrorsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListWorkRequestErrors", ctx, request)
+	ret0, _ := ret[0].(networkloadbalancer.ListWorkRequestErrorsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListWorkRequestErrors indicates an expected call of GetWorkRequest.
+func (mr *MockNetworkLoadBalancerClientMockRecorder) ListWorkRequestErrors(ctx, request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkRequestErrors", reflect.TypeOf((*MockNetworkLoadBalancerClient)(nil).ListWorkRequestErrors), ctx, request)
+}
+
 // ListNetworkLoadBalancers mocks base method.
 func (m *MockNetworkLoadBalancerClient) ListNetworkLoadBalancers(ctx context.Context, request networkloadbalancer.ListNetworkLoadBalancersRequest) (networkloadbalancer.ListNetworkLoadBalancersResponse, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
**What this PR does / why we need it**:
The work-request-errors for loadbalancer and networkloadbalancer will be populated in the events incase of failure of workrequests for better information.

**Which issue(s) this PR fixes**:
Fixes #383 
