### PR TITLE
feat #388: Add support for paravirtualized launch volume attachment

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -41,7 +41,7 @@ if "default_registry" in settings:
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.19 as tilt-helper
+FROM golang:1.21.8 as tilt-helper
 # Support live reloading with Tilt
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/tilt-dev/rerun-process-wrapper/master/restart.sh  && \
@@ -196,7 +196,7 @@ def base64_decode(to_decode):
     return str(decode_blob)
 
 def kustomizesub(folder):
-    yaml = local('hack/kustomize-sub.sh {}'.format(folder), quiet=True)
+    yaml = local('bash hack/kustomize-sub.sh {}'.format(folder), quiet=True)
     return yaml
 
 ##############################

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -1098,6 +1098,7 @@ type VolumeType string
 
 const (
 	IscsiType VolumeType = "iscsi"
+	ParavirtualizedType VolumeType = "paravirtualized"
 )
 
 // EncryptionInTransitTypeEnum Enum with underlying type: string
@@ -1115,6 +1116,7 @@ type LaunchVolumeAttachment struct {
 
 	// The details of iscsi volume attachment.
 	IscsiAttachment LaunchIscsiVolumeAttachment `json:"launchIscsiVolumeAttachment,omitempty"`
+	ParavirtualizedAttachment LaunchParavirtualizedVolumeAttachment `json:"launchParavirtualizedVolumeAttachment,omitempty"`
 }
 
 // LaunchIscsiVolumeAttachment specifies the iscsi volume attachments to create as part of the launch instance operation.
@@ -1150,6 +1152,35 @@ type LaunchIscsiVolumeAttachment struct {
 	// Refer the top-level definition of encryptionInTransitType.
 	// The default value is NONE.
 	EncryptionInTransitType EncryptionInTransitTypeEnum `json:"encryptionInTransitType,omitempty"`
+}
+
+// LaunchParavirtualizedVolumeAttachment specifies the paravirtualized volume attachments to create as part of the launch instance operation.
+type LaunchParavirtualizedVolumeAttachment struct {
+	// The device name. To retrieve a list of devices for a given instance, see ListInstanceDevices.
+	Device *string `json:"device,omitempty"`
+
+	// A user-friendly name. Does not have to be unique, and it's changeable.
+	// Avoid entering confidential information.
+	DisplayName *string `json:"displayName,omitempty"`
+
+	// Whether the attachment was created in read-only mode.
+	IsReadOnly *bool `json:"isReadOnly,omitempty"`
+
+	// Whether the attachment should be created in shareable mode. If an attachment
+	// is created in shareable mode, then other instances can attach the same volume, provided
+	// that they also create their attachments in shareable mode. Only certain volume types can
+	// be attached in shareable mode. Defaults to false if not specified.
+	IsShareable *bool `json:"isShareable,omitempty"`
+
+	// The OCID of the volume. If CreateVolumeDetails is specified, this field must be omitted from the request.
+	VolumeId *string `json:"volumeId,omitempty"`
+
+	// LaunchCreateVolumeFromAttributes The details of the volume to create for CreateVolume operation.
+	LaunchCreateVolumeFromAttributes LaunchCreateVolumeFromAttributes `json:"launchCreateVolumeFromAttributes,omitempty"`
+	
+	// Refer the top-level definition of isPvEncryptionInTransitEnabled.
+	// The default value is False.
+	IsPvEncryptionInTransitEnabled *bool `json:"isPvEncryptionInTransitEnabled,omitempty"`
 }
 
 // LaunchCreateVolumeFromAttributes The details of the volume to create for CreateVolume operation.

--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -1168,6 +1168,7 @@ type VolumeType string
 
 const (
 	IscsiType VolumeType = "iscsi"
+	ParavirtualizedType VolumeType = "paravirtualized"
 )
 
 // EncryptionInTransitTypeEnum Enum with underlying type: string
