### PR TITLE
fix: Guard against Network Security Group ID being nil.

### DIFF
--- a/cloud/scope/util.go
+++ b/cloud/scope/util.go
@@ -32,7 +32,7 @@ func GetNsgNamesFromId(ids []string, nsgs []*infrastructurev1beta2.NSG) []string
 	names := make([]string, 0)
 	for _, id := range ids {
 		for _, nsg := range nsgs {
-			if id == *nsg.ID {
+			if nsg.ID != nil && id == *nsg.ID {
 				names = append(names, nsg.Name)
 			}
 		}

--- a/cloud/scope/util_test.go
+++ b/cloud/scope/util_test.go
@@ -76,6 +76,17 @@ func Test_GetNsgNamesFromId(t *testing.T) {
 			},
 			expected: make([]string, 0),
 		},
+		{
+			name: "nil",
+			ids:  []string{"id-3"},
+			nsgs: []*infrastructurev1beta2.NSG{
+				{
+					//ID:   nil, // Not specifying ID should set it to nil.
+					Name: "test-1",
+				},
+			},
+			expected: make([]string, 0),
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
If the ID of the [Network Security Group](https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/networksecuritygroups.htm) is null, it gets deref'd crashing the provider.