### PR TITLE
Update release workflow to use new upload-artifact@v4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
           echo "Release Tag: ${{ github.ref_name }}" 
           curl -sSL https://doc.crds.dev/github.com/oracle/cluster-api-provider-oci@${{ github.ref_name }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: CAPOCI Artifacts
           path: out/


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the release workflow issue and is now working on the release branch here: https://github.com/oracle/cluster-api-provider-oci/actions/runs/10941758099

v2 is deprecated
https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
