### PR TITLE
added oidc config for v1beta2

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimanagedcontrolplanes.yaml
@@ -350,6 +350,87 @@ spec:
                           not to enable the Pod Security Policy admission controller.
                         type: boolean
                     type: object
+                  openIdConnectDiscovery:
+                    description: OpenIDConnectDiscovery specifies OIDC discovery settings
+                    properties:
+                      isOpenIdConnectDiscoveryEnabled:
+                        description: IsOpenIDConnectDiscoveryEnabled defines whether
+                          or not to enable the OIDC discovery.
+                        type: boolean
+                    type: object
+                  openIdConnectTokenAuthenticationConfig:
+                    description: OpenIDConnectTokenAuthenticationConfig
+                    properties:
+                      caCertificate:
+                        description: A Base64 encoded public RSA or ECDSA certificates
+                          used to sign your identity provider's web certificate.
+                        type: string
+                      clientId:
+                        description: A client id that all tokens must be issued for.
+                        type: string
+                      groupsClaim:
+                        description: JWT claim to use as the user's group. If the
+                          claim is present it must be an array of strings.
+                        type: string
+                      groupsPrefix:
+                        description: Prefix prepended to group claims to prevent clashes
+                          with existing names (such as system:groups).
+                        type: string
+                      isOpenIdConnectAuthEnabled:
+                        description: IsOpenIdConnectAuthEnabled defines whether or
+                          not to enable the OIDC authentication.
+                        type: boolean
+                      issuerUrl:
+                        description: URL of the provider that allows the API server
+                          to discover public signing keys. Only URLs that use the
+                          https:// scheme are accepted. This is typically the provider's
+                          discovery URL, changed to have an empty path.
+                        type: string
+                      requiredClaims:
+                        description: A key=value pair that describes a required claim
+                          in the ID Token. If set, the claim is verified to be present
+                          in the ID Token with a matching value. Repeat this flag
+                          to specify multiple claims.
+                        items:
+                          description: KeyValue The properties that define a key value
+                            pair.
+                          properties:
+                            key:
+                              description: The key of the pair.
+                              type: string
+                            value:
+                              description: The value of the pair.
+                              type: string
+                          required:
+                          - key
+                          - value
+                          type: object
+                        type: array
+                      signingAlgorithms:
+                        description: The signing algorithms accepted. Default is ["RS256"].
+                        items:
+                          type: string
+                        type: array
+                      usernameClaim:
+                        description: JWT claim to use as the user name. By default
+                          sub, which is expected to be a unique identifier of the
+                          end user. Admins can choose other claims, such as email
+                          or name, depending on their provider. However, claims other
+                          than email will be prefixed with the issuer URL to prevent
+                          naming clashes with other plugins.
+                        type: string
+                      usernamePrefix:
+                        description: 'Prefix prepended to username claims to prevent
+                          clashes with existing names (such as system:users). For
+                          example, the value oidc: will create usernames like oidc:jane.doe.
+                          If this flag isn''t provided and --oidc-username-claim is
+                          a value other than email the prefix defaults to ( Issuer
+                          URL )# where ( Issuer URL ) is the value of --oidc-issuer-url.
+                          The value - can be used to disable all prefixing.'
+                        type: string
+                    required:
+                    - isOpenIdConnectAuthEnabled
+                    type: object
                 type: object
               clusterPodNetworkOptions:
                 description: ClusterPodNetworkOptions defines the available CNIs and

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimanagedcontrolplanetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimanagedcontrolplanetemplates.yaml
@@ -331,6 +331,94 @@ spec:
                                   controller.
                                 type: boolean
                             type: object
+                          openIdConnectDiscovery:
+                            description: OpenIDConnectDiscovery specifies OIDC discovery
+                              settings
+                            properties:
+                              isOpenIdConnectDiscoveryEnabled:
+                                description: IsOpenIDConnectDiscoveryEnabled defines
+                                  whether or not to enable the OIDC discovery.
+                                type: boolean
+                            type: object
+                          openIdConnectTokenAuthenticationConfig:
+                            description: OpenIDConnectTokenAuthenticationConfig
+                            properties:
+                              caCertificate:
+                                description: A Base64 encoded public RSA or ECDSA
+                                  certificates used to sign your identity provider's
+                                  web certificate.
+                                type: string
+                              clientId:
+                                description: A client id that all tokens must be issued
+                                  for.
+                                type: string
+                              groupsClaim:
+                                description: JWT claim to use as the user's group.
+                                  If the claim is present it must be an array of strings.
+                                type: string
+                              groupsPrefix:
+                                description: Prefix prepended to group claims to prevent
+                                  clashes with existing names (such as system:groups).
+                                type: string
+                              isOpenIdConnectAuthEnabled:
+                                description: IsOpenIdConnectAuthEnabled defines whether
+                                  or not to enable the OIDC authentication.
+                                type: boolean
+                              issuerUrl:
+                                description: URL of the provider that allows the API
+                                  server to discover public signing keys. Only URLs
+                                  that use the https:// scheme are accepted. This
+                                  is typically the provider's discovery URL, changed
+                                  to have an empty path.
+                                type: string
+                              requiredClaims:
+                                description: A key=value pair that describes a required
+                                  claim in the ID Token. If set, the claim is verified
+                                  to be present in the ID Token with a matching value.
+                                  Repeat this flag to specify multiple claims.
+                                items:
+                                  description: KeyValue The properties that define
+                                    a key value pair.
+                                  properties:
+                                    key:
+                                      description: The key of the pair.
+                                      type: string
+                                    value:
+                                      description: The value of the pair.
+                                      type: string
+                                  required:
+                                  - key
+                                  - value
+                                  type: object
+                                type: array
+                              signingAlgorithms:
+                                description: The signing algorithms accepted. Default
+                                  is ["RS256"].
+                                items:
+                                  type: string
+                                type: array
+                              usernameClaim:
+                                description: JWT claim to use as the user name. By
+                                  default sub, which is expected to be a unique identifier
+                                  of the end user. Admins can choose other claims,
+                                  such as email or name, depending on their provider.
+                                  However, claims other than email will be prefixed
+                                  with the issuer URL to prevent naming clashes with
+                                  other plugins.
+                                type: string
+                              usernamePrefix:
+                                description: 'Prefix prepended to username claims
+                                  to prevent clashes with existing names (such as
+                                  system:users). For example, the value oidc: will
+                                  create usernames like oidc:jane.doe. If this flag
+                                  isn''t provided and --oidc-username-claim is a value
+                                  other than email the prefix defaults to ( Issuer
+                                  URL )# where ( Issuer URL ) is the value of --oidc-issuer-url.
+                                  The value - can be used to disable all prefixing.'
+                                type: string
+                            required:
+                            - isOpenIdConnectAuthEnabled
+                            type: object
                         type: object
                       clusterPodNetworkOptions:
                         description: ClusterPodNetworkOptions defines the available


### PR DESCRIPTION
What this PR does / why we need it:
Updates CRDs for oci managed control plane to make OIDC configuration available for v1beta2

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes https://github.com/oracle/cluster-api-provider-oci/issues/425