### PR TITLE
Ipv6 implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,23 +34,8 @@ _artifacts/
 config/default/manager_image_patch.yaml-e
 config/default/manager_pull_policy.yaml-e
 test/e2e/config/e2e_conf-envsubst.yaml
-test/e2e/data/infrastructure-oci/v1beta1/cluster-template-antrea.yaml
-test/e2e/data/infrastructure-oci/v1beta1/cluster-template-ccm-testing.yaml
-test/e2e/data/infrastructure-oci/v1beta1/cluster-template-kcp-remediation.yaml
-test/e2e/data/infrastructure-oci/v1beta1/cluster-template-md-remediation.yaml
-test/e2e/data/infrastructure-oci/v1beta1/cluster-template-node-drain.yaml
-test/e2e/data/infrastructure-oci/v1beta1/cluster-template-oracle-linux.yaml
-test/e2e/data/infrastructure-oci/v1beta1/cluster-template.yaml
-test/e2e/data/infrastructure-oci/v1beta1/cluster-template-bare-metal.yaml
-test/e2e/data/infrastructure-oci/v1beta1/cluster-template-custom-networking-seclist.yaml
-test/e2e/data/infrastructure-oci/v1beta1/cluster-template-custom-networking-nsg.yaml
-test/e2e/data/infrastructure-oci/v1beta1/cluster-template-multiple-node-nsg.yaml
-test/e2e/data/infrastructure-oci/v1beta1/cluster-template-local-vcn-peering.yaml
-test/e2e/data/infrastructure-oci/v1beta1/cluster-template-cluster-class.yaml
-test/e2e/data/infrastructure-oci/v1beta1/cluster-template-remote-vcn-peering.yaml
-test/e2e/data/infrastructure-oci/v1beta1/cluster-template-externally-managed-vcn.yaml
-test/e2e/data/infrastructure-oci/v1beta1/cluster-template-alternative-region.yaml
-test/e2e/data/infrastructure-oci/v1beta1/cluster-template-machine-pool.yaml
+test/e2e/data/infrastructure-oci/v1beta*/cluster-template*.yaml
+
 
 # tilt
 tilt-settings.json

--- a/Makefile
+++ b/Makefile
@@ -295,6 +295,8 @@ generate-e2e-templates: $(KUSTOMIZE)
 	$(KUSTOMIZE) build $(OCI_TEMPLATES)/v1beta2/cluster-template-windows-calico --load-restrictor LoadRestrictionsNone > $(OCI_TEMPLATES)/v1beta2/cluster-template-windows-calico.yaml
 	$(KUSTOMIZE) build $(OCI_TEMPLATES)/v1beta2/cluster-template-managed-virtual --load-restrictor LoadRestrictionsNone > $(OCI_TEMPLATES)/v1beta2/cluster-template-managed-virtual.yaml
 	$(KUSTOMIZE) build $(OCI_TEMPLATES)/v1beta2/cluster-template-managed-self-managed-nodes --load-restrictor LoadRestrictionsNone > $(OCI_TEMPLATES)/v1beta2/cluster-template-managed-self-managed-nodes.yaml