@@ -1186,6 +1187,7 @@ type LaunchVolumeAttachment struct {
 
 	// The details of iscsi volume attachment.
 	IscsiAttachment LaunchIscsiVolumeAttachment `json:"launchIscsiVolumeAttachment,omitempty"`
+	ParavirtualizedAttachment LaunchParavirtualizedVolumeAttachment `json:"launchParavirtualizedVolumeAttachment,omitempty"`
 }
 
 // LaunchIscsiVolumeAttachment specifies the iscsi volume attachments to create as part of the launch instance operation.
@@ -1222,6 +1224,36 @@ type LaunchIscsiVolumeAttachment struct {
 	// The default value is NONE.
 	EncryptionInTransitType EncryptionInTransitTypeEnum `json:"encryptionInTransitType,omitempty"`
 }
+
+// LaunchParavirtualizedVolumeAttachment specifies the paravirtualized volume attachments to create as part of the launch instance operation.
+type LaunchParavirtualizedVolumeAttachment struct {
+	// The device name. To retrieve a list of devices for a given instance, see ListInstanceDevices.
+	Device *string `json:"device,omitempty"`
+
+	// A user-friendly name. Does not have to be unique, and it's changeable.
+	// Avoid entering confidential information.
+	DisplayName *string `json:"displayName,omitempty"`
+
+	// Whether the attachment was created in read-only mode.
+	IsReadOnly *bool `json:"isReadOnly,omitempty"`
+
+	// Whether the attachment should be created in shareable mode. If an attachment
+	// is created in shareable mode, then other instances can attach the same volume, provided
+	// that they also create their attachments in shareable mode. Only certain volume types can
+	// be attached in shareable mode. Defaults to false if not specified.
+	IsShareable *bool `json:"isShareable,omitempty"`
+
+	// The OCID of the volume. If CreateVolumeDetails is specified, this field must be omitted from the request.
+	VolumeId *string `json:"volumeId,omitempty"`
+
+	// LaunchCreateVolumeFromAttributes The details of the volume to create for CreateVolume operation.
+	LaunchCreateVolumeFromAttributes LaunchCreateVolumeFromAttributes `json:"launchCreateVolumeFromAttributes,omitempty"`
+
+	// Refer the top-level definition of encryptionInTransitType.
+	// The default value is False.
+	IsPvEncryptionInTransitEnabled *bool `json:"isPvEncryptionInTransitEnabled,omitempty"`
+}
+
 
 // LaunchCreateVolumeFromAttributes The details of the volume to create for CreateVolume operation.
 type LaunchCreateVolumeFromAttributes struct {

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -1000,7 +1000,7 @@ func (m *MachineScope) getLaunchVolumeAttachments() []core.LaunchAttachVolumeDet
 		} else if attachment.Type == infrastructurev1beta2.ParavirtualizedType {
 			volumes = append(volumes, getParavirtualizedVolumeAttachment(attachment.ParavirtualizedAttachment))
 		} else {
-			m.Logger.Info("Block Volume attachment type not supported")
+			m.Logger.Info("Unknown attachment type not supported")
 		}
 	}
 	return volumes

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -997,6 +997,10 @@ func (m *MachineScope) getLaunchVolumeAttachments() []core.LaunchAttachVolumeDet
 	for _, attachment := range volumeAttachmentsInSpec {
 		if attachment.Type == infrastructurev1beta2.IscsiType {
 			volumes = append(volumes, getIscsiVolumeAttachment(attachment.IscsiAttachment))
+		} else if attachment.Type == infrastructurev1beta2.ParavirtualizedType {
+			volumes = append(volumes, getParavirtualizedVolumeAttachment(attachment.ParavirtualizedAttachment))
+		} else {
+			m.Logger.Info("Block Volume attachment type not supported")
 		}
 	}
 	return volumes
