### PR TITLE
Update policy for instance-family

### DIFF
--- a/docs/src/gs/install-csi.md
+++ b/docs/src/gs/install-csi.md
@@ -13,7 +13,7 @@ Oracle recommends using [Instance principals][instance-principals] to be used by
 following policies in the dynamic group for CSI to be able to talk to various OCI Services.
 
 ```
-allow dynamic-group [your dynamic group name] to read instance-family in compartment [your compartment name]
+allow dynamic-group [your dynamic group name] to use instance-family in compartment [your compartment name]
 allow dynamic-group [your dynamic group name] to use virtual-network-family in compartment [your compartment name]
 allow dynamic-group [your dynamic group name] to manage volume-family in compartment [your compartment name]
 ```


### PR DESCRIPTION
<!-- please add a type to the title of this PR (see https://www.conventionalcommits.org/en/v1.0.0/#summary), and delete this line and similar ones -->
<!-- the type will be either fix:, feat:, docs:, test: see https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional for a more exhaustive list -->

**What this PR does / why we need it**:
Previous version mentioned the policy is 'to read instance-family', This lets you list but not attach volumes. The 'use instance-family' is needed, according to: https://docs.oracle.com/en-us/iaas/Content/Identity/Concepts/commonpolicies.htm#volume-admins-manage-volumes-and-backups

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