+	$(KUSTOMIZE) build $(OCI_TEMPLATES)/v1beta2/cluster-template-machine-with-ipv6 --load-restrictor LoadRestrictionsNone > $(OCI_TEMPLATES)/v1beta2/cluster-template-machine-with-ipv6.yaml
+	$(KUSTOMIZE) build $(OCI_TEMPLATES)/v1beta2/cluster-template-with-paravirt-bv --load-restrictor LoadRestrictionsNone > $(OCI_TEMPLATES)/v1beta2/cluster-template-with-paravirt-bv.yaml
 
 .PHONY: test-e2e-run
 test-e2e-run: generate-e2e-templates $(GINKGO) $(ENVSUBST) ## Run e2e tests

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -74,9 +74,6 @@ type VnicAttachment struct {
 	// VnicAttachmentId defines the ID of the VnicAttachment
 	VnicAttachmentId *string `json:"vnicAttachmentId,omitempty"`
 
-	// IPv6 defines if the instance should have an IPv6
-	AssignIpv6Ip bool `json:"assignIpv6Ip,omitempty"`
-
 	// AssignPublicIp defines whether the vnic should have a public IP address
 	// +optional
 	AssignPublicIp bool `json:"assignPublicIp,omitempty"`
@@ -873,6 +870,11 @@ type Subnet struct {
 	// +optional
 	DnsLabel *string `json:"dnsLabel,omitempty"`
 
+	// Use this to enable IPv6 hextet for this subnet. The VCN must be enabled for IPv6.
+	// You can't change this subnet characteristic later. All subnets are /64 in size. The subnet
+	// portion of the IPv6 address is the fourth hextet from the left (1111 in the following example).
+	// Example: `2001:0db8:0123:1111::/64`
+	// +optional
 	Ipv6CidrBlockHextet *string `json:"ipv6CidrBlockHextet,omitempty"`
 }
 
@@ -951,7 +953,7 @@ type VCN struct {
 	// +optional
 	DnsLabel *string `json:"dnsLabel,omitempty"`
 
-	// Configuration to allow OCI to assign IPv6 Prefix.
+	// Configuration to allow OCI to assign IPv6 Prefix. When true will use a /56 IPv6 global unicast address (GUA) prefix allocated by Oracle
 	// +optional
 	IsOracleGuaAllocationEnabled *bool `json:"isOracleGuaAllocationEnabled,omitempty"`
 

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -37,6 +37,9 @@ type NetworkDetails struct {
 	// SubnetId defines the ID of the subnet to use. This parameter takes priority over SubnetName.
 	SubnetId *string `json:"subnetId,omitempty"`
 
+	// IPv6 defines if the instance should have an IPv6
+	AssignIpv6Ip bool `json:"assignIpv6Ip,omitempty"`
+
 	// AssignPublicIp defines whether the instance should have a public IP address
 	AssignPublicIp bool `json:"assignPublicIp,omitempty"`
 
@@ -70,6 +73,9 @@ type NetworkDetails struct {
 type VnicAttachment struct {
 	// VnicAttachmentId defines the ID of the VnicAttachment
 	VnicAttachmentId *string `json:"vnicAttachmentId,omitempty"`
+
+	// IPv6 defines if the instance should have an IPv6
+	AssignIpv6Ip bool `json:"assignIpv6Ip,omitempty"`
 
 	// AssignPublicIp defines whether the vnic should have a public IP address
 	// +optional
@@ -866,6 +872,8 @@ type Subnet struct {
 	// within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
 	// +optional
 	DnsLabel *string `json:"dnsLabel,omitempty"`
+
+	Ipv6CidrBlockHextet *string `json:"ipv6CidrBlockHextet,omitempty"`
 }
 
 // NSG defines configuration for a Network Security Group.
@@ -942,6 +950,14 @@ type VCN struct {
 	// within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
 	// +optional
 	DnsLabel *string `json:"dnsLabel,omitempty"`
+
+	// Configuration to allow OCI to assign IPv6 Prefix.
+	// +optional
+	IsOracleGuaAllocationEnabled *bool `json:"isOracleGuaAllocationEnabled,omitempty"`
+
+	// Configuration to enable IPv6.
+	// +optional
+	IsIpv6Enabled *bool `json:"isIpv6Enabled,omitempty"`
 }
 
 // LoadBalancer Configuration
@@ -1097,7 +1113,7 @@ type RemotePeeringConnection struct {
 type VolumeType string
 
 const (
-	IscsiType VolumeType = "iscsi"
+	IscsiType           VolumeType = "iscsi"
 	ParavirtualizedType VolumeType = "paravirtualized"
 )
 
@@ -1115,7 +1131,7 @@ type LaunchVolumeAttachment struct {
 	Type VolumeType `json:"volumeType,omitempty"`
 
 	// The details of iscsi volume attachment.
-	IscsiAttachment LaunchIscsiVolumeAttachment `json:"launchIscsiVolumeAttachment,omitempty"`
+	IscsiAttachment           LaunchIscsiVolumeAttachment           `json:"launchIscsiVolumeAttachment,omitempty"`
 	ParavirtualizedAttachment LaunchParavirtualizedVolumeAttachment `json:"launchParavirtualizedVolumeAttachment,omitempty"`
 }
 
@@ -1177,7 +1193,7 @@ type LaunchParavirtualizedVolumeAttachment struct {
 
 	// LaunchCreateVolumeFromAttributes The details of the volume to create for CreateVolume operation.
 	LaunchCreateVolumeFromAttributes LaunchCreateVolumeFromAttributes `json:"launchCreateVolumeFromAttributes,omitempty"`
-	
+
 	// Refer the top-level definition of isPvEncryptionInTransitEnabled.
 	// The default value is False.
 	IsPvEncryptionInTransitEnabled *bool `json:"isPvEncryptionInTransitEnabled,omitempty"`

--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -76,10 +76,6 @@ type VnicAttachment struct {
 	// VnicAttachmentId defines the ID of the VnicAttachment
 	VnicAttachmentId *string `json:"vnicAttachmentId,omitempty"`
 
-	// AssignIPv6 defines whether the vnic should have a IPv6 address
-	// +optional
-	AssignIpv6Ip bool `json:"assignIpv6Ip,omitempty"`
-
 	// AssignPublicIp defines whether the vnic should have a public IP address
 	// +optional
 	AssignPublicIp bool `json:"assignPublicIp,omitempty"`
@@ -951,7 +947,7 @@ type VCN struct {
 	// +optional
 	DnsLabel *string `json:"dnsLabel,omitempty"`
 
-	// Configuration to allow OCI to assign IPv6 Prefix.
+	// Configuration to allow OCI to assign IPv6 Prefix. When true will use a /56 IPv6 global unicast address (GUA) prefix allocated by Oracle
 	// +optional
 	IsOracleGuaAllocationEnabled *bool `json:"isOracleGuaAllocationEnabled,omitempty"`
 

--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -38,6 +38,10 @@ type NetworkDetails struct {
 	// SubnetId defines the ID of the subnet to use. This parameter takes priority over SubnetName.
 	SubnetId *string `json:"subnetId,omitempty"`
 
+	// AssignIPv6 determines whether to assign a IPv6 address to the instance.
+	// +optional
+	AssignIpv6Ip bool `json:"assignIpv6Ip,omitempty"`
+
 	// AssignPublicIp defines whether the instance should have a public IP address
 	AssignPublicIp bool `json:"assignPublicIp,omitempty"`
 
@@ -71,6 +75,10 @@ type NetworkDetails struct {
 type VnicAttachment struct {
 	// VnicAttachmentId defines the ID of the VnicAttachment
 	VnicAttachmentId *string `json:"vnicAttachmentId,omitempty"`
+
+	// AssignIPv6 defines whether the vnic should have a IPv6 address
+	// +optional
+	AssignIpv6Ip bool `json:"assignIpv6Ip,omitempty"`
 
 	// AssignPublicIp defines whether the vnic should have a public IP address
 	// +optional
@@ -865,6 +873,13 @@ type Subnet struct {
 	// within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
 	// +optional
 	DnsLabel *string `json:"dnsLabel,omitempty"`
+
+	// Use this to enable IPv6 hextet for this subnet. The VCN must be enabled for IPv6.
+	// You can't change this subnet characteristic later. All subnets are /64 in size. The subnet
+	// portion of the IPv6 address is the fourth hextet from the left (1111 in the following example).
+	// Example: `2001:0db8:0123:1111::/64`
+	// +optional
+	Ipv6CidrBlockHextet *string `json:"ipv6CidrBlockHextet,omitempty"`
 }
 
 // NSG defines configuration for a Network Security Group.
@@ -935,6 +950,14 @@ type VCN struct {
 	// within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
 	// +optional
 	DnsLabel *string `json:"dnsLabel,omitempty"`
+
+	// Configuration to allow OCI to assign IPv6 Prefix.
+	// +optional
+	IsOracleGuaAllocationEnabled *bool `json:"isOracleGuaAllocationEnabled,omitempty"`
+
+	// Configuration to enable IPv6.
+	// +optional
+	IsIpv6Enabled *bool `json:"isIpv6Enabled,omitempty"`
 }
 
 // LoadBalancerType is an enumeration of the supported load balancer types.
@@ -1167,7 +1190,7 @@ type NetworkSecurityGroup struct {
 type VolumeType string
 
 const (
-	IscsiType VolumeType = "iscsi"
+	IscsiType           VolumeType = "iscsi"
 	ParavirtualizedType VolumeType = "paravirtualized"
 )
 
@@ -1186,7 +1209,7 @@ type LaunchVolumeAttachment struct {
 	Type VolumeType `json:"volumeType,omitempty"`
 
 	// The details of iscsi volume attachment.
-	IscsiAttachment LaunchIscsiVolumeAttachment `json:"launchIscsiVolumeAttachment,omitempty"`
+	IscsiAttachment           LaunchIscsiVolumeAttachment           `json:"launchIscsiVolumeAttachment,omitempty"`
 	ParavirtualizedAttachment LaunchParavirtualizedVolumeAttachment `json:"launchParavirtualizedVolumeAttachment,omitempty"`
 }
 
@@ -1253,7 +1276,6 @@ type LaunchParavirtualizedVolumeAttachment struct {
 	// The default value is False.
 	IsPvEncryptionInTransitEnabled *bool `json:"isPvEncryptionInTransitEnabled,omitempty"`
 }
-
 
 // LaunchCreateVolumeFromAttributes The details of the volume to create for CreateVolume operation.
 type LaunchCreateVolumeFromAttributes struct {

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -248,6 +248,7 @@ func (m *MachineScope) GetOrCreateMachine(ctx context.Context) (*core.Instance, 
 		SourceDetails: sourceDetails,
 		CreateVnicDetails: &core.CreateVnicDetails{
 			SubnetId:               subnetId,
+			AssignIpv6Ip:           common.Bool(m.OCIMachine.Spec.NetworkDetails.AssignIpv6Ip),
 			AssignPublicIp:         common.Bool(m.OCIMachine.Spec.NetworkDetails.AssignPublicIp),
 			FreeformTags:           tags,
 			DefinedTags:            definedTags,
@@ -1023,13 +1024,13 @@ func getIscsiVolumeAttachment(attachment infrastructurev1beta2.LaunchIscsiVolume
 
 func getParavirtualizedVolumeAttachment(attachment infrastructurev1beta2.LaunchParavirtualizedVolumeAttachment) core.LaunchAttachVolumeDetails {
 	volumeDetails := core.LaunchAttachParavirtualizedVolumeDetails{
-		Device:                       attachment.Device,
-		DisplayName:                  attachment.DisplayName,
-		IsShareable:                  attachment.IsShareable,
-		IsReadOnly:                   attachment.IsReadOnly,
-		VolumeId:                     attachment.VolumeId,
-		IsPvEncryptionInTransitEnabled:      attachment.IsPvEncryptionInTransitEnabled,
-		LaunchCreateVolumeDetails:    getLaunchCreateVolumeDetails(attachment.LaunchCreateVolumeFromAttributes),
+		Device:                         attachment.Device,
+		DisplayName:                    attachment.DisplayName,
+		IsShareable:                    attachment.IsShareable,
+		IsReadOnly:                     attachment.IsReadOnly,
+		VolumeId:                       attachment.VolumeId,
+		IsPvEncryptionInTransitEnabled: attachment.IsPvEncryptionInTransitEnabled,
+		LaunchCreateVolumeDetails:      getLaunchCreateVolumeDetails(attachment.LaunchCreateVolumeFromAttributes),
 	}
 	return volumeDetails
 }

--- a/cloud/scope/route_table_reconciler.go
+++ b/cloud/scope/route_table_reconciler.go
@@ -151,6 +151,18 @@ func (s *ClusterScope) CreateRouteTable(ctx context.Context, routeTableType stri
 				Description:     common.String("traffic to/from internet"),
 			},
 		}
+		resp, err := s.VCNClient.GetVcn(ctx, core.GetVcnRequest{VcnId: s.getVcnId()})
+		if err != nil {
+			panic(err)
+		}
+		if resp.Vcn.Ipv6CidrBlocks != nil {
+			routeRules = append(routeRules, core.RouteRule{
+				DestinationType: core.RouteRuleDestinationTypeCidrBlock,
+				Destination:     common.String("::/0"),
+				NetworkEntityId: s.OCIClusterAccessor.GetNetworkSpec().Vcn.InternetGateway.Id,
+				Description:     common.String("ipv6 traffic to/from internet"),
+			})
+		}
 		routeTableName = PublicRouteTableName
 	}
 	vcnId := s.getVcnId()

--- a/cloud/scope/subnet_reconciler.go
+++ b/cloud/scope/subnet_reconciler.go
@@ -123,7 +123,7 @@ func (s *ClusterScope) CreateSubnet(ctx context.Context, spec infrastructurev1be
 		hextets := strings.Split(ip.String(), ":")
 
 		// Modify the 4th hextet (index 3) of vcn CIDR to reflect the subnet CIDR with Ipv6CidrBlockHextet value in it
-		if len(hextets) == 8 {
+		if len(hextets) >= 4 {
 			originalHextet := hextets[3]
 			if len(originalHextet) < 4 {
 				originalHextet = fmt.Sprintf("%04s", originalHextet)

--- a/cloud/scope/vcn_reconciler.go
+++ b/cloud/scope/vcn_reconciler.go
@@ -131,8 +131,10 @@ func (s *ClusterScope) CreateVCN(ctx context.Context, spec infrastructurev1beta2
 		IsIpv6Enabled: spec.IsIpv6Enabled,
 	}
 
-	if *spec.IsIpv6Enabled {
-		vcnDetails.IsOracleGuaAllocationEnabled = common.Bool(true)
+	if spec.IsIpv6Enabled != nil {
+		if spec.IsIpv6Enabled == common.Bool(true) {
+			vcnDetails.IsOracleGuaAllocationEnabled = common.Bool(true)
+		}
 	}
 
 	vcnResponse, err := s.VCNClient.CreateVcn(ctx, core.CreateVcnRequest{

--- a/cloud/scope/vcn_reconciler.go
+++ b/cloud/scope/vcn_reconciler.go
@@ -130,9 +130,11 @@ func (s *ClusterScope) CreateVCN(ctx context.Context, spec infrastructurev1beta2
 		DnsLabel:      spec.DnsLabel,
 		IsIpv6Enabled: spec.IsIpv6Enabled,
 	}
-	if spec.IsIpv6Enabled != common.Bool(false) {
+
+	if *spec.IsIpv6Enabled {
 		vcnDetails.IsOracleGuaAllocationEnabled = common.Bool(true)
 	}
+
 	vcnResponse, err := s.VCNClient.CreateVcn(ctx, core.CreateVcnRequest{
 		CreateVcnDetails: vcnDetails,
 		OpcRetryToken:    ociutil.GetOPCRetryToken("%s-%s", "create-vcn", string(s.OCIClusterAccessor.GetOCIResourceIdentifier())),

--- a/cloud/scope/vcn_reconciler.go
+++ b/cloud/scope/vcn_reconciler.go
@@ -122,14 +122,16 @@ func (s *ClusterScope) UpdateVCN(ctx context.Context, vcn infrastructurev1beta2.
 
 func (s *ClusterScope) CreateVCN(ctx context.Context, spec infrastructurev1beta2.VCN) (*string, error) {
 	vcnDetails := core.CreateVcnDetails{
-		CompartmentId:                common.String(s.GetCompartmentId()),
-		DisplayName:                  common.String(s.GetVcnName()),
-		CidrBlocks:                   s.GetVcnCidrs(),
-		FreeformTags:                 s.GetFreeFormTags(),
-		DefinedTags:                  s.GetDefinedTags(),
-		DnsLabel:                     spec.DnsLabel,
-		IsOracleGuaAllocationEnabled: spec.IsOracleGuaAllocationEnabled,
-		IsIpv6Enabled:                spec.IsIpv6Enabled,
+		CompartmentId: common.String(s.GetCompartmentId()),
+		DisplayName:   common.String(s.GetVcnName()),
+		CidrBlocks:    s.GetVcnCidrs(),
+		FreeformTags:  s.GetFreeFormTags(),
+		DefinedTags:   s.GetDefinedTags(),
+		DnsLabel:      spec.DnsLabel,
+		IsIpv6Enabled: spec.IsIpv6Enabled,
+	}
+	if spec.IsIpv6Enabled != common.Bool(false) {
+		vcnDetails.IsOracleGuaAllocationEnabled = common.Bool(true)
 	}
 	vcnResponse, err := s.VCNClient.CreateVcn(ctx, core.CreateVcnRequest{
 		CreateVcnDetails: vcnDetails,

--- a/cloud/scope/vcn_reconciler.go
+++ b/cloud/scope/vcn_reconciler.go
@@ -122,12 +122,14 @@ func (s *ClusterScope) UpdateVCN(ctx context.Context, vcn infrastructurev1beta2.
 
 func (s *ClusterScope) CreateVCN(ctx context.Context, spec infrastructurev1beta2.VCN) (*string, error) {
 	vcnDetails := core.CreateVcnDetails{
-		CompartmentId: common.String(s.GetCompartmentId()),
-		DisplayName:   common.String(s.GetVcnName()),
-		CidrBlocks:    s.GetVcnCidrs(),
-		FreeformTags:  s.GetFreeFormTags(),
-		DefinedTags:   s.GetDefinedTags(),
-		DnsLabel:      spec.DnsLabel,
+		CompartmentId:                common.String(s.GetCompartmentId()),
+		DisplayName:                  common.String(s.GetVcnName()),
+		CidrBlocks:                   s.GetVcnCidrs(),
+		FreeformTags:                 s.GetFreeFormTags(),
+		DefinedTags:                  s.GetDefinedTags(),
+		DnsLabel:                     spec.DnsLabel,
+		IsOracleGuaAllocationEnabled: spec.IsOracleGuaAllocationEnabled,
+		IsIpv6Enabled:                spec.IsIpv6Enabled,
 	}
 	vcnResponse, err := s.VCNClient.CreateVcn(ctx, core.CreateVcnRequest{
 		CreateVcnDetails: vcnDetails,

--- a/cloud/scope/vcn_reconciler_test.go
+++ b/cloud/scope/vcn_reconciler_test.go
@@ -71,11 +71,10 @@ func TestClusterScope_CreateVCN(t *testing.T) {
 			spec: infrastructurev1beta2.OCIClusterSpec{
 				NetworkSpec: infrastructurev1beta2.NetworkSpec{
 					Vcn: infrastructurev1beta2.VCN{
-						Name:                         "normal",
-						DnsLabel:                     common.String("label"),
-						CIDR:                         "test-cidr",
-						IsIpv6Enabled:                common.Bool(true),
-						IsOracleGuaAllocationEnabled: common.Bool(true),
+						Name:          "normal",
+						DnsLabel:      common.String("label"),
+						CIDR:          "test-cidr",
+						IsIpv6Enabled: common.Bool(true),
 					},
 				},
 			},
@@ -87,11 +86,10 @@ func TestClusterScope_CreateVCN(t *testing.T) {
 			spec: infrastructurev1beta2.OCIClusterSpec{
 				NetworkSpec: infrastructurev1beta2.NetworkSpec{
 					Vcn: infrastructurev1beta2.VCN{
-						Name:                         "normal",
-						DnsLabel:                     common.String("label"),
-						CIDRS:                        []string{"test-cidr1", "test-cidr2"},
-						IsIpv6Enabled:                common.Bool(true),
-						IsOracleGuaAllocationEnabled: common.Bool(true),
+						Name:          "normal",
+						DnsLabel:      common.String("label"),
+						CIDRS:         []string{"test-cidr1", "test-cidr2"},
+						IsIpv6Enabled: common.Bool(true),
 					},
 				},
 			},

--- a/cloud/scope/vcn_reconciler_test.go
+++ b/cloud/scope/vcn_reconciler_test.go
@@ -71,9 +71,11 @@ func TestClusterScope_CreateVCN(t *testing.T) {
 			spec: infrastructurev1beta2.OCIClusterSpec{
 				NetworkSpec: infrastructurev1beta2.NetworkSpec{
 					Vcn: infrastructurev1beta2.VCN{
-						Name:     "normal",
-						DnsLabel: common.String("label"),
-						CIDR:     "test-cidr",
+						Name:                         "normal",
+						DnsLabel:                     common.String("label"),
+						CIDR:                         "test-cidr",
+						IsIpv6Enabled:                common.Bool(true),
+						IsOracleGuaAllocationEnabled: common.Bool(true),
 					},
 				},
 			},
@@ -85,9 +87,11 @@ func TestClusterScope_CreateVCN(t *testing.T) {
 			spec: infrastructurev1beta2.OCIClusterSpec{
 				NetworkSpec: infrastructurev1beta2.NetworkSpec{
 					Vcn: infrastructurev1beta2.VCN{
-						Name:     "normal",
-						DnsLabel: common.String("label"),
-						CIDRS:    []string{"test-cidr1", "test-cidr2"},
+						Name:                         "normal",
+						DnsLabel:                     common.String("label"),
+						CIDRS:                        []string{"test-cidr1", "test-cidr2"},
+						IsIpv6Enabled:                common.Bool(true),
+						IsOracleGuaAllocationEnabled: common.Bool(true),
 					},
 				},
 			},

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclusters.yaml
@@ -166,6 +166,12 @@ spec:
                   vcn:
                     description: VCN configuration.
                     properties:
+                      isIpv6Enabled:
+                        description: isIpv6Enabled enables the possibility to assign IPv6 to cluster nodes.
+                        type: boolean
+                      isOracleGuaAllocationEnabled:
+                        description: isOracleGuaAllocationEnabled enables OCI to assign a /56 prefix.
+                        type: boolean
                       cidr:
                         description: VCN CIDR. Deprecated, please use NetworkDetails.cidrs
                         type: string
@@ -590,6 +596,9 @@ spec:
                                 in conjunction with the VNIC's hostname and VCN's
                                 DNS label to form a fully qualified domain name (FQDN)
                                 for each VNIC within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
+                              type: string
+                            ipv6CidrBlockHextet:
+                              description: Subnet IPv6 CIDR.
                               type: string
                             id:
                               description: Subnet OCID.
@@ -1382,6 +1391,12 @@ spec:
                   vcn:
                     description: VCN configuration.
                     properties:
+                      isIpv6Enabled:
+                        description: isIpv6Enabled enables the possibility to assign IPv6 to cluster nodes.
+                        type: boolean
+                      isOracleGuaAllocationEnabled:
+                        description: isOracleGuaAllocationEnabled enables OCI to assign a /56 prefix.
+                        type: boolean
                       cidr:
                         description: VCN CIDR. Deprecated, please use NetworkDetails.cidrs
                         type: string
@@ -1865,6 +1880,9 @@ spec:
                                 in conjunction with the VNIC's hostname and VCN's
                                 DNS label to form a fully qualified domain name (FQDN)
                                 for each VNIC within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
+                              type: string
+                            ipv6CidrBlockHextet:
+                              description: Subnet IPv6 CIDR.
                               type: string
                             id:
                               description: Subnet OCID.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclusters.yaml
@@ -169,9 +169,6 @@ spec:
                       isIpv6Enabled:
                         description: isIpv6Enabled enables the possibility to assign IPv6 to cluster nodes.
                         type: boolean
-                      isOracleGuaAllocationEnabled:
-                        description: isOracleGuaAllocationEnabled enables OCI to assign a /56 prefix.
-                        type: boolean
                       cidr:
                         description: VCN CIDR. Deprecated, please use NetworkDetails.cidrs
                         type: string
@@ -1393,9 +1390,6 @@ spec:
                     properties:
                       isIpv6Enabled:
                         description: isIpv6Enabled enables the possibility to assign IPv6 to cluster nodes.
-                        type: boolean
-                      isOracleGuaAllocationEnabled:
-                        description: isOracleGuaAllocationEnabled enables OCI to assign a /56 prefix.
                         type: boolean
                       cidr:
                         description: VCN CIDR. Deprecated, please use NetworkDetails.cidrs

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimachines.yaml
@@ -413,6 +413,9 @@ spec:
                     description: AssignPrivateDnsRecord defines whether the VNIC should
                       be assigned a DNS record.
                     type: boolean
+                  assignIpv6Ip:
+                    description: assignIpv6Ip defines if the instance should have an IPv6
+                    type: boolean
                   assignPublicIp:
                     description: AssignPublicIp defines whether the instance should
                       have a public IP address
@@ -833,6 +836,10 @@ spec:
                   of VNICs scale proportionately with the number of OCPUs.
                 items:
                   properties:
+                    assignIpv6Ip:
+                      description: assignIpv6Ip defines whether the VNIC should
+                        be assigned a IPv6.
+                      type: boolean
                     assignPublicIp:
                       description: AssignPublicIp defines whether the vnic should
                         have a public IP address
@@ -1350,6 +1357,9 @@ spec:
                     description: AssignPrivateDnsRecord defines whether the VNIC should
                       be assigned a DNS record.
                     type: boolean
+                  assignIpv6Ip:
+                    description: assignIpv6Ip defines if the instance should have an IPv6
+                    type: boolean
                   assignPublicIp:
                     description: AssignPublicIp defines whether the instance should
                       have a public IP address
@@ -1764,6 +1774,10 @@ spec:
                   of VNICs scale proportionately with the number of OCPUs.
                 items:
                   properties:
+                    assignIpv6Ip:
+                      description: assignIpv6Ip defines whether the VNIC should
+                        be assigned a IPv6.
+                      type: boolean
                     assignPublicIp:
                       description: AssignPublicIp defines whether the vnic should
                         have a public IP address

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimachinetemplates.yaml
@@ -447,6 +447,10 @@ spec:
                             description: AssignPrivateDnsRecord defines whether the
                               VNIC should be assigned a DNS record.
                             type: boolean
+                          assignIpv6Ip:
+                            description: assignIpv6Ip defines whether the VNIC should
+                              be assigned a IPv6.
+                            type: boolean
                           assignPublicIp:
                             description: AssignPublicIp defines whether the instance
                               should have a public IP address
@@ -904,6 +908,10 @@ spec:
                           of OCPUs.
                         items:
                           properties:
+                            assignIpv6Ip:
+                              description: assignIpv6Ip defines whether the VNIC should
+                                be assigned a IPv6.
+                              type: boolean
                             assignPublicIp:
                               description: AssignPublicIp defines whether the vnic
                                 should have a public IP address
@@ -1374,6 +1382,10 @@ spec:
                             description: AssignPrivateDnsRecord defines whether the
                               VNIC should be assigned a DNS record.
                             type: boolean
+                          assignIpv6Ip:
+                            description: assignIpv6Ip defines whether the VNIC should
+                              be assigned a IPv6.
+                            type: boolean
                           assignPublicIp:
                             description: AssignPublicIp defines whether the instance
                               should have a public IP address
@@ -1825,6 +1837,10 @@ spec:
                           of OCPUs.
                         items:
                           properties:
+                            assignIpv6Ip:
+                              description: assignIpv6Ip defines whether the VNIC should
+                                be assigned a IPv6.
+                              type: boolean
                             assignPublicIp:
                               description: AssignPublicIp defines whether the vnic
                                 should have a public IP address

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -34,6 +34,7 @@
   - [Default Network Infrastructure](./networking/infrastructure.md)
     - [Using Calico](./networking/calico.md)
     - [Using Antrea](./networking/antrea.md)
+    - [Using IPv6](./networking/ipv6.md)
   - [Custom Networking](./networking/custom-networking.md)
   - [Private Cluster](./networking/private-cluster.md)
 - [Managed Clusters (OKE)](./managed/managedcluster.md)

--- a/docs/src/networking/ipv6.md
+++ b/docs/src/networking/ipv6.md
@@ -1,0 +1,78 @@
+# IPv6 GUA Allocated by Oracle Guide
+
+This section contains information about the IPv6 aspects of Cluster API Provider OCI.
+
+In order to have a VM created with IPv6 Ip assigned you should have the following defined:
+1. For OCICluster:
+    - ``` yaml 
+        networkSpec:
+            vcn:
+                isIpv6Enabled: true
+                subnets:
+                    - ipv6CidrBlockHextet: "01"
+      ```
+* example:
+```yaml
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: OCICluster
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
+  name: "${CLUSTER_NAME}"
+spec:
+  compartmentId: "${OCI_COMPARTMENT_ID}"
+  networkSpec:
+    vcn:
+      isIpv6Enabled: true
+      subnets:
+        - ipv6CidrBlockHextet: "01"
+          name: control-plane-endpoint
+          role: control-plane-endpoint
+          type: public
+        - ipv6CidrBlockHextet: "02"
+          name: control-plane
+          role: control-plane
+          type: private
+        - ipv6CidrBlockHextet: "03"
+          name: service-lb
+          role: service-lb
+          type: public
+        - ipv6CidrBlockHextet: "04"
+          name: worker
+          role: worker
+          type: private
+```
+
+2. For OCIMachineTemplate:
+    - ``` yaml 
+        networkDetails:
+            assignIpv6Ip: true
+      ```
+
+* example: 
+```yaml
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: OCIMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      imageId: "${OCI_IMAGE_ID}"
+      compartmentId: "${OCI_COMPARTMENT_ID}"
+      shape: "${OCI_NODE_MACHINE_TYPE=VM.Standard.E5.Flex}"
+      shapeConfig:
+        ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=1}"
+      metadata:
+        ssh_authorized_keys: "${OCI_SSH_KEY}"
+      isPvEncryptionInTransitEnabled: ${OCI_NODE_PV_TRANSIT_ENCRYPTION=true}
+      networkDetails:
+        assignIpv6Ip: true
+```
+
+
+**Note:**
+- **VCNs, subnets and VMs can be asigned with IPv6 just at creation step. After creation they can be updated with IPv6 just from UI console**
+- **You cannot create a VM with IPv6 in a subnet/vcn without IPv6 enabled capabilities.**

--- a/docs/src/networking/ipv6.md
+++ b/docs/src/networking/ipv6.md
@@ -1,4 +1,4 @@
-# IPv6 GUA Allocated by Oracle Guide
+# IPv6 Global Unicast Address (GUA) Allocated by Oracle Guide
 
 This section contains information about the IPv6 aspects of Cluster API Provider OCI.
 
@@ -72,7 +72,11 @@ spec:
         assignIpv6Ip: true
 ```
 
+- [IPv6 Example Template](../../../templates/cluster-template-with-ipv6.yaml)
+
 
 **Note:**
-- **VCNs, subnets and VMs can be asigned with IPv6 just at creation step. After creation they can be updated with IPv6 just from UI console**
+- **VCNs, subnets and VMs can be asigned with IPv6 just at creation step. After creation they can be updated with IPv6 just from UI console.**
 - **You cannot create a VM with IPv6 in a subnet/vcn without IPv6 enabled capabilities.**
+- **Once VCNs, subnets are enabled with IPv6 cannot unassign their IPv6 CIDRs.**
+- **CAPOCI don't support BYOIP IPv6 prefix at the moment.**

--- a/hack/ensure-kubectl.sh
+++ b/hack/ensure-kubectl.sh
@@ -27,7 +27,7 @@ verify_kubectl_version() {
   fi
 
   local kubectl_version
-  IFS=" " read -ra kubectl_version <<< "$(kubectl version --client --short)"
+  IFS=" " read -ra kubectl_version <<< "$(kubectl version --client | head -n 1)"
   if [[ "${MINIMUM_KUBECTL_VERSION}" != $(echo -e "${MINIMUM_KUBECTL_VERSION}\n${kubectl_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]]; then
     cat <<EOF
 Detected kubectl version: ${kubectl_version[2]}.

--- a/templates/cluster-template-with-ipv6.yaml
+++ b/templates/cluster-template-with-ipv6.yaml
@@ -36,7 +36,6 @@ spec:
   networkSpec:
     vcn:
       isIpv6Enabled: true
-      isOracleGuaAllocationEnabled: true
       subnets:
         - ipv6CidrBlockHextet: "01"
           name: control-plane-endpoint

--- a/templates/cluster-template-with-ipv6.yaml
+++ b/templates/cluster-template-with-ipv6.yaml
@@ -33,6 +33,28 @@ metadata:
   name: "${CLUSTER_NAME}"
 spec:
   compartmentId: "${OCI_COMPARTMENT_ID}"
+  networkSpec:
+    vcn:
+      isIpv6Enabled: true
+      isOracleGuaAllocationEnabled: true
+      subnets:
+        - ipv6CidrBlockHextet: "01"
+          name: control-plane-endpoint
+          role: control-plane-endpoint
+          type: public
+        - ipv6CidrBlockHextet: "02"
+          name: control-plane
+          role: control-plane
+          type: private
+        - ipv6CidrBlockHextet: "03"
+          name: service-lb
+          role: service-lb
+          type: public
+        - ipv6CidrBlockHextet: "04"
+          name: worker
+          role: worker
+          type: private
+      
 ---
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -86,6 +108,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_CONTROL_PLANE_PV_TRANSIT_ENCRYPTION=true}
+      networkDetails:
+        assignIpv6Ip: true
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
@@ -102,6 +126,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_NODE_PV_TRANSIT_ENCRYPTION=true}
+      networkDetails:
+        assignIpv6Ip: true
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/templates/cluster-template-with-paravirt-bv.yaml
+++ b/templates/cluster-template-with-paravirt-bv.yaml
@@ -102,6 +102,16 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_NODE_PV_TRANSIT_ENCRYPTION=true}
+      launchVolumeAttachments:
+        - volumeType: "paravirtualized"
+          launchParavirtualizedVolumeAttachment:
+            isReadOnly: true
+            isShareable: true
+            isPvEncryptionInTransitEnabled: true
+            launchCreateVolumeFromAttributes:
+              displayName: "paravirt-volume"
+              sizeInGBs: 75
+              vpusPerGB: 20
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/cluster_test.go
+++ b/test/e2e/cluster_test.go
@@ -200,7 +200,7 @@ var _ = Describe("Workload cluster creation", func() {
 		validateOLImage(namespace.Name, clusterName)
 	})
 
-	It("Oracle Linux with IPv6 - With 1 control-plane nodes and 1 worker nodes [PRBlocking]", func() {
+	It("Machine with IPv6 - With 1 control-plane nodes and 1 worker nodes [PRBlocking]", func() {
 		clusterName = getClusterName(clusterNamePrefix, "machine-with-ipv6")
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: bootstrapClusterProxy,
@@ -220,10 +220,9 @@ var _ = Describe("Workload cluster creation", func() {
 			WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
 			WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
 		}, result)
-		validateOLImage(namespace.Name, clusterName)
 	})
 
-	It("Oracle Linux with paravirtualized - With 1 control-plane nodes and 1 worker nodes [PRBlocking]", func() {
+	It("Machine with pravirtualized - With 1 control-plane nodes and 1 worker nodes [PRBlocking]", func() {
 		clusterName = getClusterName(clusterNamePrefix, "with-paravirt-bv")
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: bootstrapClusterProxy,
@@ -243,7 +242,6 @@ var _ = Describe("Workload cluster creation", func() {
 			WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
 			WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
 		}, result)
-		validateOLImage(namespace.Name, clusterName)
 	})
 
 	It("Windows - With 1 Linux control-plane nodes and with 1 Windows worker nodes using Calico CNI", func() {

--- a/test/e2e/cluster_test.go
+++ b/test/e2e/cluster_test.go
@@ -200,7 +200,7 @@ var _ = Describe("Workload cluster creation", func() {
 		validateOLImage(namespace.Name, clusterName)
 	})
 
-	It("Machine with IPv6 - With 1 control-plane nodes and 1 worker nodes [PRBlocking]", func() {
+	It("Oracle Linux with IPv6 - With 1 control-plane nodes and 1 worker nodes [PRBlocking]", func() {
 		clusterName = getClusterName(clusterNamePrefix, "machine-with-ipv6")
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: bootstrapClusterProxy,
@@ -220,10 +220,10 @@ var _ = Describe("Workload cluster creation", func() {
 			WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
 			WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
 		}, result)
-		validateWindowsImage(namespace.Name, clusterName)
+		validateOLImage(namespace.Name, clusterName)
 	})
 
-	It("Machine with pravirtualized - With 1 control-plane nodes and 1 worker nodes [PRBlocking]", func() {
+	It("Oracle Linux with paravirtualized - With 1 control-plane nodes and 1 worker nodes [PRBlocking]", func() {
 		clusterName = getClusterName(clusterNamePrefix, "with-paravirt-bv")
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: bootstrapClusterProxy,
@@ -243,7 +243,7 @@ var _ = Describe("Workload cluster creation", func() {
 			WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
 			WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
 		}, result)
-		validateWindowsImage(namespace.Name, clusterName)
+		validateOLImage(namespace.Name, clusterName)
 	})
 
 	It("Windows - With 1 Linux control-plane nodes and with 1 Windows worker nodes using Calico CNI", func() {

--- a/test/e2e/cluster_test.go
+++ b/test/e2e/cluster_test.go
@@ -200,6 +200,52 @@ var _ = Describe("Workload cluster creation", func() {
 		validateOLImage(namespace.Name, clusterName)
 	})
 
+	It("Machine with IPv6 - With 1 control-plane nodes and 1 worker nodes [PRBlocking]", func() {
+		clusterName = getClusterName(clusterNamePrefix, "machine-with-ipv6")
+		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+			ClusterProxy: bootstrapClusterProxy,
+			ConfigCluster: clusterctl.ConfigClusterInput{
+				LogFolder:                filepath.Join(artifactFolder, "clusters", bootstrapClusterProxy.GetName()),
+				ClusterctlConfigPath:     clusterctlConfigPath,
+				KubeconfigPath:           bootstrapClusterProxy.GetKubeconfigPath(),
+				InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+				Flavor:                   "machine-with-ipv6",
+				Namespace:                namespace.Name,
+				ClusterName:              clusterName,
+				KubernetesVersion:        e2eConfig.GetVariable(capi_e2e.KubernetesVersion),
+				ControlPlaneMachineCount: pointer.Int64Ptr(1),
+				WorkerMachineCount:       pointer.Int64Ptr(1),
+			},
+			WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
+			WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
+			WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
+		}, result)
+		validateWindowsImage(namespace.Name, clusterName)
+	})
+
+	It("Machine with pravirtualized - With 1 control-plane nodes and 1 worker nodes [PRBlocking]", func() {
+		clusterName = getClusterName(clusterNamePrefix, "with-paravirt-bv")
+		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+			ClusterProxy: bootstrapClusterProxy,
+			ConfigCluster: clusterctl.ConfigClusterInput{
+				LogFolder:                filepath.Join(artifactFolder, "clusters", bootstrapClusterProxy.GetName()),
+				ClusterctlConfigPath:     clusterctlConfigPath,
+				KubeconfigPath:           bootstrapClusterProxy.GetKubeconfigPath(),
+				InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+				Flavor:                   "with-paravirt-bv",
+				Namespace:                namespace.Name,
+				ClusterName:              clusterName,
+				KubernetesVersion:        e2eConfig.GetVariable(capi_e2e.KubernetesVersion),
+				ControlPlaneMachineCount: pointer.Int64Ptr(1),
+				WorkerMachineCount:       pointer.Int64Ptr(1),
+			},
+			WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
+			WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
+			WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
+		}, result)
+		validateWindowsImage(namespace.Name, clusterName)
+	})
+
 	It("Windows - With 1 Linux control-plane nodes and with 1 Windows worker nodes using Calico CNI", func() {
 		clusterName = getClusterName(clusterNamePrefix, "windows-calico")
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -77,6 +77,8 @@ providers:
           - sourcePath: "../data/infrastructure-oci/v1beta2/cluster-template-managed-cluster-identity.yaml"
           - sourcePath: "../data/infrastructure-oci/v1beta2/cluster-template-cluster-identity.yaml"
           - sourcePath: "../data/infrastructure-oci/v1beta2/cluster-template-windows-calico.yaml"
+          - sourcePath: "../data/infrastructure-oci/v1beta2/cluster-template-machine-with-ipv6.yaml"
+          - sourcePath: "../data/infrastructure-oci/v1beta2/cluster-template-with-paravirt-bv.yaml"
           - sourcePath: "../data/infrastructure-oci/v1beta2/metadata.yaml"
 
 variables:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-machine-with-ipv6/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-machine-with-ipv6/cluster.yaml
@@ -10,7 +10,6 @@ spec:
   networkSpec:
     vcn:
       isIpv6Enabled: true
-      isOracleGuaAllocationEnabled: true
       subnets:
         - ipv6CidrBlockHextet: "01"
           name: control-plane-endpoint

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-machine-with-ipv6/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-machine-with-ipv6/cluster.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: OCICluster
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
+  name: "${CLUSTER_NAME}"
+spec:
+  compartmentId: "${OCI_COMPARTMENT_ID}"
+  networkSpec:
+    vcn:
+      isIpv6Enabled: true
+      isOracleGuaAllocationEnabled: true
+      subnets:
+        - ipv6CidrBlockHextet: "01"
+          name: control-plane-endpoint
+          role: control-plane-endpoint
+          type: public
+        - ipv6CidrBlockHextet: "02"
+          name: control-plane
+          role: control-plane
+          type: private
+        - ipv6CidrBlockHextet: "03"
+          name: service-lb
+          role: service-lb
+          type: public
+        - ipv6CidrBlockHextet: "04"
+          name: worker
+          role: worker
+          type: private
+---
+kind: OCIMachineTemplate
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  template:
+    spec:
+      networkDetails:
+        assignIpv6Ip: true

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-machine-with-ipv6/kustomization.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-machine-with-ipv6/kustomization.yaml
@@ -1,0 +1,8 @@
+bases:
+ - ../bases/cluster.yaml
+ - ../bases/md.yaml
+ - ../../bases/crs.yaml
+ - ../../bases/ccm.yaml
+patchesStrategicMerge:
+  - ./cluster.yaml
+  - ./md.yaml

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-machine-with-ipv6/md.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-machine-with-ipv6/md.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: OCIMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      networkDetails:
+        assignIpv6Ip: true

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-with-paravirt-bv/kustomization.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-with-paravirt-bv/kustomization.yaml
@@ -1,0 +1,7 @@
+bases:
+ - ../bases/cluster.yaml
+ - ../bases/md.yaml
+ - ../../bases/crs.yaml
+ - ../../bases/ccm.yaml
+patchesStrategicMerge:
+  - ./md.yaml

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-with-paravirt-bv/md.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-with-paravirt-bv/md.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: OCIMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      launchVolumeAttachments:
+        - volumeType: "paravirtualized"
+          launchParavirtualizedVolumeAttachment:
+            isReadOnly: true
+            isShareable: true
+            isPvEncryptionInTransitEnabled: true
+            launchCreateVolumeFromAttributes:
+              displayName: "paravirt-volume"
+              sizeInGBs: 75
+              vpusPerGB: 20


### PR DESCRIPTION
What this PR does / why we need it:
This PR adds support for IPv6 at instance creation.
Adds support for IPv6 for VCN and subnets.
Adds paravirtualized block volumes templates.

Which issue(s) this PR fixes:
Fixes #400 