@@ -1012,6 +1016,19 @@ func getIscsiVolumeAttachment(attachment infrastructurev1beta2.LaunchIscsiVolume
 		UseChap:                      attachment.UseChap,
 		IsAgentAutoIscsiLoginEnabled: attachment.IsAgentAutoIscsiLoginEnabled,
 		EncryptionInTransitType:      getEncryptionType(attachment.EncryptionInTransitType),
+		LaunchCreateVolumeDetails:    getLaunchCreateVolumeDetails(attachment.LaunchCreateVolumeFromAttributes),
+	}
+	return volumeDetails
+}
+
+func getParavirtualizedVolumeAttachment(attachment infrastructurev1beta2.LaunchParavirtualizedVolumeAttachment) core.LaunchAttachVolumeDetails {
+	volumeDetails := core.LaunchAttachParavirtualizedVolumeDetails{
+		Device:                       attachment.Device,
+		DisplayName:                  attachment.DisplayName,
+		IsShareable:                  attachment.IsShareable,
+		IsReadOnly:                   attachment.IsReadOnly,
+		VolumeId:                     attachment.VolumeId,
+		IsPvEncryptionInTransitEnabled:      attachment.IsPvEncryptionInTransitEnabled,
 		LaunchCreateVolumeDetails:    getLaunchCreateVolumeDetails(attachment.LaunchCreateVolumeFromAttributes),
 	}
 	return volumeDetails

--- a/cloud/scope/machine_test.go
+++ b/cloud/scope/machine_test.go
@@ -552,7 +552,7 @@ func TestInstanceReconciliation(t *testing.T) {
 			},
 		},
 		{
-			name:          "check all params together, with subnet id set, nsg id list",
+			name:          "check all params together, with paravirtualized volume support",
 			errorExpected: false,
 			testSpecificSetup: func(machineScope *MachineScope, computeClient *mock_compute.MockComputeClient) {
 				setupAllParams(ms)

--- a/cloud/scope/machine_test.go
+++ b/cloud/scope/machine_test.go
@@ -568,10 +568,11 @@ func TestInstanceReconciliation(t *testing.T) {
 				ms.OCIMachine.Spec.NetworkDetails.DisplayName = common.String("display-name")
 				ms.OCIMachine.Spec.LaunchVolumeAttachment = []infrastructurev1beta2.LaunchVolumeAttachment{
 					{
-						Type: infrastructurev1beta2.IscsiType,
-						IscsiAttachment: infrastructurev1beta2.LaunchIscsiVolumeAttachment{
+						Type: infrastructurev1beta2.ParavirtualizedType,
+						ParavirtualizedAttachment: infrastructurev1beta2.LaunchParavirtualizedVolumeAttachment{
 							Device:      common.String("/dev/oci"),
 							IsShareable: common.Bool(true),
+							IsPvEncryptionInTransitEnabled: common.Bool(false), 
 							LaunchCreateVolumeFromAttributes: infrastructurev1beta2.LaunchCreateVolumeFromAttributes{
 								DisplayName: common.String("test-volume"),
 								SizeInGBs:   common.Int64(75),

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimachines.yaml
@@ -328,8 +328,74 @@ spec:
                             is specified, this field must be omitted from the request.
                           type: string
                       type: object
+                    launchParavirtualizedVolumeAttachment:
+                      description: The details of paravirtualized volume attachment.
+                      properties:
+                        device:
+                          description: The device name. To retrieve a list of devices
+                            for a given instance, see ListInstanceDevices.
+                          type: string
+                        displayName:
+                          description: A user-friendly name. Does not have to be unique,
+                            and it's changeable. Avoid entering confidential information.
+                          type: string
+                        isPvEncryptionInTransitEnabled:
+                          description: Refer the top-level definition of isPvEncryptionInTransitEnabled.
+                            The default value is False.
+                          type: boolean
+                        isReadOnly:
+                          description: Whether the attachment was created in read-only
+                            mode.
+                          type: boolean
+                        isShareable:
+                          description: Whether the attachment should be created in
+                            shareable mode. If an attachment is created in shareable
+                            mode, then other instances can attach the same volume,
+                            provided that they also create their attachments in shareable
+                            mode. Only certain volume types can be attached in shareable
+                            mode. Defaults to false if not specified.
+                          type: boolean
+                        launchCreateVolumeFromAttributes:
+                          description: LaunchCreateVolumeFromAttributes The details
+                            of the volume to create for CreateVolume operation.
+                          properties:
+                            compartmentId:
+                              description: The OCID of the compartment that contains
+                                the volume. If not provided, it will be inherited
+                                from the instance.
+                              type: string
+                            displayName:
+                              description: A user-friendly name. Does not have to
+                                be unique, and it's changeable. Avoid entering confidential
+                                information.
+                              type: string
+                            kmsKeyId:
+                              description: The OCID of the Vault service key to assign
+                                as the master encryption key for the volume.
+                              type: string
+                            sizeInGBs:
+                              description: The size of the volume in GBs.
+                              format: int64
+                              type: integer
+                            vpusPerGB:
+                              description: 'The number of volume performance units
+                                (VPUs) that will be applied to this volume per GB,
+                                representing the Block Volume service''s elastic performance
+                                options. See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels)
+                                for more information. Allowed values: * `0`: Represents
+                                Lower Cost option. * `10`: Represents Balanced option.
+                                * `20`: Represents Higher Performance option. * `30`-`120`:
+                                Represents the Ultra High Performance option.'
+                              format: int64
+                              type: integer
+                          type: object
+                        volumeId:
+                          description: The OCID of the volume. If CreateVolumeDetails
+                            is specified, this field must be omitted from the request.
+                          type: string
+                      type: object
                     volumeType:
-                      description: The type of volume. Valid value is iscsi.
+                      description: The type of volume. Valid value is iscsi/paravirtualized.
                       type: string
                   type: object
                 type: array
@@ -1194,6 +1260,72 @@ spec:
                           description: Whether to use CHAP authentication for the
                             volume attachment. Defaults to false.
                           type: boolean
+                        volumeId:
+                          description: The OCID of the volume. If CreateVolumeDetails
+                            is specified, this field must be omitted from the request.
+                          type: string
+                      type: object
+                    launchParavirtualizedVolumeAttachment:
+                      description: The details of paravirtualized volume attachment.
+                      properties:
+                        device:
+                          description: The device name. To retrieve a list of devices
+                            for a given instance, see ListInstanceDevices.
+                          type: string
+                        displayName:
+                          description: A user-friendly name. Does not have to be unique,
+                            and it's changeable. Avoid entering confidential information.
+                          type: string
+                        isPvEncryptionInTransitEnabled:
+                          description: Refer the top-level definition of isPvEncryptionInTransitEnabled.
+                            The default value is False.
+                          type: boolean
+                        isReadOnly:
+                          description: Whether the attachment was created in read-only
+                            mode.
+                          type: boolean
+                        isShareable:
+                          description: Whether the attachment should be created in
+                            shareable mode. If an attachment is created in shareable
+                            mode, then other instances can attach the same volume,
+                            provided that they also create their attachments in shareable
+                            mode. Only certain volume types can be attached in shareable
+                            mode. Defaults to false if not specified.
+                          type: boolean
+                        launchCreateVolumeFromAttributes:
+                          description: LaunchCreateVolumeFromAttributes The details
+                            of the volume to create for CreateVolume operation.
+                          properties:
+                            compartmentId:
+                              description: The OCID of the compartment that contains
+                                the volume. If not provided, it will be inherited
+                                from the instance.
+                              type: string
+                            displayName:
+                              description: A user-friendly name. Does not have to
+                                be unique, and it's changeable. Avoid entering confidential
+                                information.
+                              type: string
+                            kmsKeyId:
+                              description: The OCID of the Vault service key to assign
+                                as the master encryption key for the volume.
+                              type: string
+                            sizeInGBs:
+                              description: The size of the volume in GBs.
+                              format: int64
+                              type: integer
+                            vpusPerGB:
+                              description: 'The number of volume performance units
+                                (VPUs) that will be applied to this volume per GB,
+                                representing the Block Volume service''s elastic performance
+                                options. See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels)
+                                for more information. Allowed values: * `0`: Represents
+                                Lower Cost option. * `10`: Represents Balanced option.
+                                * `20`: Represents Higher Performance option. * `30`-`120`:
+                                Represents the Ultra High Performance option.'
+                              format: int64
+                              type: integer
+                          type: object
                         volumeId:
                           description: The OCID of the volume. If CreateVolumeDetails
                             is specified, this field must be omitted from the request.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimachinetemplates.yaml
@@ -362,6 +362,72 @@ spec:
                                     the request.
                                   type: string
                               type: object
+                            launchParavirtualizedVolumeAttachment:
+                              description: The details of paravirtualized volume attachment.
+                              properties:
+                                device:
+                                  description: The device name. To retrieve a list of devices
+                                    for a given instance, see ListInstanceDevices.
+                                  type: string
+                                displayName:
+                                  description: A user-friendly name. Does not have to be unique,
+                                    and it's changeable. Avoid entering confidential information.
+                                  type: string
+                                isPvEncryptionInTransitEnabled:
+                                  description: Refer the top-level definition of isPvEncryptionInTransitEnabled.
+                                    The default value is False.
+                                  type: boolean
+                                isReadOnly:
+                                  description: Whether the attachment was created in read-only
+                                    mode.
+                                  type: boolean
+                                isShareable:
+                                  description: Whether the attachment should be created in
+                                    shareable mode. If an attachment is created in shareable
+                                    mode, then other instances can attach the same volume,
+                                    provided that they also create their attachments in shareable
+                                    mode. Only certain volume types can be attached in shareable
+                                    mode. Defaults to false if not specified.
+                                  type: boolean
+                                launchCreateVolumeFromAttributes:
+                                  description: LaunchCreateVolumeFromAttributes The details
+                                    of the volume to create for CreateVolume operation.
+                                  properties:
+                                    compartmentId:
+                                      description: The OCID of the compartment that contains
+                                        the volume. If not provided, it will be inherited
+                                        from the instance.
+                                      type: string
+                                    displayName:
+                                      description: A user-friendly name. Does not have to
+                                        be unique, and it's changeable. Avoid entering confidential
+                                        information.
+                                      type: string
+                                    kmsKeyId:
+                                      description: The OCID of the Vault service key to assign
+                                        as the master encryption key for the volume.
+                                      type: string
+                                    sizeInGBs:
+                                      description: The size of the volume in GBs.
+                                      format: int64
+                                      type: integer
+                                    vpusPerGB:
+                                      description: 'The number of volume performance units
+                                        (VPUs) that will be applied to this volume per GB,
+                                        representing the Block Volume service''s elastic performance
+                                        options. See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels)
+                                        for more information. Allowed values: * `0`: Represents
+                                        Lower Cost option. * `10`: Represents Balanced option.
+                                        * `20`: Represents Higher Performance option. * `30`-`120`:
+                                        Represents the Ultra High Performance option.'
+                                      format: int64
+                                      type: integer
+                                  type: object
+                                volumeId:
+                                  description: The OCID of the volume. If CreateVolumeDetails
+                                    is specified, this field must be omitted from the request.
+                                  type: string
+                              type: object
                             volumeType:
                               description: The type of volume. Valid value is iscsi.
                               type: string
@@ -1221,6 +1287,72 @@ spec:
                                   description: The OCID of the volume. If CreateVolumeDetails
                                     is specified, this field must be omitted from
                                     the request.
+                                  type: string
+                              type: object
+                            launchParavirtualizedVolumeAttachment:
+                              description: The details of paravirtualized volume attachment.
+                              properties:
+                                device:
+                                  description: The device name. To retrieve a list of devices
+                                    for a given instance, see ListInstanceDevices.
+                                  type: string
+                                displayName:
+                                  description: A user-friendly name. Does not have to be unique,
+                                    and it's changeable. Avoid entering confidential information.
+                                  type: string
+                                isPvEncryptionInTransitEnabled:
+                                  description: Refer the top-level definition of isPvEncryptionInTransitEnabled.
+                                    The default value is False.
+                                  type: boolean
+                                isReadOnly:
+                                  description: Whether the attachment was created in read-only
+                                    mode.
+                                  type: boolean
+                                isShareable:
+                                  description: Whether the attachment should be created in
+                                    shareable mode. If an attachment is created in shareable
+                                    mode, then other instances can attach the same volume,
+                                    provided that they also create their attachments in shareable
+                                    mode. Only certain volume types can be attached in shareable
+                                    mode. Defaults to false if not specified.
+                                  type: boolean
+                                launchCreateVolumeFromAttributes:
+                                  description: LaunchCreateVolumeFromAttributes The details
+                                    of the volume to create for CreateVolume operation.
+                                  properties:
+                                    compartmentId:
+                                      description: The OCID of the compartment that contains
+                                        the volume. If not provided, it will be inherited
+                                        from the instance.
+                                      type: string
+                                    displayName:
+                                      description: A user-friendly name. Does not have to
+                                        be unique, and it's changeable. Avoid entering confidential
+                                        information.
+                                      type: string
+                                    kmsKeyId:
+                                      description: The OCID of the Vault service key to assign
+                                        as the master encryption key for the volume.
+                                      type: string
+                                    sizeInGBs:
+                                      description: The size of the volume in GBs.
+                                      format: int64
+                                      type: integer
+                                    vpusPerGB:
+                                      description: 'The number of volume performance units
+                                        (VPUs) that will be applied to this volume per GB,
+                                        representing the Block Volume service''s elastic performance
+                                        options. See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels)
+                                        for more information. Allowed values: * `0`: Represents
+                                        Lower Cost option. * `10`: Represents Balanced option.
+                                        * `20`: Represents Higher Performance option. * `30`-`120`:
+                                        Represents the Ultra High Performance option.'
+                                      format: int64
+                                      type: integer
+                                  type: object
+                                volumeId:
+                                  description: The OCID of the volume. If CreateVolumeDetails
+                                    is specified, this field must be omitted from the request.
                                   type: string
                               type: object
                             volumeType:

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/gofuzz v1.2.0
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.32.0
-	github.com/oracle/oci-go-sdk/v65 v65.70.0
+	github.com/oracle/oci-go-sdk/v65 v65.81.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.18.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/oracle/oci-go-sdk/v65 v65.70.0 h1:gLa0IX/SidTm60VbHabnImrW3hyymmNLQJy6gZGrgDA=
-github.com/oracle/oci-go-sdk/v65 v65.70.0/go.mod h1:IBEV9l1qBzUpo7zgGaRUhbB05BVfcDGYRFBCPlTcPp0=
+github.com/oracle/oci-go-sdk/v65 v65.81.1 h1:JYc47bk8n/MUchA2KHu1ggsCQzlJZQLJ+tTKfOho00E=
+github.com/oracle/oci-go-sdk/v65 v65.81.1/go.mod h1:IBEV9l1qBzUpo7zgGaRUhbB05BVfcDGYRFBCPlTcPp0=
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=


### PR DESCRIPTION
feat Add support for paravirtualized launch volume attachment
**What this PR does / why we need it**: 
Recently support was added for configuring [paravirtualized launch volume attachments](https://docs.oracle.com/en-us/iaas/api/#/en/iaas/20160918/datatypes/InstanceConfigurationAttachVolumeDetails) at instance creation with go sdk v65.75.1 onwards, added the support for attaching paravirtualized volume at instance creation via cluster api provider.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: #388 
Fixes #
Updated OCI Go sdk version to v65.81.1
Updated tilt-helper docker manifest go version to 1.21.8
added support for paravirtualized volumes

Signed-off-by: Mayank Kakani <mkakani1@gmail.com>