### PR TITLE
NetworkCompartmentId implementation + fixes for OCIManagedMachinePool

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -1043,6 +1043,10 @@ type NetworkSpec struct {
 	// VCNPeering configuration.
 	// +optional
 	VCNPeering *VCNPeering `json:"vcnPeering,omitempty"`
+
+	// CompartmentId where to provision network resources
+	// +optional
+	CompartmentId string `json:"compartmentId,omitempty"`
 }
 
 // VCNPeering defines the VCN peering details of the workload cluster VCN.

--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -1995,6 +1995,7 @@ func autoConvert_v1beta1_NetworkSpec_To_v1beta2_NetworkSpec(in *NetworkSpec, out
 		return err
 	}
 	out.VCNPeering = (*v1beta2.VCNPeering)(unsafe.Pointer(in.VCNPeering))
+	out.CompartmentId = in.CompartmentId
 	return nil
 }
 
@@ -2012,6 +2013,7 @@ func autoConvert_v1beta2_NetworkSpec_To_v1beta1_NetworkSpec(in *v1beta2.NetworkS
 		return err
 	}
 	out.VCNPeering = (*VCNPeering)(unsafe.Pointer(in.VCNPeering))
+	out.CompartmentId = in.CompartmentId
 	return nil
 }
 

--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -1053,6 +1053,10 @@ type NetworkSpec struct {
 	// VCNPeering configuration.
 	// +optional
 	VCNPeering *VCNPeering `json:"vcnPeering,omitempty"`
+
+	// CompartmentId where to provision network resources
+	// +optional
+	CompartmentId string `json:"compartmentId,omitempty"`
 }
 
 // VCNPeering defines the VCN peering details of the workload cluster VCN.

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -250,6 +250,14 @@ func (s *ClusterScope) GetCompartmentId() string {
 	return s.OCIClusterAccessor.GetCompartmentId()
 }
 
+// GetCompartmentId returns the CompartmentId defined in OCICluster's spec
+func (s *ClusterScope) GetNetworkCompartmentId() string {
+	if s.OCIClusterAccessor.GetNetworkCompartmentId() == "" {
+		return s.GetCompartmentId()
+	}
+	return s.OCIClusterAccessor.GetNetworkCompartmentId()
+}
+
 // APIServerPort returns the APIServerPort to use when creating the load balancer.
 func (s *ClusterScope) APIServerPort() int32 {
 	if s.Cluster.Spec.ClusterNetwork != nil && s.Cluster.Spec.ClusterNetwork.APIServerPort != nil {

--- a/cloud/scope/cluster_accessor.go
+++ b/cloud/scope/cluster_accessor.go
@@ -34,6 +34,8 @@ type OCIClusterAccessor interface {
 	GetDefinedTags() map[string]map[string]string
 	// GetCompartmentId returns the compartment id of the cluster.
 	GetCompartmentId() string
+	// GetNetworkCompartmentId returns the compartment id where network resources are created
+	GetNetworkCompartmentId() string
 	// GetFreeformTags returns the free form tags of the cluster.
 	GetFreeformTags() map[string]string
 	// GetName returns the name of the cluster.

--- a/cloud/scope/drg_reconciler.go
+++ b/cloud/scope/drg_reconciler.go
@@ -85,7 +85,7 @@ func (s *ClusterScope) GetDRG(ctx context.Context) (*core.Drg, error) {
 
 	for {
 		response, err := s.VCNClient.ListDrgs(ctx, core.ListDrgsRequest{
-			CompartmentId: common.String(s.GetCompartmentId()),
+			CompartmentId: common.String(s.GetNetworkCompartmentId()),
 			Page:          page,
 		})
 		if err != nil {
@@ -113,7 +113,7 @@ func (s *ClusterScope) GetDRG(ctx context.Context) (*core.Drg, error) {
 func (s *ClusterScope) createDRG(ctx context.Context) (*core.Drg, error) {
 	response, err := s.VCNClient.CreateDrg(ctx, core.CreateDrgRequest{
 		CreateDrgDetails: core.CreateDrgDetails{
-			CompartmentId: common.String(s.GetCompartmentId()),
+			CompartmentId: common.String(s.GetNetworkCompartmentId()),
 			FreeformTags:  s.GetFreeFormTags(),
 			DefinedTags:   s.GetDefinedTags(),
 			DisplayName:   common.String(s.GetDRGName()),

--- a/cloud/scope/drg_rpc_attachment_reconciler.go
+++ b/cloud/scope/drg_rpc_attachment_reconciler.go
@@ -148,7 +148,7 @@ func (s *ClusterScope) createRPC(ctx context.Context, drgId *string, displayName
 			DrgId:         drgId,
 			FreeformTags:  s.GetFreeFormTags(),
 			DefinedTags:   s.GetDefinedTags(),
-			CompartmentId: common.String(s.GetCompartmentId()),
+			CompartmentId: common.String(s.GetNetworkCompartmentId()),
 		},
 	})
 	if err != nil {
@@ -176,7 +176,7 @@ func (s *ClusterScope) lookupRPC(ctx context.Context, drgId *string, rpcId *stri
 			var page *string
 			response, err := vcnClient.ListRemotePeeringConnections(ctx, core.ListRemotePeeringConnectionsRequest{
 				DrgId:         drgId,
-				CompartmentId: common.String(s.GetCompartmentId()),
+				CompartmentId: common.String(s.GetNetworkCompartmentId()),
 				Page:          page,
 			})
 			if err != nil {

--- a/cloud/scope/drg_vcn_attachment_reconciler.go
+++ b/cloud/scope/drg_vcn_attachment_reconciler.go
@@ -84,7 +84,7 @@ func (s *ClusterScope) GetDRGAttachment(ctx context.Context) (*core.DrgAttachmen
 		DisplayName:    common.String(s.OCIClusterAccessor.GetName()),
 		DrgId:          s.getDrgID(),
 		NetworkId:      s.OCIClusterAccessor.GetNetworkSpec().Vcn.ID,
-		CompartmentId:  common.String(s.GetCompartmentId()),
+		CompartmentId:  common.String(s.GetNetworkCompartmentId()),
 	})
 
 	if err != nil {

--- a/cloud/scope/internet_gateway_reconciler.go
+++ b/cloud/scope/internet_gateway_reconciler.go
@@ -76,7 +76,7 @@ func (s *ClusterScope) GetInternetGateway(ctx context.Context) (*core.InternetGa
 		}
 	}
 	igws, err := s.VCNClient.ListInternetGateways(ctx, core.ListInternetGatewaysRequest{
-		CompartmentId: common.String(s.GetCompartmentId()),
+		CompartmentId: common.String(s.GetNetworkCompartmentId()),
 		VcnId:         s.getVcnId(),
 		DisplayName:   common.String(InternetGatewayName),
 	})
@@ -95,7 +95,7 @@ func (s *ClusterScope) GetInternetGateway(ctx context.Context) (*core.InternetGa
 // CreateInternetGateway creates the Internet Gateway for the cluster based on the ClusterScope
 func (s *ClusterScope) CreateInternetGateway(ctx context.Context) (*string, error) {
 	igwDetails := core.CreateInternetGatewayDetails{
-		CompartmentId: common.String(s.GetCompartmentId()),
+		CompartmentId: common.String(s.GetNetworkCompartmentId()),
 		DisplayName:   common.String(InternetGatewayName),
 		IsEnabled:     common.Bool(true),
 		VcnId:         s.getVcnId(),

--- a/cloud/scope/load_balancer_reconciler.go
+++ b/cloud/scope/load_balancer_reconciler.go
@@ -171,7 +171,7 @@ func (s *ClusterScope) CreateLB(ctx context.Context, lb infrastructurev1beta2.Lo
 	}
 
 	lbDetails := loadbalancer.CreateLoadBalancerDetails{
-		CompartmentId: common.String(s.GetCompartmentId()),
+		CompartmentId: common.String(s.GetNetworkCompartmentId()),
 		DisplayName:   common.String(lb.Name),
 		ShapeName:     common.String("flexible"),
 		ShapeDetails: &loadbalancer.ShapeDetails{MinimumBandwidthInMbps: common.Int(10),
@@ -279,7 +279,7 @@ func (s *ClusterScope) GetLoadBalancers(ctx context.Context) (*loadbalancer.Load
 	var page *string
 	for {
 		lbs, err := s.LoadBalancerClient.ListLoadBalancers(ctx, loadbalancer.ListLoadBalancersRequest{
-			CompartmentId: common.String(s.GetCompartmentId()),
+			CompartmentId: common.String(s.GetNetworkCompartmentId()),
 			DisplayName:   common.String(s.GetControlPlaneLoadBalancerName()),
 			Page:          page,
 		})

--- a/cloud/scope/managed_machine_pool_test.go
+++ b/cloud/scope/managed_machine_pool_test.go
@@ -189,7 +189,7 @@ func TestManagedMachinePoolCreate(t *testing.T) {
 						ImageId:             common.String("test-image-id"),
 						BootVolumeSizeInGBs: common.Int64(75),
 					},
-					SshPublicKey: "test-ssh-public-key",
+					SshPublicKey: common.String("test-ssh-public-key"),
 					NodePoolNodeConfig: &infrav2exp.NodePoolNodeConfig{
 						PlacementConfigs: []infrav2exp.PlacementConfig{
 							{
@@ -314,7 +314,7 @@ func TestManagedMachinePoolCreate(t *testing.T) {
 					NodeSourceViaImage: &infrav2exp.NodeSourceViaImage{
 						BootVolumeSizeInGBs: common.Int64(75),
 					},
-					SshPublicKey: "test-ssh-public-key",
+					SshPublicKey: common.String("test-ssh-public-key"),
 					NodePoolNodeConfig: &infrav2exp.NodePoolNodeConfig{
 						PlacementConfigs: []infrav2exp.PlacementConfig{
 							{
@@ -461,7 +461,7 @@ func TestManagedMachinePoolCreate(t *testing.T) {
 					NodeSourceViaImage: &infrav2exp.NodeSourceViaImage{
 						BootVolumeSizeInGBs: common.Int64(75),
 					},
-					SshPublicKey: "test-ssh-public-key",
+					SshPublicKey: common.String("test-ssh-public-key"),
 					NodePoolNodeConfig: &infrav2exp.NodePoolNodeConfig{
 						PlacementConfigs: []infrav2exp.PlacementConfig{
 							{
@@ -610,7 +610,7 @@ func TestManagedMachinePoolCreate(t *testing.T) {
 					NodeSourceViaImage: &infrav2exp.NodeSourceViaImage{
 						BootVolumeSizeInGBs: common.Int64(75),
 					},
-					SshPublicKey: "test-ssh-public-key",
+					SshPublicKey: common.String("test-ssh-public-key"),
 					NodePoolNodeConfig: &infrav2exp.NodePoolNodeConfig{
 						PlacementConfigs: []infrav2exp.PlacementConfig{
 							{
@@ -681,7 +681,7 @@ func TestManagedMachinePoolCreate(t *testing.T) {
 					NodeSourceViaImage: &infrav2exp.NodeSourceViaImage{
 						ImageId: common.String("test-image-id"),
 					},
-					SshPublicKey: "test-ssh-public-key",
+					SshPublicKey: common.String("test-ssh-public-key"),
 					NodePoolNodeConfig: &infrav2exp.NodePoolNodeConfig{
 						NsgNames:                       []string{"worker-nsg"},
 						KmsKeyId:                       common.String("kms-key-id"),
@@ -794,7 +794,7 @@ func TestManagedMachinePoolCreate(t *testing.T) {
 			testSpecificSetup: func(cs *ManagedMachinePoolScope, okeClient *mock_containerengine.MockClient) {
 				ms.OCIManagedCluster.Spec.OCIResourceIdentifier = "resource_uid"
 				ms.OCIManagedMachinePool.Spec = infrav2exp.OCIManagedMachinePoolSpec{
-					SshPublicKey: "test-ssh-public-key",
+					SshPublicKey: common.String("test-ssh-public-key"),
 					NodePoolNodeConfig: &infrav2exp.NodePoolNodeConfig{
 						PlacementConfigs: []infrav2exp.PlacementConfig{
 							{
@@ -984,7 +984,7 @@ func TestManagedMachinePoolUpdate(t *testing.T) {
 					NodeSourceViaImage: &infrav2exp.NodeSourceViaImage{
 						ImageId: common.String("test-image-id"),
 					},
-					SshPublicKey: "test-ssh-public-key",
+					SshPublicKey: common.String("test-ssh-public-key"),
 					NodePoolNodeConfig: &infrav2exp.NodePoolNodeConfig{
 						PlacementConfigs: []infrav2exp.PlacementConfig{
 							{
@@ -1082,7 +1082,7 @@ func TestManagedMachinePoolUpdate(t *testing.T) {
 					NodeSourceViaImage: &infrav2exp.NodeSourceViaImage{
 						ImageId: common.String("test-image-id"),
 					},
-					SshPublicKey: "test-ssh-public-key",
+					SshPublicKey: common.String("test-ssh-public-key"),
 					NodePoolNodeConfig: &infrav2exp.NodePoolNodeConfig{
 						PlacementConfigs: []infrav2exp.PlacementConfig{
 							{
@@ -1223,7 +1223,7 @@ func TestManagedMachinePoolUpdate(t *testing.T) {
 					NodeSourceViaImage: &infrav2exp.NodeSourceViaImage{
 						ImageId: common.String("test-image-id"),
 					},
-					SshPublicKey: "test-ssh-public-key",
+					SshPublicKey: common.String("test-ssh-public-key"),
 					NodePoolNodeConfig: &infrav2exp.NodePoolNodeConfig{
 						PlacementConfigs: []infrav2exp.PlacementConfig{
 							{
@@ -1321,7 +1321,7 @@ func TestManagedMachinePoolUpdate(t *testing.T) {
 					NodeSourceViaImage: &infrav2exp.NodeSourceViaImage{
 						ImageId: common.String("test-image-id"),
 					},
-					SshPublicKey: "test-ssh-public-key",
+					SshPublicKey: common.String("test-ssh-public-key"),
 					NodePoolNodeConfig: &infrav2exp.NodePoolNodeConfig{
 						PlacementConfigs: []infrav2exp.PlacementConfig{
 							{
@@ -1457,7 +1457,7 @@ func TestManagedMachinePoolUpdate(t *testing.T) {
 					NodeSourceViaImage: &infrav2exp.NodeSourceViaImage{
 						ImageId: common.String("test-image-id"),
 					},
-					SshPublicKey: "test-ssh-public-key",
+					SshPublicKey: common.String("test-ssh-public-key"),
 					NodePoolNodeConfig: &infrav2exp.NodePoolNodeConfig{
 						PlacementConfigs: []infrav2exp.PlacementConfig{
 							{
@@ -1607,7 +1607,7 @@ func TestManagedMachinePoolUpdate(t *testing.T) {
 						MaximumSurge:         common.String("20%"),
 						MaximumUnavailable:   common.String("10%"),
 					},
-					SshPublicKey: "test-ssh-public-key",
+					SshPublicKey: common.String("test-ssh-public-key"),
 					NodePoolNodeConfig: &infrav2exp.NodePoolNodeConfig{
 						PlacementConfigs: []infrav2exp.PlacementConfig{
 							{
@@ -1724,6 +1724,11 @@ func TestManagedMachinePoolUpdate(t *testing.T) {
 				NodeEvictionNodePoolSettings: &oke.NodeEvictionNodePoolSettings{
 					EvictionGraceDuration:           common.String("PT30M"),
 					IsForceDeleteAfterGraceDuration: common.Bool(true),
+				},
+				NodePoolCyclingDetails: &oke.NodePoolCyclingDetails{
+					IsNodeCyclingEnabled: common.Bool(true),
+					MaximumSurge:         common.String("20%"),
+					MaximumUnavailable:   common.String("10%"),
 				},
 			},
 		},

--- a/cloud/scope/nat_gateway_reconciler.go
+++ b/cloud/scope/nat_gateway_reconciler.go
@@ -73,7 +73,7 @@ func (s *ClusterScope) GetNatGateway(ctx context.Context) (*core.NatGateway, err
 		}
 	}
 	ngws, err := s.VCNClient.ListNatGateways(ctx, core.ListNatGatewaysRequest{
-		CompartmentId: common.String(s.GetCompartmentId()),
+		CompartmentId: common.String(s.GetNetworkCompartmentId()),
 		VcnId:         s.getVcnId(),
 		DisplayName:   common.String(NatGatewayName),
 	})
@@ -110,7 +110,7 @@ func (s *ClusterScope) UpdateNatGateway(ctx context.Context) error {
 // CreateNatGateway creates the NAT Gateway for the cluster based on the ClusterScope
 func (s *ClusterScope) CreateNatGateway(ctx context.Context) (*string, error) {
 	ngwDetails := core.CreateNatGatewayDetails{
-		CompartmentId: common.String(s.GetCompartmentId()),
+		CompartmentId: common.String(s.GetNetworkCompartmentId()),
 		DisplayName:   common.String(NatGatewayName),
 		VcnId:         s.getVcnId(),
 		FreeformTags:  s.GetFreeFormTags(),

--- a/cloud/scope/network_load_balancer_reconciler.go
+++ b/cloud/scope/network_load_balancer_reconciler.go
@@ -190,7 +190,7 @@ func (s *ClusterScope) CreateNLB(ctx context.Context, lb infrastructurev1beta2.L
 		return nil, nil, errors.New("cannot have more than 1 control plane endpoint subnet")
 	}
 	nlbDetails := networkloadbalancer.CreateNetworkLoadBalancerDetails{
-		CompartmentId: common.String(s.GetCompartmentId()),
+		CompartmentId: common.String(s.GetNetworkCompartmentId()),
 		DisplayName:   common.String(lb.Name),
 		SubnetId:      common.String(controlPlaneEndpointSubnets[0]),
 		IsPrivate:     common.Bool(s.isControlPlaneEndpointSubnetPrivate()),
@@ -292,7 +292,7 @@ func (s *ClusterScope) GetNetworkLoadBalancers(ctx context.Context) (*networkloa
 		}
 	}
 	nlbs, err := s.NetworkLoadBalancerClient.ListNetworkLoadBalancers(ctx, networkloadbalancer.ListNetworkLoadBalancersRequest{
-		CompartmentId: common.String(s.GetCompartmentId()),
+		CompartmentId: common.String(s.GetNetworkCompartmentId()),
 		DisplayName:   common.String(s.GetControlPlaneLoadBalancerName()),
 	})
 	if err != nil {

--- a/cloud/scope/nsg_reconciler.go
+++ b/cloud/scope/nsg_reconciler.go
@@ -112,7 +112,7 @@ func (s *ClusterScope) GetNSG(ctx context.Context, spec infrastructurev1beta2.NS
 		}
 	}
 	nsgs, err := s.VCNClient.ListNetworkSecurityGroups(ctx, core.ListNetworkSecurityGroupsRequest{
-		CompartmentId: common.String(s.GetCompartmentId()),
+		CompartmentId: common.String(s.GetNetworkCompartmentId()),
 		VcnId:         s.getVcnId(),
 		DisplayName:   common.String(spec.Name),
 	})
@@ -424,7 +424,7 @@ func (s *ClusterScope) AddNSGSecurityRules(ctx context.Context, nsgId *string, i
 
 func (s *ClusterScope) CreateNSG(ctx context.Context, nsg infrastructurev1beta2.NSG) (*string, error) {
 	createNetworkSecurityGroupDetails := core.CreateNetworkSecurityGroupDetails{
-		CompartmentId: common.String(s.GetCompartmentId()),
+		CompartmentId: common.String(s.GetNetworkCompartmentId()),
 		VcnId:         s.getVcnId(),
 		DefinedTags:   s.GetDefinedTags(),
 		DisplayName:   common.String(nsg.Name),

--- a/cloud/scope/oci_managed_cluster.go
+++ b/cloud/scope/oci_managed_cluster.go
@@ -65,6 +65,10 @@ func (c OCIManagedCluster) GetCompartmentId() string {
 	return c.OCIManagedCluster.Spec.CompartmentId
 }
 
+func (c OCIManagedCluster) GetNetworkCompartmentId() string {
+	return c.OCIManagedCluster.Spec.NetworkSpec.CompartmentId
+}
+
 func (c OCIManagedCluster) GetFreeformTags() map[string]string {
 	return c.OCIManagedCluster.Spec.FreeformTags
 }

--- a/cloud/scope/oci_selfmanaged_cluster.go
+++ b/cloud/scope/oci_selfmanaged_cluster.go
@@ -65,6 +65,10 @@ func (c OCISelfManagedCluster) GetCompartmentId() string {
 	return c.OCICluster.Spec.CompartmentId
 }
 
+func (c OCISelfManagedCluster) GetNetworkCompartmentId() string {
+	return c.OCICluster.Spec.NetworkSpec.CompartmentId
+}
+
 func (c OCISelfManagedCluster) GetFreeformTags() map[string]string {
 	return c.OCICluster.Spec.FreeformTags
 }

--- a/cloud/scope/route_table_reconciler.go
+++ b/cloud/scope/route_table_reconciler.go
@@ -97,7 +97,7 @@ func (s *ClusterScope) getRouteTable(ctx context.Context, routeTableType string)
 	}
 
 	rts, err := s.VCNClient.ListRouteTables(ctx, core.ListRouteTablesRequest{
-		CompartmentId: common.String(s.GetCompartmentId()),
+		CompartmentId: common.String(s.GetNetworkCompartmentId()),
 		VcnId:         vcnId,
 		DisplayName:   common.String(routeTableName),
 	})
@@ -171,7 +171,7 @@ func (s *ClusterScope) CreateRouteTable(ctx context.Context, routeTableType stri
 	vcnId := s.getVcnId()
 	routeTableDetails := core.CreateRouteTableDetails{
 		VcnId:         vcnId,
-		CompartmentId: common.String(s.GetCompartmentId()),
+		CompartmentId: common.String(s.GetNetworkCompartmentId()),
 		DisplayName:   common.String(routeTableName),
 		RouteRules:    routeRules,
 		FreeformTags:  s.GetFreeFormTags(),

--- a/cloud/scope/security_list_reconciler.go
+++ b/cloud/scope/security_list_reconciler.go
@@ -70,7 +70,7 @@ func (s *ClusterScope) CreateSecurityList(ctx context.Context, secList infrastru
 	}
 	securityListDetails := core.CreateSecurityListDetails{
 		VcnId:                s.getVcnId(),
-		CompartmentId:        common.String(s.GetCompartmentId()),
+		CompartmentId:        common.String(s.GetNetworkCompartmentId()),
 		DisplayName:          common.String(secList.Name),
 		EgressSecurityRules:  egressRules,
 		IngressSecurityRules: ingressRules,
@@ -273,7 +273,7 @@ func (s *ClusterScope) GetSecurityList(ctx context.Context, spec infrastructurev
 		}
 	}
 	securityLists, err := s.VCNClient.ListSecurityLists(ctx, core.ListSecurityListsRequest{
-		CompartmentId: common.String(s.GetCompartmentId()),
+		CompartmentId: common.String(s.GetNetworkCompartmentId()),
 		VcnId:         s.getVcnId(),
 		DisplayName:   common.String(spec.Name),
 	})

--- a/cloud/scope/service_gateway_reconciler.go
+++ b/cloud/scope/service_gateway_reconciler.go
@@ -71,7 +71,7 @@ func (s *ClusterScope) CreateServiceGateway(ctx context.Context) (*string, error
 	}
 
 	sgwDetails := core.CreateServiceGatewayDetails{
-		CompartmentId: common.String(s.GetCompartmentId()),
+		CompartmentId: common.String(s.GetNetworkCompartmentId()),
 		DisplayName:   common.String(ServiceGatewayName),
 		VcnId:         s.getVcnId(),
 		Services:      []core.ServiceIdRequestDetails{{ServiceId: common.String(serviceOcid)}},
@@ -131,7 +131,7 @@ func (s *ClusterScope) GetServiceGateway(ctx context.Context) (*core.ServiceGate
 		}
 	}
 	sgws, err := s.VCNClient.ListServiceGateways(ctx, core.ListServiceGatewaysRequest{
-		CompartmentId: common.String(s.GetCompartmentId()),
+		CompartmentId: common.String(s.GetNetworkCompartmentId()),
 		VcnId:         s.getVcnId(),
 	})
 	if err != nil {

--- a/cloud/scope/subnet_reconciler.go
+++ b/cloud/scope/subnet_reconciler.go
@@ -144,7 +144,7 @@ func (s *ClusterScope) CreateSubnet(ctx context.Context, spec infrastructurev1be
 	}
 
 	createSubnetDetails := core.CreateSubnetDetails{
-		CompartmentId:           common.String(s.GetCompartmentId()),
+		CompartmentId:           common.String(s.GetNetworkCompartmentId()),
 		CidrBlock:               common.String(spec.CIDR),
 		VcnId:                   s.getVcnId(),
 		DisplayName:             common.String(spec.Name),
@@ -241,7 +241,7 @@ func (s *ClusterScope) GetSubnet(ctx context.Context, spec infrastructurev1beta2
 		}
 	}
 	subnets, err := s.VCNClient.ListSubnets(ctx, core.ListSubnetsRequest{
-		CompartmentId: common.String(s.GetCompartmentId()),
+		CompartmentId: common.String(s.GetNetworkCompartmentId()),
 		VcnId:         s.getVcnId(),
 		DisplayName:   common.String(spec.Name),
 	})
@@ -307,7 +307,8 @@ func (s *ClusterScope) IsSubnetsEqual(actual *core.Subnet, desired infrastructur
 	}
 	if desired.SecurityList != nil {
 		if desired.SecurityList.ID == nil {
-			return false
+			// If nobody has specified a security list, reconciliation must not happen
+			return true
 		}
 
 		return slices.Contains(actual.SecurityListIds, ptr.ToString(desired.SecurityList.ID))

--- a/cloud/scope/subnet_reconciler_test.go
+++ b/cloud/scope/subnet_reconciler_test.go
@@ -999,6 +999,7 @@ func TestClusterScope_IsSubnetsEqual(t *testing.T) {
 			want: true,
 		},
 		{
+			// Modified this test because returning nil was actually a bad logic, causing infinite reconciliation is SecurityListId was not specified
 			name: "desired security list id nil",
 			actual: core.Subnet{
 				DisplayName:     common.String("name"),
@@ -1012,7 +1013,7 @@ func TestClusterScope_IsSubnetsEqual(t *testing.T) {
 					// ID intentionally nil
 				},
 			},
-			want: false,
+			want: true,
 		},
 		{
 			name: "desired security list present but actual has none",

--- a/cloud/scope/vcn_reconciler.go
+++ b/cloud/scope/vcn_reconciler.go
@@ -93,7 +93,7 @@ func (s *ClusterScope) GetVCN(ctx context.Context) (*core.Vcn, error) {
 		}
 	}
 	vcns, err := s.VCNClient.ListVcns(ctx, core.ListVcnsRequest{
-		CompartmentId: common.String(s.GetCompartmentId()),
+		CompartmentId: common.String(s.GetNetworkCompartmentId()),
 		DisplayName:   common.String(s.GetVcnName()),
 	})
 	if err != nil {
@@ -127,7 +127,7 @@ func (s *ClusterScope) UpdateVCN(ctx context.Context, vcn infrastructurev1beta2.
 
 func (s *ClusterScope) CreateVCN(ctx context.Context, spec infrastructurev1beta2.VCN) (*string, error) {
 	vcnDetails := core.CreateVcnDetails{
-		CompartmentId: common.String(s.GetCompartmentId()),
+		CompartmentId: common.String(s.GetNetworkCompartmentId()),
 		DisplayName:   common.String(s.GetVcnName()),
 		CidrBlocks:    s.GetVcnCidrs(),
 		FreeformTags:  s.GetFreeFormTags(),

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclusteridentities.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclusteridentities.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: ociclusteridentities.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -21,14 +21,19 @@ spec:
           API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -37,71 +42,72 @@ spec:
               to create an OCIClusterIdentity.
             properties:
               allowedNamespaces:
-                description: AllowedNamespaces is used to identify the namespaces
-                  the clusters are allowed to use the identity from. Namespaces can
-                  be selected either using an array of namespaces or with label selector.
-                  An empty allowedNamespaces object indicates that OCIClusters can
-                  use this identity from any namespace. If this object is nil, no
-                  namespaces will be allowed (default behaviour, if this field is
-                  not provided) A namespace should be either in the NamespaceList
-                  or match with Selector to use the identity.
+                description: |-
+                  AllowedNamespaces is used to identify the namespaces the clusters are allowed to use the identity from.
+                  Namespaces can be selected either using an array of namespaces or with label selector.
+                  An empty allowedNamespaces object indicates that OCIClusters can use this identity from any namespace.
+                  If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided)
+                  A namespace should be either in the NamespaceList or match with Selector to use the identity.
                 nullable: true
                 properties:
                   list:
-                    description: A nil or empty list indicates that OCICluster cannot
-                      use the identity from any namespace. NamespaceList takes precedence
-                      over the Selector.
+                    description: |-
+                      A nil or empty list indicates that OCICluster cannot use the identity from any namespace.
+                      NamespaceList takes precedence over the Selector.
                     items:
                       type: string
                     nullable: true
                     type: array
                   selector:
-                    description: "Selector is a selector of namespaces that OCICluster
-                      can use this Identity from. This is a standard Kubernetes LabelSelector,
-                      a label query over a set of resources. The result of matchLabels
-                      and matchExpressions are ANDed. \n A nil or empty selector indicates
-                      that OCICluster cannot use this OCIClusterIdentity from any
-                      namespace."
+                    description: |-
+                      Selector is a selector of namespaces that OCICluster can
+                      use this Identity from. This is a standard Kubernetes LabelSelector,
+                      a label query over a set of resources. The result of matchLabels and
+                      matchExpressions are ANDed.
+
+                      A nil or empty selector indicates that OCICluster cannot use this
+                      OCIClusterIdentity from any namespace.
                     properties:
                       matchExpressions:
                         description: matchExpressions is a list of label selector
                           requirements. The requirements are ANDed.
                         items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
                           properties:
                             key:
                               description: key is the label key that the selector
                                 applies to.
                               type: string
                             operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                           required:
                           - key
                           - operator
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: matchLabels is a map of {key,value} pairs. A
-                          single {key,value} in the matchLabels map is equivalent
-                          to an element of matchExpressions, whose key field is "key",
-                          the operator is "In", and the values array contains only
-                          "value". The requirements are ANDed.
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
@@ -121,8 +127,9 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               type:
-                description: Type is the type of OCI Principal used. UserPrincipal
-                  is the only supported value
+                description: |-
+                  Type is the type of OCI Principal used.
+                  UserPrincipal is the only supported value
                 type: string
             required:
             - type
@@ -137,37 +144,44 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
+                      description: status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -188,14 +202,19 @@ spec:
           API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -204,71 +223,72 @@ spec:
               to create an OCIClusterIdentity.
             properties:
               allowedNamespaces:
-                description: AllowedNamespaces is used to identify the namespaces
-                  the clusters are allowed to use the identity from. Namespaces can
-                  be selected either using an array of namespaces or with label selector.
-                  An empty allowedNamespaces object indicates that OCIClusters can
-                  use this identity from any namespace. If this object is nil, no
-                  namespaces will be allowed (default behaviour, if this field is
-                  not provided) A namespace should be either in the NamespaceList
-                  or match with Selector to use the identity.
+                description: |-
+                  AllowedNamespaces is used to identify the namespaces the clusters are allowed to use the identity from.
+                  Namespaces can be selected either using an array of namespaces or with label selector.
+                  An empty allowedNamespaces object indicates that OCIClusters can use this identity from any namespace.
+                  If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided)
+                  A namespace should be either in the NamespaceList or match with Selector to use the identity.
                 nullable: true
                 properties:
                   list:
-                    description: A nil or empty list indicates that OCICluster cannot
-                      use the identity from any namespace. NamespaceList takes precedence
-                      over the Selector.
+                    description: |-
+                      A nil or empty list indicates that OCICluster cannot use the identity from any namespace.
+                      NamespaceList takes precedence over the Selector.
                     items:
                       type: string
                     nullable: true
                     type: array
                   selector:
-                    description: "Selector is a selector of namespaces that OCICluster
-                      can use this Identity from. This is a standard Kubernetes LabelSelector,
-                      a label query over a set of resources. The result of matchLabels
-                      and matchExpressions are ANDed. \n A nil or empty selector indicates
-                      that OCICluster cannot use this OCIClusterIdentity from any
-                      namespace."
+                    description: |-
+                      Selector is a selector of namespaces that OCICluster can
+                      use this Identity from. This is a standard Kubernetes LabelSelector,
+                      a label query over a set of resources. The result of matchLabels and
+                      matchExpressions are ANDed.
+
+                      A nil or empty selector indicates that OCICluster cannot use this
+                      OCIClusterIdentity from any namespace.
                     properties:
                       matchExpressions:
                         description: matchExpressions is a list of label selector
                           requirements. The requirements are ANDed.
                         items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
                           properties:
                             key:
                               description: key is the label key that the selector
                                 applies to.
                               type: string
                             operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                           required:
                           - key
                           - operator
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: matchLabels is a map of {key,value} pairs. A
-                          single {key,value} in the matchLabels map is equivalent
-                          to an element of matchExpressions, whose key field is "key",
-                          the operator is "In", and the values array contains only
-                          "value". The requirements are ANDed.
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
@@ -288,8 +308,9 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               type:
-                description: Type is the type of OCI Principal used. UserPrincipal
-                  is the only supported value
+                description: |-
+                  Type is the type of OCI Principal used.
+                  UserPrincipal is the only supported value
                 type: string
             required:
             - type
@@ -304,37 +325,44 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
+                      description: status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: ociclusters.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -20,14 +20,19 @@ spec:
         description: OCICluster is the Schema for the ociclusters API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -42,10 +47,11 @@ spec:
                   communicate with the control plane.
                 properties:
                   host:
-                    description: The hostname on which the API server is serving.
+                    description: host is the hostname on which the API server is serving.
+                    maxLength: 512
                     type: string
                   port:
-                    description: The port on which the API server is serving.
+                    description: port is the port on which the API server is serving.
                     format: int32
                     type: integer
                 required:
@@ -57,10 +63,10 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
-                description: 'Defined tags for this resource. Each key is predefined
-                  and scoped to a namespace. For more information, see Resource Tags
-                  (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
-                  Example: `{"Operations": {"CostCenter": "42"}}`'
+                description: |-
+                  Defined tags for this resource. Each key is predefined and scoped to a
+                  namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+                  Example: `{"Operations": {"CostCenter": "42"}}`
                 type: object
               freeformTags:
                 additionalProperties:
@@ -75,33 +81,39 @@ spec:
                     description: API version of the referent.
                     type: string
                   fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
                     type: string
                   kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                     type: string
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                     type: string
                   namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                     type: string
                   resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                     type: string
                   uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
@@ -130,15 +142,15 @@ spec:
                                   soon as current backend becomes unhealthy.
                                 properties:
                                   urlPath:
-                                    description: 'The path against which to run the
-                                      health check. Example: `/healthcheck` Default
-                                      value is `/healthz`'
+                                    description: |-
+                                      The path against which to run the health check.
+                                      Example: `/healthcheck`
+                                      Default value is `/healthz`
                                     type: string
                                 type: object
                               isFailOpen:
-                                description: If enabled, the network load balancer
-                                  will continue to distribute traffic in the configured
-                                  distribution in the event all backends are unhealthy.
+                                description: |-
+                                  If enabled, the network load balancer will continue to distribute traffic in the configured distribution in the event all backends are unhealthy.
                                   The value is false by default.
                                 type: boolean
                               isInstantFailoverEnabled:
@@ -147,30 +159,29 @@ spec:
                                   soon as current backend becomes unhealthy.
                                 type: boolean
                               isPreserveSource:
-                                description: If this parameter is enabled, then the
-                                  network load balancer preserves the source IP of
-                                  the packet when it is forwarded to backends. Backends
-                                  see the original source IP. If the isPreserveSourceDestination
-                                  parameter is enabled for the network load balancer
-                                  resource, then this parameter cannot be disabled.
+                                description: |-
+                                  If this parameter is enabled, then the network load balancer preserves the source IP of the packet when it is forwarded to backends.
+                                  Backends see the original source IP. If the isPreserveSourceDestination parameter is enabled for the network load balancer resource, then this parameter cannot be disabled.
                                   The value is false by default.
                                 type: boolean
                             type: object
                         type: object
                     type: object
+                  compartmentId:
+                    description: CompartmentId where to provision network resources
+                    type: string
                   skipNetworkManagement:
-                    description: SkipNetworkManagement defines if the networking spec(VCN
-                      related) specified by the user needs to be reconciled(actioned-upon)
+                    description: |-
+                      SkipNetworkManagement defines if the networking spec(VCN related) specified by the user needs to be reconciled(actioned-upon)
                       or used as it is. APIServerLB will still be reconciled.
                     type: boolean
                   vcn:
                     description: VCN configuration.
                     properties:
-                      isIpv6Enabled:
-                        description: isIpv6Enabled enables the possibility to assign IPv6 to cluster nodes.
-                        type: boolean
                       cidr:
-                        description: VCN CIDR. Deprecated, please use NetworkDetails.cidrs
+                        description: |-
+                          VCN CIDR.
+                          Deprecated, please use NetworkDetails.cidrs
                         type: string
                       cidrs:
                         description: VCN CIDRs.
@@ -178,20 +189,25 @@ spec:
                           type: string
                         type: array
                       dnsLabel:
-                        description: DnsLabel specifies a DNS label for the VCN, used
-                          in conjunction with the VNIC's hostname and subnet's DNS
-                          label to form a fully qualified domain name (FQDN) for each
-                          VNIC within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
+                        description: |-
+                          DnsLabel specifies a DNS label for the VCN, used in conjunction with the VNIC's hostname and
+                          subnet's DNS label to form a fully qualified domain name (FQDN) for each VNIC
+                          within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
                         type: string
                       id:
                         description: VCN OCID.
                         type: string
-                      skip:
-                        description: Skip specifies whether to skip creating vcn
-                        type: boolean
                       internetGatewayId:
                         description: ID of Internet Gateway.
                         type: string
+                      isIpv6Enabled:
+                        description: Configuration to enable IPv6.
+                        type: boolean
+                      isOracleGuaAllocationEnabled:
+                        description: Configuration to allow OCI to assign IPv6 Prefix.
+                          When true will use a /56 IPv6 global unicast address (GUA)
+                          prefix allocated by Oracle
+                        type: boolean
                       name:
                         description: VCN Name.
                         type: string
@@ -202,8 +218,9 @@ spec:
                         description: NetworkSecurityGroups is the configuration for
                           the Network Security Groups required in the VCN.
                         items:
-                          description: NSG defines configuration for a Network Security
-                            Group. https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/networksecuritygroups.htm
+                          description: |-
+                            NSG defines configuration for a Network Security Group.
+                            https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/networksecuritygroups.htm
                           properties:
                             egressRules:
                               description: EgressRules on the NSG.
@@ -220,47 +237,37 @@ spec:
                                           choice for the rule.
                                         type: string
                                       destination:
-                                        description: 'Conceptually, this is the range
-                                          of IP addresses that a packet originating
-                                          from the instance can go to. Allowed values:
-                                          * IP address range in CIDR notation. For
-                                          example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-                                          Note that IPv6 addressing is currently supported
-                                          only in certain regions. See IPv6 Addresses
-                                          (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                          * The `cidrBlock` value for a Service, if
-                                          you''re setting up a security list rule
-                                          for traffic destined for a particular `Service`
-                                          through a service gateway. For example:
-                                          `oci-phx-objectstorage`.'
+                                        description: |-
+                                          Conceptually, this is the range of IP addresses that a packet originating from the instance
+                                          can go to.
+                                          Allowed values:
+                                            * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
+                                              Note that IPv6 addressing is currently supported only in certain regions. See
+                                              IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                            * The `cidrBlock` value for a Service, if you're
+                                              setting up a security list rule for traffic destined for a particular `Service` through
+                                              a service gateway. For example: `oci-phx-objectstorage`.
                                         type: string
                                       destinationType:
-                                        description: 'Type of destination for the
-                                          rule. The default is `CIDR_BLOCK`. Allowed
-                                          values: * `CIDR_BLOCK`: If the rule''s `destination`
-                                          is an IP address range in CIDR notation.
-                                          * `SERVICE_CIDR_BLOCK`: If the rule''s `destination`
-                                          is the `cidrBlock` value for a Service (the
-                                          rule is for traffic destined for a particular
-                                          `Service` through a service gateway).'
+                                        description: |-
+                                          Type of destination for the rule. The default is `CIDR_BLOCK`.
+                                          Allowed values:
+                                            * `CIDR_BLOCK`: If the rule's `destination` is an IP address range in CIDR notation.
+                                            * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
+                                              Service (the rule is for traffic destined for a
+                                              particular `Service` through a service gateway).
                                         type: string
                                       icmpOptions:
-                                        description: 'IcmpOptions Optional and valid
-                                          only for ICMP and ICMPv6. Use to specify
-                                          a particular ICMP type and code as defined
-                                          in: - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                        description: |-
+                                          IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                          as defined in:
+                                          - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                           - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                          If you specify ICMP or ICMPv6 as the protocol
-                                          but omit this object, then all ICMP types
-                                          and codes are allowed. If you do provide
-                                          this object, the type is required and the
-                                          code is optional. To enable MTU negotiation
-                                          for ingress internet traffic via IPv4, make
-                                          sure to allow type 3 ("Destination Unreachable")
-                                          code 4 ("Fragmentation Needed and Don''t
-                                          Fragment was Set"). If you need to specify
-                                          multiple codes for a single type, create
-                                          a separate security list rule for each.'
+                                          If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                          codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                          To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                          Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                          multiple codes for a single type, create a separate security list rule for each.
                                         properties:
                                           code:
                                             description: The ICMP code (optional).
@@ -270,41 +277,33 @@ spec:
                                             type: integer
                                         type: object
                                       isStateless:
-                                        description: A stateless rule allows traffic
-                                          in one direction. Remember to add a corresponding
-                                          stateless rule in the other direction if
-                                          you need to support bidirectional traffic.
-                                          For example, if egress traffic allows TCP
-                                          destination port 80, there should be an
-                                          ingress rule to allow TCP source port 80.
-                                          Defaults to false, which means the rule
-                                          is stateful and a corresponding rule is
-                                          not necessary for bidirectional traffic.
+                                        description: |-
+                                          A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                          stateless rule in the other direction if you need to support bidirectional traffic. For
+                                          example, if egress traffic allows TCP destination port 80, there should be an ingress
+                                          rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                          and a corresponding rule is not necessary for bidirectional traffic.
                                         type: boolean
                                       protocol:
-                                        description: The transport protocol. Specify
-                                          either `all` or an IPv4 protocol number
-                                          as defined in Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                          Options are supported only for ICMP ("1"),
-                                          TCP ("6"), UDP ("17"), and ICMPv6 ("58").
+                                        description: |-
+                                          The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                          defined in
+                                          Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                          Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                         type: string
                                       tcpOptions:
-                                        description: TcpOptions Optional and valid
-                                          only for TCP. Use to specify particular
-                                          destination ports for TCP rules. If you
-                                          specify TCP as the protocol but omit this
-                                          object, then all destination ports are allowed.
+                                        description: |-
+                                          TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                          If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                         properties:
                                           destinationPortRange:
                                             description: PortRange The representation
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -317,11 +316,9 @@ spec:
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -331,22 +328,18 @@ spec:
                                             type: object
                                         type: object
                                       udpOptions:
-                                        description: UdpOptions Optional and valid
-                                          only for UDP. Use to specify particular
-                                          destination ports for UDP rules. If you
-                                          specify UDP as the protocol but omit this
-                                          object, then all destination ports are allowed.
+                                        description: |-
+                                          UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                          If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                         properties:
                                           destinationPortRange:
                                             description: PortRange The representation
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -359,11 +352,9 @@ spec:
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -374,9 +365,9 @@ spec:
                                         type: object
                                     type: object
                                   id:
-                                    description: 'EgressSecurityRule ID for NSG. Deprecated:
-                                      this field is not populated and used during
-                                      reconciliation'
+                                    description: |-
+                                      EgressSecurityRule ID for NSG.
+                                      Deprecated: this field is not populated and used during reconciliation
                                     type: string
                                 type: object
                               type: array
@@ -390,9 +381,9 @@ spec:
                                   for NSG
                                 properties:
                                   id:
-                                    description: 'IngressSecurityRule ID for NSG.
-                                      Deprecated: this field is not populated and
-                                      used during reconciliation'
+                                    description: |-
+                                      IngressSecurityRule ID for NSG.
+                                      Deprecated: this field is not populated and used during reconciliation
                                     type: string
                                   ingressRule:
                                     description: IngressSecurityRule A rule for allowing
@@ -403,22 +394,16 @@ spec:
                                           choice for the rule.
                                         type: string
                                       icmpOptions:
-                                        description: 'IcmpOptions Optional and valid
-                                          only for ICMP and ICMPv6. Use to specify
-                                          a particular ICMP type and code as defined
-                                          in: - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                        description: |-
+                                          IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                          as defined in:
+                                          - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                           - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                          If you specify ICMP or ICMPv6 as the protocol
-                                          but omit this object, then all ICMP types
-                                          and codes are allowed. If you do provide
-                                          this object, the type is required and the
-                                          code is optional. To enable MTU negotiation
-                                          for ingress internet traffic via IPv4, make
-                                          sure to allow type 3 ("Destination Unreachable")
-                                          code 4 ("Fragmentation Needed and Don''t
-                                          Fragment was Set"). If you need to specify
-                                          multiple codes for a single type, create
-                                          a separate security list rule for each.'
+                                          If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                          codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                          To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                          Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                          multiple codes for a single type, create a separate security list rule for each.
                                         properties:
                                           code:
                                             description: The ICMP code (optional).
@@ -428,66 +413,53 @@ spec:
                                             type: integer
                                         type: object
                                       isStateless:
-                                        description: A stateless rule allows traffic
-                                          in one direction. Remember to add a corresponding
-                                          stateless rule in the other direction if
-                                          you need to support bidirectional traffic.
-                                          For example, if ingress traffic allows TCP
-                                          destination port 80, there should be an
-                                          egress rule to allow TCP source port 80.
-                                          Defaults to false, which means the rule
-                                          is stateful and a corresponding rule is
-                                          not necessary for bidirectional traffic.
+                                        description: |-
+                                          A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                          stateless rule in the other direction if you need to support bidirectional traffic. For
+                                          example, if ingress traffic allows TCP destination port 80, there should be an egress
+                                          rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                          and a corresponding rule is not necessary for bidirectional traffic.
                                         type: boolean
                                       protocol:
-                                        description: The transport protocol. Specify
-                                          either `all` or an IPv4 protocol number
-                                          as defined in Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                          Options are supported only for ICMP ("1"),
-                                          TCP ("6"), UDP ("17"), and ICMPv6 ("58").
+                                        description: |-
+                                          The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                          defined in
+                                          Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                          Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                         type: string
                                       source:
-                                        description: 'Conceptually, this is the range
-                                          of IP addresses that a packet coming into
-                                          the instance can come from. Allowed values:
-                                          * IP address range in CIDR notation. For
-                                          example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
-                                          IPv6 addressing is supported for all commercial
-                                          and government regions. See IPv6 Addresses
-                                          (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                          * The `cidrBlock` value for a Service, if
-                                          you''re setting up a security list rule
-                                          for traffic coming from a particular `Service`
-                                          through a service gateway. For example:
-                                          `oci-phx-objectstorage`.'
+                                        description: |-
+                                          Conceptually, this is the range of IP addresses that a packet coming into the instance
+                                          can come from.
+                                          Allowed values:
+                                            * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
+                                              IPv6 addressing is supported for all commercial and government regions. See
+                                              IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                            * The `cidrBlock` value for a Service, if you're
+                                              setting up a security list rule for traffic coming from a particular `Service` through
+                                              a service gateway. For example: `oci-phx-objectstorage`.
                                         type: string
                                       sourceType:
-                                        description: 'Type of source for the rule.
-                                          The default is `CIDR_BLOCK`. * `CIDR_BLOCK`:
-                                          If the rule''s `source` is an IP address
-                                          range in CIDR notation. * `SERVICE_CIDR_BLOCK`:
-                                          If the rule''s `source` is the `cidrBlock`
-                                          value for a Service (the rule is for traffic
-                                          coming from a particular `Service` through
-                                          a service gateway).'
+                                        description: |-
+                                          Type of source for the rule. The default is `CIDR_BLOCK`.
+                                            * `CIDR_BLOCK`: If the rule's `source` is an IP address range in CIDR notation.
+                                            * `SERVICE_CIDR_BLOCK`: If the rule's `source` is the `cidrBlock` value for a
+                                              Service (the rule is for traffic coming from a
+                                              particular `Service` through a service gateway).
                                         type: string
                                       tcpOptions:
-                                        description: TcpOptions Optional and valid
-                                          only for TCP. Use to specify particular
-                                          destination ports for TCP rules. If you
-                                          specify TCP as the protocol but omit this
-                                          object, then all destination ports are allowed.
+                                        description: |-
+                                          TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                          If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                         properties:
                                           destinationPortRange:
                                             description: PortRange The representation
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -500,11 +472,9 @@ spec:
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -514,22 +484,18 @@ spec:
                                             type: object
                                         type: object
                                       udpOptions:
-                                        description: UdpOptions Optional and valid
-                                          only for UDP. Use to specify particular
-                                          destination ports for UDP rules. If you
-                                          specify UDP as the protocol but omit this
-                                          object, then all destination ports are allowed.
+                                        description: |-
+                                          UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                          If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                         properties:
                                           destinationPortRange:
                                             description: PortRange The representation
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -542,11 +508,9 @@ spec:
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -581,31 +545,39 @@ spec:
                       serviceGatewayId:
                         description: ID of Service Gateway.
                         type: string
+                      skip:
+                        description: |-
+                          Skip specifies whether to skip creating VCN.
+                          When is set to true, InternetGateway, NatGateway, ServiceGateway, RouteTable must have also Skip set to true
+                          If set to true(default: false) the ID must be specified by the user to a valid VCN ID.
+                        type: boolean
                       subnets:
                         description: Subnets is the configuration for subnets required
                           in the VCN.
                         items:
-                          description: Subnet defines the configuration for a network's
-                            subnet https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingVCNs_topic-Overview_of_VCNs_and_Subnets.htm#Overview
+                          description: |-
+                            Subnet defines the configuration for a network's subnet
+                            https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingVCNs_topic-Overview_of_VCNs_and_Subnets.htm#Overview
                           properties:
                             cidr:
                               description: Subnet CIDR.
                               type: string
                             dnsLabel:
-                              description: DnsLabel DNS label for the subnet, used
-                                in conjunction with the VNIC's hostname and VCN's
-                                DNS label to form a fully qualified domain name (FQDN)
-                                for each VNIC within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
-                              type: string
-                            ipv6CidrBlockHextet:
-                              description: Subnet IPv6 CIDR.
+                              description: |-
+                                DnsLabel DNS label for the subnet, used in conjunction with the VNIC's hostname and
+                                VCN's DNS label to form a fully qualified domain name (FQDN) for each VNIC
+                                within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
                               type: string
                             id:
                               description: Subnet OCID.
                               type: string
-                            skip:
-                              description: Skip specifies whether to skip creating subnet
-                              type: boolean
+                            ipv6CidrBlockHextet:
+                              description: |-
+                                Use this to enable IPv6 hextet for this subnet. The VCN must be enabled for IPv6.
+                                You can't change this subnet characteristic later. All subnets are /64 in size. The subnet
+                                portion of the IPv6 address is the fourth hextet from the left (1111 in the following example).
+                                Example: `2001:0db8:0123:1111::/64`
+                              type: string
                             name:
                               description: Subnet Name.
                               type: string
@@ -627,47 +599,37 @@ spec:
                                           choice for the rule.
                                         type: string
                                       destination:
-                                        description: 'Conceptually, this is the range
-                                          of IP addresses that a packet originating
-                                          from the instance can go to. Allowed values:
-                                          * IP address range in CIDR notation. For
-                                          example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-                                          Note that IPv6 addressing is currently supported
-                                          only in certain regions. See IPv6 Addresses
-                                          (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                          * The `cidrBlock` value for a Service, if
-                                          you''re setting up a security list rule
-                                          for traffic destined for a particular `Service`
-                                          through a service gateway. For example:
-                                          `oci-phx-objectstorage`.'
+                                        description: |-
+                                          Conceptually, this is the range of IP addresses that a packet originating from the instance
+                                          can go to.
+                                          Allowed values:
+                                            * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
+                                              Note that IPv6 addressing is currently supported only in certain regions. See
+                                              IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                            * The `cidrBlock` value for a Service, if you're
+                                              setting up a security list rule for traffic destined for a particular `Service` through
+                                              a service gateway. For example: `oci-phx-objectstorage`.
                                         type: string
                                       destinationType:
-                                        description: 'Type of destination for the
-                                          rule. The default is `CIDR_BLOCK`. Allowed
-                                          values: * `CIDR_BLOCK`: If the rule''s `destination`
-                                          is an IP address range in CIDR notation.
-                                          * `SERVICE_CIDR_BLOCK`: If the rule''s `destination`
-                                          is the `cidrBlock` value for a Service (the
-                                          rule is for traffic destined for a particular
-                                          `Service` through a service gateway).'
+                                        description: |-
+                                          Type of destination for the rule. The default is `CIDR_BLOCK`.
+                                          Allowed values:
+                                            * `CIDR_BLOCK`: If the rule's `destination` is an IP address range in CIDR notation.
+                                            * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
+                                              Service (the rule is for traffic destined for a
+                                              particular `Service` through a service gateway).
                                         type: string
                                       icmpOptions:
-                                        description: 'IcmpOptions Optional and valid
-                                          only for ICMP and ICMPv6. Use to specify
-                                          a particular ICMP type and code as defined
-                                          in: - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                        description: |-
+                                          IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                          as defined in:
+                                          - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                           - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                          If you specify ICMP or ICMPv6 as the protocol
-                                          but omit this object, then all ICMP types
-                                          and codes are allowed. If you do provide
-                                          this object, the type is required and the
-                                          code is optional. To enable MTU negotiation
-                                          for ingress internet traffic via IPv4, make
-                                          sure to allow type 3 ("Destination Unreachable")
-                                          code 4 ("Fragmentation Needed and Don''t
-                                          Fragment was Set"). If you need to specify
-                                          multiple codes for a single type, create
-                                          a separate security list rule for each.'
+                                          If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                          codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                          To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                          Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                          multiple codes for a single type, create a separate security list rule for each.
                                         properties:
                                           code:
                                             description: The ICMP code (optional).
@@ -677,41 +639,33 @@ spec:
                                             type: integer
                                         type: object
                                       isStateless:
-                                        description: A stateless rule allows traffic
-                                          in one direction. Remember to add a corresponding
-                                          stateless rule in the other direction if
-                                          you need to support bidirectional traffic.
-                                          For example, if egress traffic allows TCP
-                                          destination port 80, there should be an
-                                          ingress rule to allow TCP source port 80.
-                                          Defaults to false, which means the rule
-                                          is stateful and a corresponding rule is
-                                          not necessary for bidirectional traffic.
+                                        description: |-
+                                          A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                          stateless rule in the other direction if you need to support bidirectional traffic. For
+                                          example, if egress traffic allows TCP destination port 80, there should be an ingress
+                                          rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                          and a corresponding rule is not necessary for bidirectional traffic.
                                         type: boolean
                                       protocol:
-                                        description: The transport protocol. Specify
-                                          either `all` or an IPv4 protocol number
-                                          as defined in Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                          Options are supported only for ICMP ("1"),
-                                          TCP ("6"), UDP ("17"), and ICMPv6 ("58").
+                                        description: |-
+                                          The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                          defined in
+                                          Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                          Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                         type: string
                                       tcpOptions:
-                                        description: TcpOptions Optional and valid
-                                          only for TCP. Use to specify particular
-                                          destination ports for TCP rules. If you
-                                          specify TCP as the protocol but omit this
-                                          object, then all destination ports are allowed.
+                                        description: |-
+                                          TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                          If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                         properties:
                                           destinationPortRange:
                                             description: PortRange The representation
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -724,11 +678,9 @@ spec:
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -738,22 +690,18 @@ spec:
                                             type: object
                                         type: object
                                       udpOptions:
-                                        description: UdpOptions Optional and valid
-                                          only for UDP. Use to specify particular
-                                          destination ports for UDP rules. If you
-                                          specify UDP as the protocol but omit this
-                                          object, then all destination ports are allowed.
+                                        description: |-
+                                          UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                          If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                         properties:
                                           destinationPortRange:
                                             description: PortRange The representation
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -766,11 +714,9 @@ spec:
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -795,22 +741,16 @@ spec:
                                           choice for the rule.
                                         type: string
                                       icmpOptions:
-                                        description: 'IcmpOptions Optional and valid
-                                          only for ICMP and ICMPv6. Use to specify
-                                          a particular ICMP type and code as defined
-                                          in: - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                        description: |-
+                                          IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                          as defined in:
+                                          - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                           - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                          If you specify ICMP or ICMPv6 as the protocol
-                                          but omit this object, then all ICMP types
-                                          and codes are allowed. If you do provide
-                                          this object, the type is required and the
-                                          code is optional. To enable MTU negotiation
-                                          for ingress internet traffic via IPv4, make
-                                          sure to allow type 3 ("Destination Unreachable")
-                                          code 4 ("Fragmentation Needed and Don''t
-                                          Fragment was Set"). If you need to specify
-                                          multiple codes for a single type, create
-                                          a separate security list rule for each.'
+                                          If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                          codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                          To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                          Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                          multiple codes for a single type, create a separate security list rule for each.
                                         properties:
                                           code:
                                             description: The ICMP code (optional).
@@ -820,66 +760,53 @@ spec:
                                             type: integer
                                         type: object
                                       isStateless:
-                                        description: A stateless rule allows traffic
-                                          in one direction. Remember to add a corresponding
-                                          stateless rule in the other direction if
-                                          you need to support bidirectional traffic.
-                                          For example, if ingress traffic allows TCP
-                                          destination port 80, there should be an
-                                          egress rule to allow TCP source port 80.
-                                          Defaults to false, which means the rule
-                                          is stateful and a corresponding rule is
-                                          not necessary for bidirectional traffic.
+                                        description: |-
+                                          A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                          stateless rule in the other direction if you need to support bidirectional traffic. For
+                                          example, if ingress traffic allows TCP destination port 80, there should be an egress
+                                          rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                          and a corresponding rule is not necessary for bidirectional traffic.
                                         type: boolean
                                       protocol:
-                                        description: The transport protocol. Specify
-                                          either `all` or an IPv4 protocol number
-                                          as defined in Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                          Options are supported only for ICMP ("1"),
-                                          TCP ("6"), UDP ("17"), and ICMPv6 ("58").
+                                        description: |-
+                                          The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                          defined in
+                                          Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                          Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                         type: string
                                       source:
-                                        description: 'Conceptually, this is the range
-                                          of IP addresses that a packet coming into
-                                          the instance can come from. Allowed values:
-                                          * IP address range in CIDR notation. For
-                                          example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
-                                          IPv6 addressing is supported for all commercial
-                                          and government regions. See IPv6 Addresses
-                                          (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                          * The `cidrBlock` value for a Service, if
-                                          you''re setting up a security list rule
-                                          for traffic coming from a particular `Service`
-                                          through a service gateway. For example:
-                                          `oci-phx-objectstorage`.'
+                                        description: |-
+                                          Conceptually, this is the range of IP addresses that a packet coming into the instance
+                                          can come from.
+                                          Allowed values:
+                                            * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
+                                              IPv6 addressing is supported for all commercial and government regions. See
+                                              IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                            * The `cidrBlock` value for a Service, if you're
+                                              setting up a security list rule for traffic coming from a particular `Service` through
+                                              a service gateway. For example: `oci-phx-objectstorage`.
                                         type: string
                                       sourceType:
-                                        description: 'Type of source for the rule.
-                                          The default is `CIDR_BLOCK`. * `CIDR_BLOCK`:
-                                          If the rule''s `source` is an IP address
-                                          range in CIDR notation. * `SERVICE_CIDR_BLOCK`:
-                                          If the rule''s `source` is the `cidrBlock`
-                                          value for a Service (the rule is for traffic
-                                          coming from a particular `Service` through
-                                          a service gateway).'
+                                        description: |-
+                                          Type of source for the rule. The default is `CIDR_BLOCK`.
+                                            * `CIDR_BLOCK`: If the rule's `source` is an IP address range in CIDR notation.
+                                            * `SERVICE_CIDR_BLOCK`: If the rule's `source` is the `cidrBlock` value for a
+                                              Service (the rule is for traffic coming from a
+                                              particular `Service` through a service gateway).
                                         type: string
                                       tcpOptions:
-                                        description: TcpOptions Optional and valid
-                                          only for TCP. Use to specify particular
-                                          destination ports for TCP rules. If you
-                                          specify TCP as the protocol but omit this
-                                          object, then all destination ports are allowed.
+                                        description: |-
+                                          TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                          If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                         properties:
                                           destinationPortRange:
                                             description: PortRange The representation
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -892,11 +819,9 @@ spec:
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -906,22 +831,18 @@ spec:
                                             type: object
                                         type: object
                                       udpOptions:
-                                        description: UdpOptions Optional and valid
-                                          only for UDP. Use to specify particular
-                                          destination ports for UDP rules. If you
-                                          specify UDP as the protocol but omit this
-                                          object, then all destination ports are allowed.
+                                        description: |-
+                                          UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                          If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                         properties:
                                           destinationPortRange:
                                             description: PortRange The representation
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -934,11 +855,9 @@ spec:
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -953,6 +872,11 @@ spec:
                                   description: SecurityList Name.
                                   type: string
                               type: object
+                            skip:
+                              description: |-
+                                Skip specifies whether to skip creating subnets. If set to true (default: false) the ID
+                                must be specified by the user to a valid Subnet ID.
+                              type: boolean
                             type:
                               description: Type defines the subnet type (e.g. public,
                                 private).
@@ -970,76 +894,72 @@ spec:
                     description: VCNPeering configuration.
                     properties:
                       drg:
-                        description: DRG configuration refers to the DRG which has
-                          to be created if required. If management cluster and workload
-                          cluster shares the same DRG, this fields is not required
-                          to be specified.
+                        description: |-
+                          DRG configuration refers to the DRG which has to be created if required. If management cluster
+                          and workload cluster shares the same DRG, this fields is not required to be specified.
                         properties:
                           id:
                             description: ID is the OCID for the created DRG.
                             type: string
                           manage:
-                            description: Manage defines whether the DRG has to be
-                              managed(including create). If set to false(the default)
-                              the ID has to be specified by the user to a valid DRG
-                              ID to which the VCN has to be attached.
+                            description: |-
+                              Manage defines whether the DRG has to be managed(including create). If set to false(the default) the ID
+                              has to be specified by the user to a valid DRG ID to which the VCN has to be attached.
                             type: boolean
                           name:
                             description: Name is the name of the created DRG.
                             type: string
                           vcnAttachmentId:
-                            description: VcnAttachmentId is the ID of the VCN attachment
-                              of the DRG. The workload cluster VCN can be attached
-                              to either the management cluster VCN if they are sharing
-                              the same DRG or to the workload cluster DRG.
+                            description: |-
+                              VcnAttachmentId is the ID of the VCN attachment of the DRG.
+                              The workload cluster VCN can be attached to either the management cluster VCN if they are sharing the same DRG
+                              or to the workload cluster DRG.
                             type: string
                         type: object
                       peerRouteRules:
-                        description: PeerRouteRules defines the routing rules which
-                          will be added to the private route tables of the workload
-                          cluster VCN. The routes defined here will be directed to
-                          DRG.
+                        description: |-
+                          PeerRouteRules defines the routing rules which will be added to the private route tables
+                          of the workload cluster VCN. The routes defined here will be directed to DRG.
                         items:
                           description: PeerRouteRule defines a Route Rule to be routed
                             via a DRG.
                           properties:
                             vcnCIDRRange:
-                              description: VCNCIDRRange is the CIDR Range of peer
-                                VCN to which the workload cluster VCN will be peered.
-                                The CIDR range is required to add the route rule in
-                                the workload cluster VCN, the route rule will forward
-                                any traffic to the CIDR to the DRG.
+                              description: |-
+                                VCNCIDRRange is the CIDR Range of peer VCN to which the
+                                workload cluster VCN will be peered. The CIDR range is required to add the route rule
+                                in the workload cluster VCN, the route rule will forward any traffic to the CIDR to the DRG.
                               type: string
                           type: object
                         type: array
                       remotePeeringConnections:
-                        description: RemotePeeringConnections defines the RPC connections
-                          which be established with the workload cluster DRG.
+                        description: |-
+                          RemotePeeringConnections defines the RPC connections which be established with the
+                          workload cluster DRG.
                         items:
-                          description: RemotePeeringConnection is used to peer VCNs
-                            residing in different regions(typically). Remote VCN Peering
-                            is explained here - https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/remoteVCNpeering.htm
+                          description: |-
+                            RemotePeeringConnection is used to peer VCNs residing in different regions(typically).
+                            Remote VCN Peering is explained here - https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/remoteVCNpeering.htm
                           properties:
                             managePeerRPC:
-                              description: ManagePeerRPC will define if the Peer VCN
-                                needs to be managed. If set to true a Remote Peering
-                                Connection will be created in the Peer DRG and the
-                                connection will be created between local and peer
-                                RPC.
+                              description: |-
+                                ManagePeerRPC will define if the Peer VCN needs to be managed. If set to true
+                                a Remote Peering Connection will be created in the Peer DRG and the connection
+                                will be created between local and peer RPC.
                               type: boolean
                             name:
-                              description: A unique name identifying the RPC, please
-                                note this is to identify the RPC from other RPC elements,
-                                and will not be used in any OCI API call.
+                              description: |-
+                                A unique name identifying the RPC, please note this is to identify the RPC
+                                from other RPC elements, and will not be used in any OCI API call.
                               type: string
                             peerDRGId:
                               description: PeerDRGId defines the DRG ID of the peer.
                               type: string
                             peerRPCConnectionId:
-                              description: PeerRPCConnectionId defines the RPC ID
-                                of peer. If ManagePeerRPC is set to true this will
-                                be created by Cluster API Provider for OCI, otherwise
-                                this has be defined by the user.
+                              description: |-
+                                PeerRPCConnectionId defines the RPC ID of peer. If ManagePeerRPC is set to true
+                                this will be created by Cluster API Provider for OCI, otherwise this has be defined by the
+                                user.
                               type: string
                             peerRegionName:
                               description: PeerRegionName defined the region name
@@ -1054,14 +974,15 @@ spec:
                     type: object
                 type: object
               ociResourceIdentifier:
-                description: The unique ID which will be used to tag all the resources
-                  created by this Cluster. The tag will be used to identify resources
-                  belonging to this cluster. this will be auto-generated and should
-                  not be set by the user.
+                description: |-
+                  The unique ID which will be used to tag all the resources created by this Cluster.
+                  The tag will be used to identify resources belonging to this cluster.
+                  this will be auto-generated and should not be set by the user.
                 type: string
               region:
-                description: Region the cluster operates in. It must be one of available
-                  regions in Region Identifier format. See https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm
+                description: |-
+                  Region the cluster operates in. It must be one of available regions in Region Identifier format.
+                  See https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm
                 type: string
             type: object
           status:
@@ -1082,9 +1003,9 @@ spec:
                       description: 'Name is the AD''s full name. Example: Uocm:PHX-AD-1'
                       type: string
                   type: object
-                description: AvailabilityDomains encapsulates the clusters Availability
-                  Domain (AD) information in a map where the map key is the AD name
-                  and the struct is details about the AD.
+                description: |-
+                  AvailabilityDomains encapsulates the clusters Availability Domain (AD) information in a map
+                  where the map key is the AD name and the struct is details about the AD.
                 type: object
               conditions:
                 description: NetworkSpec encapsulates all things related to OCI network.
@@ -1093,37 +1014,44 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
+                      description: status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -1133,18 +1061,18 @@ spec:
                 type: array
               failureDomains:
                 additionalProperties:
-                  description: FailureDomainSpec is the Schema for Cluster API failure
-                    domains. It allows controllers to understand how many failure
-                    domains a cluster can optionally span across.
+                  description: |-
+                    FailureDomainSpec is the Schema for Cluster API failure domains.
+                    It allows controllers to understand how many failure domains a cluster can optionally span across.
                   properties:
                     attributes:
                       additionalProperties:
                         type: string
-                      description: Attributes is a free form map of attributes an
+                      description: attributes is a free form map of attributes an
                         infrastructure provider might use or require.
                       type: object
                     controlPlane:
-                      description: ControlPlane determines if this failure domain
+                      description: controlPlane determines if this failure domain
                         is suitable for use by control plane machines.
                       type: boolean
                   type: object
@@ -1164,14 +1092,19 @@ spec:
         description: OCICluster is the Schema for the ociclusters API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -1193,9 +1126,9 @@ spec:
                       description: 'Name is the AD''s full name. Example: Uocm:PHX-AD-1'
                       type: string
                   type: object
-                description: AvailabilityDomains encapsulates the clusters Availability
-                  Domain (AD) information in a map where the map key is the AD name
-                  and the struct is details about the AD.
+                description: |-
+                  AvailabilityDomains encapsulates the clusters Availability Domain (AD) information in a map
+                  where the map key is the AD name and the struct is details about the AD.
                 type: object
               clientOverrides:
                 description: ClientOverrides allows the default client SDK URLs to
@@ -1203,9 +1136,9 @@ spec:
                 nullable: true
                 properties:
                   certOverride:
-                    description: CertOverride is a secret that contains information
-                      about a cert override used by all the OCI SDK clients. The secret
-                      must contain data with a `cert`property.
+                    description: |-
+                      CertOverride is a secret that contains information about a cert override used by all the OCI SDK clients.
+                      The secret must contain data with a `cert`property.
                     nullable: true
                     properties:
                       name:
@@ -1267,10 +1200,11 @@ spec:
                   communicate with the control plane.
                 properties:
                   host:
-                    description: The hostname on which the API server is serving.
+                    description: host is the hostname on which the API server is serving.
+                    maxLength: 512
                     type: string
                   port:
-                    description: The port on which the API server is serving.
+                    description: port is the port on which the API server is serving.
                     format: int32
                     type: integer
                 required:
@@ -1282,10 +1216,10 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
-                description: 'Defined tags for this resource. Each key is predefined
-                  and scoped to a namespace. For more information, see Resource Tags
-                  (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
-                  Example: `{"Operations": {"CostCenter": "42"}}`'
+                description: |-
+                  Defined tags for this resource. Each key is predefined and scoped to a
+                  namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+                  Example: `{"Operations": {"CostCenter": "42"}}`
                 type: object
               freeformTags:
                 additionalProperties:
@@ -1300,33 +1234,39 @@ spec:
                     description: API version of the referent.
                     type: string
                   fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
                     type: string
                   kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                     type: string
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                     type: string
                   namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                     type: string
                   resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                     type: string
                   uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
@@ -1358,15 +1298,15 @@ spec:
                                   soon as current backend becomes unhealthy.
                                 properties:
                                   urlPath:
-                                    description: 'The path against which to run the
-                                      health check. Example: `/healthcheck` Default
-                                      value is `/healthz`'
+                                    description: |-
+                                      The path against which to run the health check.
+                                      Example: `/healthcheck`
+                                      Default value is `/healthz`
                                     type: string
                                 type: object
                               isFailOpen:
-                                description: If enabled, the network load balancer
-                                  will continue to distribute traffic in the configured
-                                  distribution in the event all backends are unhealthy.
+                                description: |-
+                                  If enabled, the network load balancer will continue to distribute traffic in the configured distribution in the event all backends are unhealthy.
                                   The value is false by default.
                                 type: boolean
                               isInstantFailoverEnabled:
@@ -1375,30 +1315,29 @@ spec:
                                   soon as current backend becomes unhealthy.
                                 type: boolean
                               isPreserveSource:
-                                description: If this parameter is enabled, then the
-                                  network load balancer preserves the source IP of
-                                  the packet when it is forwarded to backends. Backends
-                                  see the original source IP. If the isPreserveSourceDestination
-                                  parameter is enabled for the network load balancer
-                                  resource, then this parameter cannot be disabled.
+                                description: |-
+                                  If this parameter is enabled, then the network load balancer preserves the source IP of the packet when it is forwarded to backends.
+                                  Backends see the original source IP. If the isPreserveSourceDestination parameter is enabled for the network load balancer resource, then this parameter cannot be disabled.
                                   The value is false by default.
                                 type: boolean
                             type: object
                         type: object
                     type: object
+                  compartmentId:
+                    description: CompartmentId where to provision network resources
+                    type: string
                   skipNetworkManagement:
-                    description: SkipNetworkManagement defines if the networking spec(VCN
-                      related) specified by the user needs to be reconciled(actioned-upon)
+                    description: |-
+                      SkipNetworkManagement defines if the networking spec(VCN related) specified by the user needs to be reconciled(actioned-upon)
                       or used as it is. APIServerLB will still be reconciled.
                     type: boolean
                   vcn:
                     description: VCN configuration.
                     properties:
-                      isIpv6Enabled:
-                        description: isIpv6Enabled enables the possibility to assign IPv6 to cluster nodes.
-                        type: boolean
                       cidr:
-                        description: VCN CIDR. Deprecated, please use NetworkDetails.cidrs
+                        description: |-
+                          VCN CIDR.
+                          Deprecated, please use NetworkDetails.cidrs
                         type: string
                       cidrs:
                         description: VCN CIDRs.
@@ -1406,17 +1345,14 @@ spec:
                           type: string
                         type: array
                       dnsLabel:
-                        description: DnsLabel specifies a DNS label for the VCN, used
-                          in conjunction with the VNIC's hostname and subnet's DNS
-                          label to form a fully qualified domain name (FQDN) for each
-                          VNIC within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
+                        description: |-
+                          DnsLabel specifies a DNS label for the VCN, used in conjunction with the VNIC's hostname and
+                          subnet's DNS label to form a fully qualified domain name (FQDN) for each VNIC
+                          within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
                         type: string
                       id:
                         description: VCN OCID.
                         type: string
-                      skip:
-                        description: Skip specifies whether to skip creating vcn
-                        type: boolean
                       internetGateway:
                         description: Configuration for Internet Gateway.
                         properties:
@@ -1424,10 +1360,19 @@ spec:
                             description: ID of Internet Gateway.
                             type: string
                           skip:
-                            description: Skip specifies whether to skip creating internet
-                              gateway even if any one Subnet is public.
+                            description: |-
+                              Skip specifies whether to skip creating internet gateway even if any one Subnet is public.
+                              In case of VCN being Skipped (Skip field of VCN set to true), this field must be true also
                             type: boolean
                         type: object
+                      isIpv6Enabled:
+                        description: Configuration to enable IPv6.
+                        type: boolean
+                      isOracleGuaAllocationEnabled:
+                        description: Configuration to allow OCI to assign IPv6 Prefix.
+                          When true will use a /56 IPv6 global unicast address (GUA)
+                          prefix allocated by Oracle
+                        type: boolean
                       name:
                         description: VCN Name.
                         type: string
@@ -1438,8 +1383,9 @@ spec:
                             description: ID of Nat Gateway.
                             type: string
                           skip:
-                            description: Skip specifies whether to skip creating NAT
-                              gateway even if any one Subnet is private.
+                            description: |-
+                              Skip specifies whether to skip creating NAT gateway even if any one Subnet is private.
+                              In case of VCN being Skipped (Skip field of VCN set to true), this field must be true also
                             type: boolean
                         type: object
                       networkSecurityGroup:
@@ -1449,8 +1395,9 @@ spec:
                             description: NetworkSecurityGroup is the configuration
                               for the Network Security Groups required in the VCN.
                             items:
-                              description: NSG defines configuration for a Network
-                                Security Group. https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/networksecuritygroups.htm
+                              description: |-
+                                NSG defines configuration for a Network Security Group.
+                                https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/networksecuritygroups.htm
                               properties:
                                 egressRules:
                                   description: EgressRules on the NSG.
@@ -1467,54 +1414,39 @@ spec:
                                               your choice for the rule.
                                             type: string
                                           destination:
-                                            description: 'Conceptually, this is the
-                                              range of IP addresses that a packet
-                                              originating from the instance can go
-                                              to. Allowed values: * IP address range
-                                              in CIDR notation. For example: `192.168.1.0/24`
-                                              or `2001:0db8:0123:45::/56` Note that
-                                              IPv6 addressing is currently supported
-                                              only in certain regions. See IPv6 Addresses
-                                              (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                              * The `cidrBlock` value for a Service,
-                                              if you''re setting up a security list
-                                              rule for traffic destined for a particular
-                                              `Service` through a service gateway.
-                                              For example: `oci-phx-objectstorage`.'
+                                            description: |-
+                                              Conceptually, this is the range of IP addresses that a packet originating from the instance
+                                              can go to.
+                                              Allowed values:
+                                                * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
+                                                  Note that IPv6 addressing is currently supported only in certain regions. See
+                                                  IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                                * The `cidrBlock` value for a Service, if you're
+                                                  setting up a security list rule for traffic destined for a particular `Service` through
+                                                  a service gateway. For example: `oci-phx-objectstorage`.
                                             type: string
                                           destinationType:
-                                            description: 'Type of destination for
-                                              the rule. The default is `CIDR_BLOCK`.
-                                              Allowed values: * `CIDR_BLOCK`: If the
-                                              rule''s `destination` is an IP address
-                                              range in CIDR notation. * `SERVICE_CIDR_BLOCK`:
-                                              If the rule''s `destination` is the
-                                              `cidrBlock` value for a Service (the
-                                              rule is for traffic destined for a particular
-                                              `Service` through a service gateway).
-                                              * `NETWORK_SECURITY_GROUP`: If the rule''s
-                                              `destination` is the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)
-                                              of a NetworkSecurityGroup.'
+                                            description: |-
+                                              Type of destination for the rule. The default is `CIDR_BLOCK`.
+                                              Allowed values:
+                                                * `CIDR_BLOCK`: If the rule's `destination` is an IP address range in CIDR notation.
+                                                * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
+                                                  Service (the rule is for traffic destined for a
+                                                  particular `Service` through a service gateway).
+                                                * `NETWORK_SECURITY_GROUP`: If the rule's `destination` is the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a
+                                                  NetworkSecurityGroup.
                                             type: string
                                           icmpOptions:
-                                            description: 'IcmpOptions Optional and
-                                              valid only for ICMP and ICMPv6. Use
-                                              to specify a particular ICMP type and
-                                              code as defined in: - ICMP Parameters
-                                              (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                            description: |-
+                                              IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                              as defined in:
+                                              - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                               - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                              If you specify ICMP or ICMPv6 as the
-                                              protocol but omit this object, then
-                                              all ICMP types and codes are allowed.
-                                              If you do provide this object, the type
-                                              is required and the code is optional.
-                                              To enable MTU negotiation for ingress
-                                              internet traffic via IPv4, make sure
-                                              to allow type 3 ("Destination Unreachable")
-                                              code 4 ("Fragmentation Needed and Don''t
-                                              Fragment was Set"). If you need to specify
-                                              multiple codes for a single type, create
-                                              a separate security list rule for each.'
+                                              If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                              codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                              To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                              Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                              multiple codes for a single type, create a separate security list rule for each.
                                             properties:
                                               code:
                                                 description: The ICMP code (optional).
@@ -1524,45 +1456,33 @@ spec:
                                                 type: integer
                                             type: object
                                           isStateless:
-                                            description: A stateless rule allows traffic
-                                              in one direction. Remember to add a
-                                              corresponding stateless rule in the
-                                              other direction if you need to support
-                                              bidirectional traffic. For example,
-                                              if egress traffic allows TCP destination
-                                              port 80, there should be an ingress
-                                              rule to allow TCP source port 80. Defaults
-                                              to false, which means the rule is stateful
-                                              and a corresponding rule is not necessary
-                                              for bidirectional traffic.
+                                            description: |-
+                                              A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                              stateless rule in the other direction if you need to support bidirectional traffic. For
+                                              example, if egress traffic allows TCP destination port 80, there should be an ingress
+                                              rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                              and a corresponding rule is not necessary for bidirectional traffic.
                                             type: boolean
                                           protocol:
-                                            description: The transport protocol. Specify
-                                              either `all` or an IPv4 protocol number
-                                              as defined in Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                              Options are supported only for ICMP
-                                              ("1"), TCP ("6"), UDP ("17"), and ICMPv6
-                                              ("58").
+                                            description: |-
+                                              The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                              defined in
+                                              Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                              Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                             type: string
                                           tcpOptions:
-                                            description: TcpOptions Optional and valid
-                                              only for TCP. Use to specify particular
-                                              destination ports for TCP rules. If
-                                              you specify TCP as the protocol but
-                                              omit this object, then all destination
-                                              ports are allowed.
+                                            description: |-
+                                              TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                              If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                             properties:
                                               destinationPortRange:
                                                 description: PortRange The representation
                                                   of PortRange.
                                                 properties:
                                                   max:
-                                                    description: The maximum port
-                                                      number, which must not be less
-                                                      than the minimum port number.
-                                                      To specify a single port number,
-                                                      set both the min and max to
-                                                      the same value.
+                                                    description: |-
+                                                      The maximum port number, which must not be less than the minimum port number. To specify
+                                                      a single port number, set both the min and max to the same value.
                                                     type: integer
                                                   min:
                                                     description: The minimum port
@@ -1575,12 +1495,9 @@ spec:
                                                   of PortRange.
                                                 properties:
                                                   max:
-                                                    description: The maximum port
-                                                      number, which must not be less
-                                                      than the minimum port number.
-                                                      To specify a single port number,
-                                                      set both the min and max to
-                                                      the same value.
+                                                    description: |-
+                                                      The maximum port number, which must not be less than the minimum port number. To specify
+                                                      a single port number, set both the min and max to the same value.
                                                     type: integer
                                                   min:
                                                     description: The minimum port
@@ -1590,24 +1507,18 @@ spec:
                                                 type: object
                                             type: object
                                           udpOptions:
-                                            description: UdpOptions Optional and valid
-                                              only for UDP. Use to specify particular
-                                              destination ports for UDP rules. If
-                                              you specify UDP as the protocol but
-                                              omit this object, then all destination
-                                              ports are allowed.
+                                            description: |-
+                                              UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                              If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                             properties:
                                               destinationPortRange:
                                                 description: PortRange The representation
                                                   of PortRange.
                                                 properties:
                                                   max:
-                                                    description: The maximum port
-                                                      number, which must not be less
-                                                      than the minimum port number.
-                                                      To specify a single port number,
-                                                      set both the min and max to
-                                                      the same value.
+                                                    description: |-
+                                                      The maximum port number, which must not be less than the minimum port number. To specify
+                                                      a single port number, set both the min and max to the same value.
                                                     type: integer
                                                   min:
                                                     description: The minimum port
@@ -1620,12 +1531,9 @@ spec:
                                                   of PortRange.
                                                 properties:
                                                   max:
-                                                    description: The maximum port
-                                                      number, which must not be less
-                                                      than the minimum port number.
-                                                      To specify a single port number,
-                                                      set both the min and max to
-                                                      the same value.
+                                                    description: |-
+                                                      The maximum port number, which must not be less than the minimum port number. To specify
+                                                      a single port number, set both the min and max to the same value.
                                                     type: integer
                                                   min:
                                                     description: The minimum port
@@ -1655,24 +1563,16 @@ spec:
                                               your choice for the rule.
                                             type: string
                                           icmpOptions:
-                                            description: 'IcmpOptions Optional and
-                                              valid only for ICMP and ICMPv6. Use
-                                              to specify a particular ICMP type and
-                                              code as defined in: - ICMP Parameters
-                                              (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                            description: |-
+                                              IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                              as defined in:
+                                              - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                               - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                              If you specify ICMP or ICMPv6 as the
-                                              protocol but omit this object, then
-                                              all ICMP types and codes are allowed.
-                                              If you do provide this object, the type
-                                              is required and the code is optional.
-                                              To enable MTU negotiation for ingress
-                                              internet traffic via IPv4, make sure
-                                              to allow type 3 ("Destination Unreachable")
-                                              code 4 ("Fragmentation Needed and Don''t
-                                              Fragment was Set"). If you need to specify
-                                              multiple codes for a single type, create
-                                              a separate security list rule for each.'
+                                              If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                              codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                              To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                              Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                              multiple codes for a single type, create a separate security list rule for each.
                                             properties:
                                               code:
                                                 description: The ICMP code (optional).
@@ -1682,74 +1582,55 @@ spec:
                                                 type: integer
                                             type: object
                                           isStateless:
-                                            description: A stateless rule allows traffic
-                                              in one direction. Remember to add a
-                                              corresponding stateless rule in the
-                                              other direction if you need to support
-                                              bidirectional traffic. For example,
-                                              if ingress traffic allows TCP destination
-                                              port 80, there should be an egress rule
-                                              to allow TCP source port 80. Defaults
-                                              to false, which means the rule is stateful
-                                              and a corresponding rule is not necessary
-                                              for bidirectional traffic.
+                                            description: |-
+                                              A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                              stateless rule in the other direction if you need to support bidirectional traffic. For
+                                              example, if ingress traffic allows TCP destination port 80, there should be an egress
+                                              rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                              and a corresponding rule is not necessary for bidirectional traffic.
                                             type: boolean
                                           protocol:
-                                            description: The transport protocol. Specify
-                                              either `all` or an IPv4 protocol number
-                                              as defined in Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                              Options are supported only for ICMP
-                                              ("1"), TCP ("6"), UDP ("17"), and ICMPv6
-                                              ("58").
+                                            description: |-
+                                              The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                              defined in
+                                              Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                              Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                             type: string
                                           source:
-                                            description: 'Conceptually, this is the
-                                              range of IP addresses that a packet
-                                              coming into the instance can come from.
-                                              Allowed values: * IP address range in
-                                              CIDR notation. For example: `192.168.1.0/24`
-                                              or `2001:0db8:0123:45::/56`. IPv6 addressing
-                                              is supported for all commercial and
-                                              government regions. See IPv6 Addresses
-                                              (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                              * The `cidrBlock` value for a Service,
-                                              if you''re setting up a security list
-                                              rule for traffic coming from a particular
-                                              `Service` through a service gateway.
-                                              For example: `oci-phx-objectstorage`.'
+                                            description: |-
+                                              Conceptually, this is the range of IP addresses that a packet coming into the instance
+                                              can come from.
+                                              Allowed values:
+                                                * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
+                                                  IPv6 addressing is supported for all commercial and government regions. See
+                                                  IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                                * The `cidrBlock` value for a Service, if you're
+                                                  setting up a security list rule for traffic coming from a particular `Service` through
+                                                  a service gateway. For example: `oci-phx-objectstorage`.
                                             type: string
                                           sourceType:
-                                            description: 'Type of source for the rule.
-                                              The default is `CIDR_BLOCK`. * `CIDR_BLOCK`:
-                                              If the rule''s `source` is an IP address
-                                              range in CIDR notation. * `SERVICE_CIDR_BLOCK`:
-                                              If the rule''s `source` is the `cidrBlock`
-                                              value for a Service (the rule is for
-                                              traffic coming from a particular `Service`
-                                              through a service gateway). * `NETWORK_SECURITY_GROUP`:
-                                              If the rule''s `destination` is the
-                                              OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)
-                                              of a NetworkSecurityGroup.'
+                                            description: |-
+                                              Type of source for the rule. The default is `CIDR_BLOCK`.
+                                                * `CIDR_BLOCK`: If the rule's `source` is an IP address range in CIDR notation.
+                                                * `SERVICE_CIDR_BLOCK`: If the rule's `source` is the `cidrBlock` value for a
+                                                  Service (the rule is for traffic coming from a
+                                                  particular `Service` through a service gateway).
+                                                * `NETWORK_SECURITY_GROUP`: If the rule's `destination` is the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a
+                                                  NetworkSecurityGroup.
                                             type: string
                                           tcpOptions:
-                                            description: TcpOptions Optional and valid
-                                              only for TCP. Use to specify particular
-                                              destination ports for TCP rules. If
-                                              you specify TCP as the protocol but
-                                              omit this object, then all destination
-                                              ports are allowed.
+                                            description: |-
+                                              TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                              If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                             properties:
                                               destinationPortRange:
                                                 description: PortRange The representation
                                                   of PortRange.
                                                 properties:
                                                   max:
-                                                    description: The maximum port
-                                                      number, which must not be less
-                                                      than the minimum port number.
-                                                      To specify a single port number,
-                                                      set both the min and max to
-                                                      the same value.
+                                                    description: |-
+                                                      The maximum port number, which must not be less than the minimum port number. To specify
+                                                      a single port number, set both the min and max to the same value.
                                                     type: integer
                                                   min:
                                                     description: The minimum port
@@ -1762,12 +1643,9 @@ spec:
                                                   of PortRange.
                                                 properties:
                                                   max:
-                                                    description: The maximum port
-                                                      number, which must not be less
-                                                      than the minimum port number.
-                                                      To specify a single port number,
-                                                      set both the min and max to
-                                                      the same value.
+                                                    description: |-
+                                                      The maximum port number, which must not be less than the minimum port number. To specify
+                                                      a single port number, set both the min and max to the same value.
                                                     type: integer
                                                   min:
                                                     description: The minimum port
@@ -1777,24 +1655,18 @@ spec:
                                                 type: object
                                             type: object
                                           udpOptions:
-                                            description: UdpOptions Optional and valid
-                                              only for UDP. Use to specify particular
-                                              destination ports for UDP rules. If
-                                              you specify UDP as the protocol but
-                                              omit this object, then all destination
-                                              ports are allowed.
+                                            description: |-
+                                              UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                              If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                             properties:
                                               destinationPortRange:
                                                 description: PortRange The representation
                                                   of PortRange.
                                                 properties:
                                                   max:
-                                                    description: The maximum port
-                                                      number, which must not be less
-                                                      than the minimum port number.
-                                                      To specify a single port number,
-                                                      set both the min and max to
-                                                      the same value.
+                                                    description: |-
+                                                      The maximum port number, which must not be less than the minimum port number. To specify
+                                                      a single port number, set both the min and max to the same value.
                                                     type: integer
                                                   min:
                                                     description: The minimum port
@@ -1807,12 +1679,9 @@ spec:
                                                   of PortRange.
                                                 properties:
                                                   max:
-                                                    description: The maximum port
-                                                      number, which must not be less
-                                                      than the minimum port number.
-                                                      To specify a single port number,
-                                                      set both the min and max to
-                                                      the same value.
+                                                    description: |-
+                                                      The maximum port number, which must not be less than the minimum port number. To specify
+                                                      a single port number, set both the min and max to the same value.
                                                     type: integer
                                                   min:
                                                     description: The minimum port
@@ -1853,8 +1722,9 @@ spec:
                             description: ID of Public Route Table.
                             type: string
                           skip:
-                            description: Skip specifies whether to skip creating Route
-                              table.
+                            description: |-
+                              Skip specifies whether to skip creating Route table.
+                              In case of VCN being Skipped (Skip field of VCN set to true), this field must be true also
                             type: boolean
                         type: object
                       serviceGateway:
@@ -1864,35 +1734,44 @@ spec:
                             description: ID of Service Gateway.
                             type: string
                           skip:
-                            description: Skip specifies whether to skip creating Service
-                              gateway.
+                            description: |-
+                              Skip specifies whether to skip creating Service gateway.
+                              In case of VCN being Skipped (Skip field of VCN set to true), this field must be true also
                             type: boolean
                         type: object
+                      skip:
+                        description: |-
+                          Skip specifies whether to skip creating VCN.
+                          When is set to true, InternetGateway, NatGateway, ServiceGateway, RouteTable must have also Skip set to true
+                          If set to true(default: false) the ID must be specified by the user to a valid VCN ID.
+                        type: boolean
                       subnets:
                         description: Subnets is the configuration for subnets required
                           in the VCN.
                         items:
-                          description: Subnet defines the configuration for a network's
-                            subnet https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingVCNs_topic-Overview_of_VCNs_and_Subnets.htm#Overview
+                          description: |-
+                            Subnet defines the configuration for a network's subnet
+                            https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingVCNs_topic-Overview_of_VCNs_and_Subnets.htm#Overview
                           properties:
                             cidr:
                               description: Subnet CIDR.
                               type: string
                             dnsLabel:
-                              description: DnsLabel DNS label for the subnet, used
-                                in conjunction with the VNIC's hostname and VCN's
-                                DNS label to form a fully qualified domain name (FQDN)
-                                for each VNIC within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
-                              type: string
-                            ipv6CidrBlockHextet:
-                              description: Subnet IPv6 CIDR.
+                              description: |-
+                                DnsLabel DNS label for the subnet, used in conjunction with the VNIC's hostname and
+                                VCN's DNS label to form a fully qualified domain name (FQDN) for each VNIC
+                                within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
                               type: string
                             id:
                               description: Subnet OCID.
                               type: string
-                            skip:
-                              description: Skip specifies whether to skip creating subnet
-                              type: boolean
+                            ipv6CidrBlockHextet:
+                              description: |-
+                                Use this to enable IPv6 hextet for this subnet. The VCN must be enabled for IPv6.
+                                You can't change this subnet characteristic later. All subnets are /64 in size. The subnet
+                                portion of the IPv6 address is the fourth hextet from the left (1111 in the following example).
+                                Example: `2001:0db8:0123:1111::/64`
+                              type: string
                             name:
                               description: Subnet Name.
                               type: string
@@ -1914,50 +1793,39 @@ spec:
                                           choice for the rule.
                                         type: string
                                       destination:
-                                        description: 'Conceptually, this is the range
-                                          of IP addresses that a packet originating
-                                          from the instance can go to. Allowed values:
-                                          * IP address range in CIDR notation. For
-                                          example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-                                          Note that IPv6 addressing is currently supported
-                                          only in certain regions. See IPv6 Addresses
-                                          (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                          * The `cidrBlock` value for a Service, if
-                                          you''re setting up a security list rule
-                                          for traffic destined for a particular `Service`
-                                          through a service gateway. For example:
-                                          `oci-phx-objectstorage`.'
+                                        description: |-
+                                          Conceptually, this is the range of IP addresses that a packet originating from the instance
+                                          can go to.
+                                          Allowed values:
+                                            * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
+                                              Note that IPv6 addressing is currently supported only in certain regions. See
+                                              IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                            * The `cidrBlock` value for a Service, if you're
+                                              setting up a security list rule for traffic destined for a particular `Service` through
+                                              a service gateway. For example: `oci-phx-objectstorage`.
                                         type: string
                                       destinationType:
-                                        description: 'Type of destination for the
-                                          rule. The default is `CIDR_BLOCK`. Allowed
-                                          values: * `CIDR_BLOCK`: If the rule''s `destination`
-                                          is an IP address range in CIDR notation.
-                                          * `SERVICE_CIDR_BLOCK`: If the rule''s `destination`
-                                          is the `cidrBlock` value for a Service (the
-                                          rule is for traffic destined for a particular
-                                          `Service` through a service gateway). *
-                                          `NETWORK_SECURITY_GROUP`: If the rule''s
-                                          `destination` is the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)
-                                          of a NetworkSecurityGroup.'
+                                        description: |-
+                                          Type of destination for the rule. The default is `CIDR_BLOCK`.
+                                          Allowed values:
+                                            * `CIDR_BLOCK`: If the rule's `destination` is an IP address range in CIDR notation.
+                                            * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
+                                              Service (the rule is for traffic destined for a
+                                              particular `Service` through a service gateway).
+                                            * `NETWORK_SECURITY_GROUP`: If the rule's `destination` is the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a
+                                              NetworkSecurityGroup.
                                         type: string
                                       icmpOptions:
-                                        description: 'IcmpOptions Optional and valid
-                                          only for ICMP and ICMPv6. Use to specify
-                                          a particular ICMP type and code as defined
-                                          in: - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                        description: |-
+                                          IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                          as defined in:
+                                          - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                           - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                          If you specify ICMP or ICMPv6 as the protocol
-                                          but omit this object, then all ICMP types
-                                          and codes are allowed. If you do provide
-                                          this object, the type is required and the
-                                          code is optional. To enable MTU negotiation
-                                          for ingress internet traffic via IPv4, make
-                                          sure to allow type 3 ("Destination Unreachable")
-                                          code 4 ("Fragmentation Needed and Don''t
-                                          Fragment was Set"). If you need to specify
-                                          multiple codes for a single type, create
-                                          a separate security list rule for each.'
+                                          If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                          codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                          To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                          Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                          multiple codes for a single type, create a separate security list rule for each.
                                         properties:
                                           code:
                                             description: The ICMP code (optional).
@@ -1967,41 +1835,33 @@ spec:
                                             type: integer
                                         type: object
                                       isStateless:
-                                        description: A stateless rule allows traffic
-                                          in one direction. Remember to add a corresponding
-                                          stateless rule in the other direction if
-                                          you need to support bidirectional traffic.
-                                          For example, if egress traffic allows TCP
-                                          destination port 80, there should be an
-                                          ingress rule to allow TCP source port 80.
-                                          Defaults to false, which means the rule
-                                          is stateful and a corresponding rule is
-                                          not necessary for bidirectional traffic.
+                                        description: |-
+                                          A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                          stateless rule in the other direction if you need to support bidirectional traffic. For
+                                          example, if egress traffic allows TCP destination port 80, there should be an ingress
+                                          rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                          and a corresponding rule is not necessary for bidirectional traffic.
                                         type: boolean
                                       protocol:
-                                        description: The transport protocol. Specify
-                                          either `all` or an IPv4 protocol number
-                                          as defined in Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                          Options are supported only for ICMP ("1"),
-                                          TCP ("6"), UDP ("17"), and ICMPv6 ("58").
+                                        description: |-
+                                          The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                          defined in
+                                          Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                          Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                         type: string
                                       tcpOptions:
-                                        description: TcpOptions Optional and valid
-                                          only for TCP. Use to specify particular
-                                          destination ports for TCP rules. If you
-                                          specify TCP as the protocol but omit this
-                                          object, then all destination ports are allowed.
+                                        description: |-
+                                          TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                          If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                         properties:
                                           destinationPortRange:
                                             description: PortRange The representation
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -2014,11 +1874,9 @@ spec:
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -2028,22 +1886,18 @@ spec:
                                             type: object
                                         type: object
                                       udpOptions:
-                                        description: UdpOptions Optional and valid
-                                          only for UDP. Use to specify particular
-                                          destination ports for UDP rules. If you
-                                          specify UDP as the protocol but omit this
-                                          object, then all destination ports are allowed.
+                                        description: |-
+                                          UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                          If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                         properties:
                                           destinationPortRange:
                                             description: PortRange The representation
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -2056,11 +1910,9 @@ spec:
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -2085,22 +1937,16 @@ spec:
                                           choice for the rule.
                                         type: string
                                       icmpOptions:
-                                        description: 'IcmpOptions Optional and valid
-                                          only for ICMP and ICMPv6. Use to specify
-                                          a particular ICMP type and code as defined
-                                          in: - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                        description: |-
+                                          IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                          as defined in:
+                                          - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                           - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                          If you specify ICMP or ICMPv6 as the protocol
-                                          but omit this object, then all ICMP types
-                                          and codes are allowed. If you do provide
-                                          this object, the type is required and the
-                                          code is optional. To enable MTU negotiation
-                                          for ingress internet traffic via IPv4, make
-                                          sure to allow type 3 ("Destination Unreachable")
-                                          code 4 ("Fragmentation Needed and Don''t
-                                          Fragment was Set"). If you need to specify
-                                          multiple codes for a single type, create
-                                          a separate security list rule for each.'
+                                          If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                          codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                          To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                          Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                          multiple codes for a single type, create a separate security list rule for each.
                                         properties:
                                           code:
                                             description: The ICMP code (optional).
@@ -2110,69 +1956,55 @@ spec:
                                             type: integer
                                         type: object
                                       isStateless:
-                                        description: A stateless rule allows traffic
-                                          in one direction. Remember to add a corresponding
-                                          stateless rule in the other direction if
-                                          you need to support bidirectional traffic.
-                                          For example, if ingress traffic allows TCP
-                                          destination port 80, there should be an
-                                          egress rule to allow TCP source port 80.
-                                          Defaults to false, which means the rule
-                                          is stateful and a corresponding rule is
-                                          not necessary for bidirectional traffic.
+                                        description: |-
+                                          A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                          stateless rule in the other direction if you need to support bidirectional traffic. For
+                                          example, if ingress traffic allows TCP destination port 80, there should be an egress
+                                          rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                          and a corresponding rule is not necessary for bidirectional traffic.
                                         type: boolean
                                       protocol:
-                                        description: The transport protocol. Specify
-                                          either `all` or an IPv4 protocol number
-                                          as defined in Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                          Options are supported only for ICMP ("1"),
-                                          TCP ("6"), UDP ("17"), and ICMPv6 ("58").
+                                        description: |-
+                                          The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                          defined in
+                                          Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                          Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                         type: string
                                       source:
-                                        description: 'Conceptually, this is the range
-                                          of IP addresses that a packet coming into
-                                          the instance can come from. Allowed values:
-                                          * IP address range in CIDR notation. For
-                                          example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
-                                          IPv6 addressing is supported for all commercial
-                                          and government regions. See IPv6 Addresses
-                                          (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                          * The `cidrBlock` value for a Service, if
-                                          you''re setting up a security list rule
-                                          for traffic coming from a particular `Service`
-                                          through a service gateway. For example:
-                                          `oci-phx-objectstorage`.'
+                                        description: |-
+                                          Conceptually, this is the range of IP addresses that a packet coming into the instance
+                                          can come from.
+                                          Allowed values:
+                                            * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
+                                              IPv6 addressing is supported for all commercial and government regions. See
+                                              IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                            * The `cidrBlock` value for a Service, if you're
+                                              setting up a security list rule for traffic coming from a particular `Service` through
+                                              a service gateway. For example: `oci-phx-objectstorage`.
                                         type: string
                                       sourceType:
-                                        description: 'Type of source for the rule.
-                                          The default is `CIDR_BLOCK`. * `CIDR_BLOCK`:
-                                          If the rule''s `source` is an IP address
-                                          range in CIDR notation. * `SERVICE_CIDR_BLOCK`:
-                                          If the rule''s `source` is the `cidrBlock`
-                                          value for a Service (the rule is for traffic
-                                          coming from a particular `Service` through
-                                          a service gateway). * `NETWORK_SECURITY_GROUP`:
-                                          If the rule''s `destination` is the OCID
-                                          (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)
-                                          of a NetworkSecurityGroup.'
+                                        description: |-
+                                          Type of source for the rule. The default is `CIDR_BLOCK`.
+                                            * `CIDR_BLOCK`: If the rule's `source` is an IP address range in CIDR notation.
+                                            * `SERVICE_CIDR_BLOCK`: If the rule's `source` is the `cidrBlock` value for a
+                                              Service (the rule is for traffic coming from a
+                                              particular `Service` through a service gateway).
+                                            * `NETWORK_SECURITY_GROUP`: If the rule's `destination` is the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a
+                                              NetworkSecurityGroup.
                                         type: string
                                       tcpOptions:
-                                        description: TcpOptions Optional and valid
-                                          only for TCP. Use to specify particular
-                                          destination ports for TCP rules. If you
-                                          specify TCP as the protocol but omit this
-                                          object, then all destination ports are allowed.
+                                        description: |-
+                                          TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                          If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                         properties:
                                           destinationPortRange:
                                             description: PortRange The representation
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -2185,11 +2017,9 @@ spec:
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -2199,22 +2029,18 @@ spec:
                                             type: object
                                         type: object
                                       udpOptions:
-                                        description: UdpOptions Optional and valid
-                                          only for UDP. Use to specify particular
-                                          destination ports for UDP rules. If you
-                                          specify UDP as the protocol but omit this
-                                          object, then all destination ports are allowed.
+                                        description: |-
+                                          UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                          If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                         properties:
                                           destinationPortRange:
                                             description: PortRange The representation
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -2227,11 +2053,9 @@ spec:
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -2246,6 +2070,11 @@ spec:
                                   description: SecurityList Name.
                                   type: string
                               type: object
+                            skip:
+                              description: |-
+                                Skip specifies whether to skip creating subnets. If set to true(default: false) the ID
+                                must be specified by the user to a valid Subnet ID.
+                              type: boolean
                             type:
                               description: Type defines the subnet type (e.g. public,
                                 private).
@@ -2263,76 +2092,72 @@ spec:
                     description: VCNPeering configuration.
                     properties:
                       drg:
-                        description: DRG configuration refers to the DRG which has
-                          to be created if required. If management cluster and workload
-                          cluster shares the same DRG, this fields is not required
-                          to be specified.
+                        description: |-
+                          DRG configuration refers to the DRG which has to be created if required. If management cluster
+                          and workload cluster shares the same DRG, this fields is not required to be specified.
                         properties:
                           id:
                             description: ID is the OCID for the created DRG.
                             type: string
                           manage:
-                            description: Manage defines whether the DRG has to be
-                              managed(including create). If set to false(the default)
-                              the ID has to be specified by the user to a valid DRG
-                              ID to which the VCN has to be attached.
+                            description: |-
+                              Manage defines whether the DRG has to be managed(including create). If set to false(the default) the ID
+                              has to be specified by the user to a valid DRG ID to which the VCN has to be attached.
                             type: boolean
                           name:
                             description: Name is the name of the created DRG.
                             type: string
                           vcnAttachmentId:
-                            description: VcnAttachmentId is the ID of the VCN attachment
-                              of the DRG. The workload cluster VCN can be attached
-                              to either the management cluster VCN if they are sharing
-                              the same DRG or to the workload cluster DRG.
+                            description: |-
+                              VcnAttachmentId is the ID of the VCN attachment of the DRG.
+                              The workload cluster VCN can be attached to either the management cluster VCN if they are sharing the same DRG
+                              or to the workload cluster DRG.
                             type: string
                         type: object
                       peerRouteRules:
-                        description: PeerRouteRules defines the routing rules which
-                          will be added to the private route tables of the workload
-                          cluster VCN. The routes defined here will be directed to
-                          DRG.
+                        description: |-
+                          PeerRouteRules defines the routing rules which will be added to the private route tables
+                          of the workload cluster VCN. The routes defined here will be directed to DRG.
                         items:
                           description: PeerRouteRule defines a Route Rule to be routed
                             via a DRG.
                           properties:
                             vcnCIDRRange:
-                              description: VCNCIDRRange is the CIDR Range of peer
-                                VCN to which the workload cluster VCN will be peered.
-                                The CIDR range is required to add the route rule in
-                                the workload cluster VCN, the route rule will forward
-                                any traffic to the CIDR to the DRG.
+                              description: |-
+                                VCNCIDRRange is the CIDR Range of peer VCN to which the
+                                workload cluster VCN will be peered. The CIDR range is required to add the route rule
+                                in the workload cluster VCN, the route rule will forward any traffic to the CIDR to the DRG.
                               type: string
                           type: object
                         type: array
                       remotePeeringConnections:
-                        description: RemotePeeringConnections defines the RPC connections
-                          which be established with the workload cluster DRG.
+                        description: |-
+                          RemotePeeringConnections defines the RPC connections which be established with the
+                          workload cluster DRG.
                         items:
-                          description: RemotePeeringConnection is used to peer VCNs
-                            residing in different regions(typically). Remote VCN Peering
-                            is explained here - https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/remoteVCNpeering.htm
+                          description: |-
+                            RemotePeeringConnection is used to peer VCNs residing in different regions(typically).
+                            Remote VCN Peering is explained here - https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/remoteVCNpeering.htm
                           properties:
                             managePeerRPC:
-                              description: ManagePeerRPC will define if the Peer VCN
-                                needs to be managed. If set to true a Remote Peering
-                                Connection will be created in the Peer DRG and the
-                                connection will be created between local and peer
-                                RPC.
+                              description: |-
+                                ManagePeerRPC will define if the Peer VCN needs to be managed. If set to true
+                                a Remote Peering Connection will be created in the Peer DRG and the connection
+                                will be created between local and peer RPC.
                               type: boolean
                             name:
-                              description: A unique name identifying the RPC, please
-                                note this is to identify the RPC from other RPC elements,
-                                and will not be used in any OCI API call.
+                              description: |-
+                                A unique name identifying the RPC, please note this is to identify the RPC
+                                from other RPC elements, and will not be used in any OCI API call.
                               type: string
                             peerDRGId:
                               description: PeerDRGId defines the DRG ID of the peer.
                               type: string
                             peerRPCConnectionId:
-                              description: PeerRPCConnectionId defines the RPC ID
-                                of peer. If ManagePeerRPC is set to true this will
-                                be created by Cluster API Provider for OCI, otherwise
-                                this has be defined by the user.
+                              description: |-
+                                PeerRPCConnectionId defines the RPC ID of peer. If ManagePeerRPC is set to true
+                                this will be created by Cluster API Provider for OCI, otherwise this has be defined by the
+                                user.
                               type: string
                             peerRegionName:
                               description: PeerRegionName defined the region name
@@ -2347,14 +2172,15 @@ spec:
                     type: object
                 type: object
               ociResourceIdentifier:
-                description: The unique ID which will be used to tag all the resources
-                  created by this Cluster. The tag will be used to identify resources
-                  belonging to this cluster. this will be auto-generated and should
-                  not be set by the user.
+                description: |-
+                  The unique ID which will be used to tag all the resources created by this Cluster.
+                  The tag will be used to identify resources belonging to this cluster.
+                  this will be auto-generated and should not be set by the user.
                 type: string
               region:
-                description: Region the cluster operates in. It must be one of available
-                  regions in Region Identifier format. See https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm
+                description: |-
+                  Region the cluster operates in. It must be one of available regions in Region Identifier format.
+                  See https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm
                 type: string
             type: object
           status:
@@ -2367,37 +2193,44 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
+                      description: status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -2407,18 +2240,18 @@ spec:
                 type: array
               failureDomains:
                 additionalProperties:
-                  description: FailureDomainSpec is the Schema for Cluster API failure
-                    domains. It allows controllers to understand how many failure
-                    domains a cluster can optionally span across.
+                  description: |-
+                    FailureDomainSpec is the Schema for Cluster API failure domains.
+                    It allows controllers to understand how many failure domains a cluster can optionally span across.
                   properties:
                     attributes:
                       additionalProperties:
                         type: string
-                      description: Attributes is a free form map of attributes an
+                      description: attributes is a free form map of attributes an
                         infrastructure provider might use or require.
                       type: object
                     controlPlane:
-                      description: ControlPlane determines if this failure domain
+                      description: controlPlane determines if this failure domain
                         is suitable for use by control plane machines.
                       type: boolean
                   type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ociclustertemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: ociclustertemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -23,14 +23,19 @@ spec:
           API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -52,10 +57,13 @@ spec:
                           used to communicate with the control plane.
                         properties:
                           host:
-                            description: The hostname on which the API server is serving.
+                            description: host is the hostname on which the API server
+                              is serving.
+                            maxLength: 512
                             type: string
                           port:
-                            description: The port on which the API server is serving.
+                            description: port is the port on which the API server
+                              is serving.
                             format: int32
                             type: integer
                         required:
@@ -67,10 +75,10 @@ spec:
                           additionalProperties:
                             type: string
                           type: object
-                        description: 'Defined tags for this resource. Each key is
-                          predefined and scoped to a namespace. For more information,
-                          see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
-                          Example: `{"Operations": {"CostCenter": "42"}}`'
+                        description: |-
+                          Defined tags for this resource. Each key is predefined and scoped to a
+                          namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+                          Example: `{"Operations": {"CostCenter": "42"}}`
                         type: object
                       freeformTags:
                         additionalProperties:
@@ -85,34 +93,39 @@ spec:
                             description: API version of the referent.
                             type: string
                           fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
                             type: string
                           kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                             type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                             type: string
                           namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                             type: string
                           resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                             type: string
                           uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
@@ -143,17 +156,16 @@ spec:
                                           unhealthy.
                                         properties:
                                           urlPath:
-                                            description: 'The path against which to
-                                              run the health check. Example: `/healthcheck`
-                                              Default value is `/healthz`'
+                                            description: |-
+                                              The path against which to run the health check.
+                                              Example: `/healthcheck`
+                                              Default value is `/healthz`
                                             type: string
                                         type: object
                                       isFailOpen:
-                                        description: If enabled, the network load
-                                          balancer will continue to distribute traffic
-                                          in the configured distribution in the event
-                                          all backends are unhealthy. The value is
-                                          false by default.
+                                        description: |-
+                                          If enabled, the network load balancer will continue to distribute traffic in the configured distribution in the event all backends are unhealthy.
+                                          The value is false by default.
                                         type: boolean
                                       isInstantFailoverEnabled:
                                         description: If enabled existing connections
@@ -162,29 +174,30 @@ spec:
                                           unhealthy.
                                         type: boolean
                                       isPreserveSource:
-                                        description: If this parameter is enabled,
-                                          then the network load balancer preserves
-                                          the source IP of the packet when it is forwarded
-                                          to backends. Backends see the original source
-                                          IP. If the isPreserveSourceDestination parameter
-                                          is enabled for the network load balancer
-                                          resource, then this parameter cannot be
-                                          disabled. The value is false by default.
+                                        description: |-
+                                          If this parameter is enabled, then the network load balancer preserves the source IP of the packet when it is forwarded to backends.
+                                          Backends see the original source IP. If the isPreserveSourceDestination parameter is enabled for the network load balancer resource, then this parameter cannot be disabled.
+                                          The value is false by default.
                                         type: boolean
                                     type: object
                                 type: object
                             type: object
+                          compartmentId:
+                            description: CompartmentId where to provision network
+                              resources
+                            type: string
                           skipNetworkManagement:
-                            description: SkipNetworkManagement defines if the networking
-                              spec(VCN related) specified by the user needs to be
-                              reconciled(actioned-upon) or used as it is. APIServerLB
-                              will still be reconciled.
+                            description: |-
+                              SkipNetworkManagement defines if the networking spec(VCN related) specified by the user needs to be reconciled(actioned-upon)
+                              or used as it is. APIServerLB will still be reconciled.
                             type: boolean
                           vcn:
                             description: VCN configuration.
                             properties:
                               cidr:
-                                description: VCN CIDR. Deprecated, please use NetworkDetails.cidrs
+                                description: |-
+                                  VCN CIDR.
+                                  Deprecated, please use NetworkDetails.cidrs
                                 type: string
                               cidrs:
                                 description: VCN CIDRs.
@@ -192,21 +205,25 @@ spec:
                                   type: string
                                 type: array
                               dnsLabel:
-                                description: DnsLabel specifies a DNS label for the
-                                  VCN, used in conjunction with the VNIC's hostname
-                                  and subnet's DNS label to form a fully qualified
-                                  domain name (FQDN) for each VNIC within this subnet
-                                  (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
+                                description: |-
+                                  DnsLabel specifies a DNS label for the VCN, used in conjunction with the VNIC's hostname and
+                                  subnet's DNS label to form a fully qualified domain name (FQDN) for each VNIC
+                                  within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
                                 type: string
                               id:
                                 description: VCN OCID.
                                 type: string
-                              skip:
-                                description: Skip specifies whether to skip creating vcn
-                                type: boolean
                               internetGatewayId:
                                 description: ID of Internet Gateway.
                                 type: string
+                              isIpv6Enabled:
+                                description: Configuration to enable IPv6.
+                                type: boolean
+                              isOracleGuaAllocationEnabled:
+                                description: Configuration to allow OCI to assign
+                                  IPv6 Prefix. When true will use a /56 IPv6 global
+                                  unicast address (GUA) prefix allocated by Oracle
+                                type: boolean
                               name:
                                 description: VCN Name.
                                 type: string
@@ -218,8 +235,9 @@ spec:
                                   for the Network Security Groups required in the
                                   VCN.
                                 items:
-                                  description: NSG defines configuration for a Network
-                                    Security Group. https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/networksecuritygroups.htm
+                                  description: |-
+                                    NSG defines configuration for a Network Security Group.
+                                    https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/networksecuritygroups.htm
                                   properties:
                                     egressRules:
                                       description: EgressRules on the NSG.
@@ -236,55 +254,37 @@ spec:
                                                   of your choice for the rule.
                                                 type: string
                                               destination:
-                                                description: 'Conceptually, this is
-                                                  the range of IP addresses that a
-                                                  packet originating from the instance
-                                                  can go to. Allowed values: * IP
-                                                  address range in CIDR notation.
-                                                  For example: `192.168.1.0/24` or
-                                                  `2001:0db8:0123:45::/56` Note that
-                                                  IPv6 addressing is currently supported
-                                                  only in certain regions. See IPv6
-                                                  Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                                  * The `cidrBlock` value for a Service,
-                                                  if you''re setting up a security
-                                                  list rule for traffic destined for
-                                                  a particular `Service` through a
-                                                  service gateway. For example: `oci-phx-objectstorage`.'
+                                                description: |-
+                                                  Conceptually, this is the range of IP addresses that a packet originating from the instance
+                                                  can go to.
+                                                  Allowed values:
+                                                    * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
+                                                      Note that IPv6 addressing is currently supported only in certain regions. See
+                                                      IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                                    * The `cidrBlock` value for a Service, if you're
+                                                      setting up a security list rule for traffic destined for a particular `Service` through
+                                                      a service gateway. For example: `oci-phx-objectstorage`.
                                                 type: string
                                               destinationType:
-                                                description: 'Type of destination
-                                                  for the rule. The default is `CIDR_BLOCK`.
-                                                  Allowed values: * `CIDR_BLOCK`:
-                                                  If the rule''s `destination` is
-                                                  an IP address range in CIDR notation.
-                                                  * `SERVICE_CIDR_BLOCK`: If the rule''s
-                                                  `destination` is the `cidrBlock`
-                                                  value for a Service (the rule is
-                                                  for traffic destined for a particular
-                                                  `Service` through a service gateway).'
+                                                description: |-
+                                                  Type of destination for the rule. The default is `CIDR_BLOCK`.
+                                                  Allowed values:
+                                                    * `CIDR_BLOCK`: If the rule's `destination` is an IP address range in CIDR notation.
+                                                    * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
+                                                      Service (the rule is for traffic destined for a
+                                                      particular `Service` through a service gateway).
                                                 type: string
                                               icmpOptions:
-                                                description: 'IcmpOptions Optional
-                                                  and valid only for ICMP and ICMPv6.
-                                                  Use to specify a particular ICMP
-                                                  type and code as defined in: - ICMP
-                                                  Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                                description: |-
+                                                  IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                                  as defined in:
+                                                  - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                                   - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                                  If you specify ICMP or ICMPv6 as
-                                                  the protocol but omit this object,
-                                                  then all ICMP types and codes are
-                                                  allowed. If you do provide this
-                                                  object, the type is required and
-                                                  the code is optional. To enable
-                                                  MTU negotiation for ingress internet
-                                                  traffic via IPv4, make sure to allow
-                                                  type 3 ("Destination Unreachable")
-                                                  code 4 ("Fragmentation Needed and
-                                                  Don''t Fragment was Set"). If you
-                                                  need to specify multiple codes for
-                                                  a single type, create a separate
-                                                  security list rule for each.'
+                                                  If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                                  codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                                  To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                                  Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                                  multiple codes for a single type, create a separate security list rule for each.
                                                 properties:
                                                   code:
                                                     description: The ICMP code (optional).
@@ -294,48 +294,33 @@ spec:
                                                     type: integer
                                                 type: object
                                               isStateless:
-                                                description: A stateless rule allows
-                                                  traffic in one direction. Remember
-                                                  to add a corresponding stateless
-                                                  rule in the other direction if you
-                                                  need to support bidirectional traffic.
-                                                  For example, if egress traffic allows
-                                                  TCP destination port 80, there should
-                                                  be an ingress rule to allow TCP
-                                                  source port 80. Defaults to false,
-                                                  which means the rule is stateful
-                                                  and a corresponding rule is not
-                                                  necessary for bidirectional traffic.
+                                                description: |-
+                                                  A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                                  stateless rule in the other direction if you need to support bidirectional traffic. For
+                                                  example, if egress traffic allows TCP destination port 80, there should be an ingress
+                                                  rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                                  and a corresponding rule is not necessary for bidirectional traffic.
                                                 type: boolean
                                               protocol:
-                                                description: The transport protocol.
-                                                  Specify either `all` or an IPv4
-                                                  protocol number as defined in Protocol
-                                                  Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                                  Options are supported only for ICMP
-                                                  ("1"), TCP ("6"), UDP ("17"), and
-                                                  ICMPv6 ("58").
+                                                description: |-
+                                                  The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                                  defined in
+                                                  Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                                  Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                                 type: string
                                               tcpOptions:
-                                                description: TcpOptions Optional and
-                                                  valid only for TCP. Use to specify
-                                                  particular destination ports for
-                                                  TCP rules. If you specify TCP as
-                                                  the protocol but omit this object,
-                                                  then all destination ports are allowed.
+                                                description: |-
+                                                  TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                                  If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                                 properties:
                                                   destinationPortRange:
                                                     description: PortRange The representation
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -349,13 +334,9 @@ spec:
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -366,25 +347,18 @@ spec:
                                                     type: object
                                                 type: object
                                               udpOptions:
-                                                description: UdpOptions Optional and
-                                                  valid only for UDP. Use to specify
-                                                  particular destination ports for
-                                                  UDP rules. If you specify UDP as
-                                                  the protocol but omit this object,
-                                                  then all destination ports are allowed.
+                                                description: |-
+                                                  UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                                  If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                                 properties:
                                                   destinationPortRange:
                                                     description: PortRange The representation
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -398,13 +372,9 @@ spec:
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -416,9 +386,9 @@ spec:
                                                 type: object
                                             type: object
                                           id:
-                                            description: 'EgressSecurityRule ID for
-                                              NSG. Deprecated: this field is not populated
-                                              and used during reconciliation'
+                                            description: |-
+                                              EgressSecurityRule ID for NSG.
+                                              Deprecated: this field is not populated and used during reconciliation
                                             type: string
                                         type: object
                                       type: array
@@ -432,9 +402,9 @@ spec:
                                           IngressSecurityRule for NSG
                                         properties:
                                           id:
-                                            description: 'IngressSecurityRule ID for
-                                              NSG. Deprecated: this field is not populated
-                                              and used during reconciliation'
+                                            description: |-
+                                              IngressSecurityRule ID for NSG.
+                                              Deprecated: this field is not populated and used during reconciliation
                                             type: string
                                           ingressRule:
                                             description: IngressSecurityRule A rule
@@ -445,26 +415,16 @@ spec:
                                                   of your choice for the rule.
                                                 type: string
                                               icmpOptions:
-                                                description: 'IcmpOptions Optional
-                                                  and valid only for ICMP and ICMPv6.
-                                                  Use to specify a particular ICMP
-                                                  type and code as defined in: - ICMP
-                                                  Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                                description: |-
+                                                  IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                                  as defined in:
+                                                  - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                                   - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                                  If you specify ICMP or ICMPv6 as
-                                                  the protocol but omit this object,
-                                                  then all ICMP types and codes are
-                                                  allowed. If you do provide this
-                                                  object, the type is required and
-                                                  the code is optional. To enable
-                                                  MTU negotiation for ingress internet
-                                                  traffic via IPv4, make sure to allow
-                                                  type 3 ("Destination Unreachable")
-                                                  code 4 ("Fragmentation Needed and
-                                                  Don''t Fragment was Set"). If you
-                                                  need to specify multiple codes for
-                                                  a single type, create a separate
-                                                  security list rule for each.'
+                                                  If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                                  codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                                  To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                                  Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                                  multiple codes for a single type, create a separate security list rule for each.
                                                 properties:
                                                   code:
                                                     description: The ICMP code (optional).
@@ -474,77 +434,53 @@ spec:
                                                     type: integer
                                                 type: object
                                               isStateless:
-                                                description: A stateless rule allows
-                                                  traffic in one direction. Remember
-                                                  to add a corresponding stateless
-                                                  rule in the other direction if you
-                                                  need to support bidirectional traffic.
-                                                  For example, if ingress traffic
-                                                  allows TCP destination port 80,
-                                                  there should be an egress rule to
-                                                  allow TCP source port 80. Defaults
-                                                  to false, which means the rule is
-                                                  stateful and a corresponding rule
-                                                  is not necessary for bidirectional
-                                                  traffic.
+                                                description: |-
+                                                  A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                                  stateless rule in the other direction if you need to support bidirectional traffic. For
+                                                  example, if ingress traffic allows TCP destination port 80, there should be an egress
+                                                  rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                                  and a corresponding rule is not necessary for bidirectional traffic.
                                                 type: boolean
                                               protocol:
-                                                description: The transport protocol.
-                                                  Specify either `all` or an IPv4
-                                                  protocol number as defined in Protocol
-                                                  Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                                  Options are supported only for ICMP
-                                                  ("1"), TCP ("6"), UDP ("17"), and
-                                                  ICMPv6 ("58").
+                                                description: |-
+                                                  The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                                  defined in
+                                                  Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                                  Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                                 type: string
                                               source:
-                                                description: 'Conceptually, this is
-                                                  the range of IP addresses that a
-                                                  packet coming into the instance
-                                                  can come from. Allowed values: *
-                                                  IP address range in CIDR notation.
-                                                  For example: `192.168.1.0/24` or
-                                                  `2001:0db8:0123:45::/56`. IPv6 addressing
-                                                  is supported for all commercial
-                                                  and government regions. See IPv6
-                                                  Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                                  * The `cidrBlock` value for a Service,
-                                                  if you''re setting up a security
-                                                  list rule for traffic coming from
-                                                  a particular `Service` through a
-                                                  service gateway. For example: `oci-phx-objectstorage`.'
+                                                description: |-
+                                                  Conceptually, this is the range of IP addresses that a packet coming into the instance
+                                                  can come from.
+                                                  Allowed values:
+                                                    * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
+                                                      IPv6 addressing is supported for all commercial and government regions. See
+                                                      IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                                    * The `cidrBlock` value for a Service, if you're
+                                                      setting up a security list rule for traffic coming from a particular `Service` through
+                                                      a service gateway. For example: `oci-phx-objectstorage`.
                                                 type: string
                                               sourceType:
-                                                description: 'Type of source for the
-                                                  rule. The default is `CIDR_BLOCK`.
-                                                  * `CIDR_BLOCK`: If the rule''s `source`
-                                                  is an IP address range in CIDR notation.
-                                                  * `SERVICE_CIDR_BLOCK`: If the rule''s
-                                                  `source` is the `cidrBlock` value
-                                                  for a Service (the rule is for traffic
-                                                  coming from a particular `Service`
-                                                  through a service gateway).'
+                                                description: |-
+                                                  Type of source for the rule. The default is `CIDR_BLOCK`.
+                                                    * `CIDR_BLOCK`: If the rule's `source` is an IP address range in CIDR notation.
+                                                    * `SERVICE_CIDR_BLOCK`: If the rule's `source` is the `cidrBlock` value for a
+                                                      Service (the rule is for traffic coming from a
+                                                      particular `Service` through a service gateway).
                                                 type: string
                                               tcpOptions:
-                                                description: TcpOptions Optional and
-                                                  valid only for TCP. Use to specify
-                                                  particular destination ports for
-                                                  TCP rules. If you specify TCP as
-                                                  the protocol but omit this object,
-                                                  then all destination ports are allowed.
+                                                description: |-
+                                                  TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                                  If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                                 properties:
                                                   destinationPortRange:
                                                     description: PortRange The representation
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -558,13 +494,9 @@ spec:
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -575,25 +507,18 @@ spec:
                                                     type: object
                                                 type: object
                                               udpOptions:
-                                                description: UdpOptions Optional and
-                                                  valid only for UDP. Use to specify
-                                                  particular destination ports for
-                                                  UDP rules. If you specify UDP as
-                                                  the protocol but omit this object,
-                                                  then all destination ports are allowed.
+                                                description: |-
+                                                  UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                                  If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                                 properties:
                                                   destinationPortRange:
                                                     description: PortRange The representation
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -607,13 +532,9 @@ spec:
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -650,29 +571,39 @@ spec:
                               serviceGatewayId:
                                 description: ID of Service Gateway.
                                 type: string
+                              skip:
+                                description: |-
+                                  Skip specifies whether to skip creating VCN.
+                                  When is set to true, InternetGateway, NatGateway, ServiceGateway, RouteTable must have also Skip set to true
+                                  If set to true(default: false) the ID must be specified by the user to a valid VCN ID.
+                                type: boolean
                               subnets:
                                 description: Subnets is the configuration for subnets
                                   required in the VCN.
                                 items:
-                                  description: Subnet defines the configuration for
-                                    a network's subnet https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingVCNs_topic-Overview_of_VCNs_and_Subnets.htm#Overview
+                                  description: |-
+                                    Subnet defines the configuration for a network's subnet
+                                    https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingVCNs_topic-Overview_of_VCNs_and_Subnets.htm#Overview
                                   properties:
                                     cidr:
                                       description: Subnet CIDR.
                                       type: string
                                     dnsLabel:
-                                      description: DnsLabel DNS label for the subnet,
-                                        used in conjunction with the VNIC's hostname
-                                        and VCN's DNS label to form a fully qualified
-                                        domain name (FQDN) for each VNIC within this
-                                        subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
+                                      description: |-
+                                        DnsLabel DNS label for the subnet, used in conjunction with the VNIC's hostname and
+                                        VCN's DNS label to form a fully qualified domain name (FQDN) for each VNIC
+                                        within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
                                       type: string
                                     id:
                                       description: Subnet OCID.
                                       type: string
-                                    skip:
-                                      description: Skip specifies whether to skip creating subnet
-                                      type: boolean
+                                    ipv6CidrBlockHextet:
+                                      description: |-
+                                        Use this to enable IPv6 hextet for this subnet. The VCN must be enabled for IPv6.
+                                        You can't change this subnet characteristic later. All subnets are /64 in size. The subnet
+                                        portion of the IPv6 address is the fourth hextet from the left (1111 in the following example).
+                                        Example: `2001:0db8:0123:1111::/64`
+                                      type: string
                                     name:
                                       description: Subnet Name.
                                       type: string
@@ -696,55 +627,37 @@ spec:
                                                   of your choice for the rule.
                                                 type: string
                                               destination:
-                                                description: 'Conceptually, this is
-                                                  the range of IP addresses that a
-                                                  packet originating from the instance
-                                                  can go to. Allowed values: * IP
-                                                  address range in CIDR notation.
-                                                  For example: `192.168.1.0/24` or
-                                                  `2001:0db8:0123:45::/56` Note that
-                                                  IPv6 addressing is currently supported
-                                                  only in certain regions. See IPv6
-                                                  Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                                  * The `cidrBlock` value for a Service,
-                                                  if you''re setting up a security
-                                                  list rule for traffic destined for
-                                                  a particular `Service` through a
-                                                  service gateway. For example: `oci-phx-objectstorage`.'
+                                                description: |-
+                                                  Conceptually, this is the range of IP addresses that a packet originating from the instance
+                                                  can go to.
+                                                  Allowed values:
+                                                    * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
+                                                      Note that IPv6 addressing is currently supported only in certain regions. See
+                                                      IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                                    * The `cidrBlock` value for a Service, if you're
+                                                      setting up a security list rule for traffic destined for a particular `Service` through
+                                                      a service gateway. For example: `oci-phx-objectstorage`.
                                                 type: string
                                               destinationType:
-                                                description: 'Type of destination
-                                                  for the rule. The default is `CIDR_BLOCK`.
-                                                  Allowed values: * `CIDR_BLOCK`:
-                                                  If the rule''s `destination` is
-                                                  an IP address range in CIDR notation.
-                                                  * `SERVICE_CIDR_BLOCK`: If the rule''s
-                                                  `destination` is the `cidrBlock`
-                                                  value for a Service (the rule is
-                                                  for traffic destined for a particular
-                                                  `Service` through a service gateway).'
+                                                description: |-
+                                                  Type of destination for the rule. The default is `CIDR_BLOCK`.
+                                                  Allowed values:
+                                                    * `CIDR_BLOCK`: If the rule's `destination` is an IP address range in CIDR notation.
+                                                    * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
+                                                      Service (the rule is for traffic destined for a
+                                                      particular `Service` through a service gateway).
                                                 type: string
                                               icmpOptions:
-                                                description: 'IcmpOptions Optional
-                                                  and valid only for ICMP and ICMPv6.
-                                                  Use to specify a particular ICMP
-                                                  type and code as defined in: - ICMP
-                                                  Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                                description: |-
+                                                  IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                                  as defined in:
+                                                  - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                                   - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                                  If you specify ICMP or ICMPv6 as
-                                                  the protocol but omit this object,
-                                                  then all ICMP types and codes are
-                                                  allowed. If you do provide this
-                                                  object, the type is required and
-                                                  the code is optional. To enable
-                                                  MTU negotiation for ingress internet
-                                                  traffic via IPv4, make sure to allow
-                                                  type 3 ("Destination Unreachable")
-                                                  code 4 ("Fragmentation Needed and
-                                                  Don''t Fragment was Set"). If you
-                                                  need to specify multiple codes for
-                                                  a single type, create a separate
-                                                  security list rule for each.'
+                                                  If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                                  codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                                  To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                                  Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                                  multiple codes for a single type, create a separate security list rule for each.
                                                 properties:
                                                   code:
                                                     description: The ICMP code (optional).
@@ -754,48 +667,33 @@ spec:
                                                     type: integer
                                                 type: object
                                               isStateless:
-                                                description: A stateless rule allows
-                                                  traffic in one direction. Remember
-                                                  to add a corresponding stateless
-                                                  rule in the other direction if you
-                                                  need to support bidirectional traffic.
-                                                  For example, if egress traffic allows
-                                                  TCP destination port 80, there should
-                                                  be an ingress rule to allow TCP
-                                                  source port 80. Defaults to false,
-                                                  which means the rule is stateful
-                                                  and a corresponding rule is not
-                                                  necessary for bidirectional traffic.
+                                                description: |-
+                                                  A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                                  stateless rule in the other direction if you need to support bidirectional traffic. For
+                                                  example, if egress traffic allows TCP destination port 80, there should be an ingress
+                                                  rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                                  and a corresponding rule is not necessary for bidirectional traffic.
                                                 type: boolean
                                               protocol:
-                                                description: The transport protocol.
-                                                  Specify either `all` or an IPv4
-                                                  protocol number as defined in Protocol
-                                                  Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                                  Options are supported only for ICMP
-                                                  ("1"), TCP ("6"), UDP ("17"), and
-                                                  ICMPv6 ("58").
+                                                description: |-
+                                                  The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                                  defined in
+                                                  Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                                  Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                                 type: string
                                               tcpOptions:
-                                                description: TcpOptions Optional and
-                                                  valid only for TCP. Use to specify
-                                                  particular destination ports for
-                                                  TCP rules. If you specify TCP as
-                                                  the protocol but omit this object,
-                                                  then all destination ports are allowed.
+                                                description: |-
+                                                  TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                                  If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                                 properties:
                                                   destinationPortRange:
                                                     description: PortRange The representation
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -809,13 +707,9 @@ spec:
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -826,25 +720,18 @@ spec:
                                                     type: object
                                                 type: object
                                               udpOptions:
-                                                description: UdpOptions Optional and
-                                                  valid only for UDP. Use to specify
-                                                  particular destination ports for
-                                                  UDP rules. If you specify UDP as
-                                                  the protocol but omit this object,
-                                                  then all destination ports are allowed.
+                                                description: |-
+                                                  UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                                  If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                                 properties:
                                                   destinationPortRange:
                                                     description: PortRange The representation
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -858,13 +745,9 @@ spec:
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -890,26 +773,16 @@ spec:
                                                   of your choice for the rule.
                                                 type: string
                                               icmpOptions:
-                                                description: 'IcmpOptions Optional
-                                                  and valid only for ICMP and ICMPv6.
-                                                  Use to specify a particular ICMP
-                                                  type and code as defined in: - ICMP
-                                                  Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                                description: |-
+                                                  IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                                  as defined in:
+                                                  - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                                   - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                                  If you specify ICMP or ICMPv6 as
-                                                  the protocol but omit this object,
-                                                  then all ICMP types and codes are
-                                                  allowed. If you do provide this
-                                                  object, the type is required and
-                                                  the code is optional. To enable
-                                                  MTU negotiation for ingress internet
-                                                  traffic via IPv4, make sure to allow
-                                                  type 3 ("Destination Unreachable")
-                                                  code 4 ("Fragmentation Needed and
-                                                  Don''t Fragment was Set"). If you
-                                                  need to specify multiple codes for
-                                                  a single type, create a separate
-                                                  security list rule for each.'
+                                                  If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                                  codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                                  To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                                  Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                                  multiple codes for a single type, create a separate security list rule for each.
                                                 properties:
                                                   code:
                                                     description: The ICMP code (optional).
@@ -919,77 +792,53 @@ spec:
                                                     type: integer
                                                 type: object
                                               isStateless:
-                                                description: A stateless rule allows
-                                                  traffic in one direction. Remember
-                                                  to add a corresponding stateless
-                                                  rule in the other direction if you
-                                                  need to support bidirectional traffic.
-                                                  For example, if ingress traffic
-                                                  allows TCP destination port 80,
-                                                  there should be an egress rule to
-                                                  allow TCP source port 80. Defaults
-                                                  to false, which means the rule is
-                                                  stateful and a corresponding rule
-                                                  is not necessary for bidirectional
-                                                  traffic.
+                                                description: |-
+                                                  A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                                  stateless rule in the other direction if you need to support bidirectional traffic. For
+                                                  example, if ingress traffic allows TCP destination port 80, there should be an egress
+                                                  rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                                  and a corresponding rule is not necessary for bidirectional traffic.
                                                 type: boolean
                                               protocol:
-                                                description: The transport protocol.
-                                                  Specify either `all` or an IPv4
-                                                  protocol number as defined in Protocol
-                                                  Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                                  Options are supported only for ICMP
-                                                  ("1"), TCP ("6"), UDP ("17"), and
-                                                  ICMPv6 ("58").
+                                                description: |-
+                                                  The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                                  defined in
+                                                  Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                                  Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                                 type: string
                                               source:
-                                                description: 'Conceptually, this is
-                                                  the range of IP addresses that a
-                                                  packet coming into the instance
-                                                  can come from. Allowed values: *
-                                                  IP address range in CIDR notation.
-                                                  For example: `192.168.1.0/24` or
-                                                  `2001:0db8:0123:45::/56`. IPv6 addressing
-                                                  is supported for all commercial
-                                                  and government regions. See IPv6
-                                                  Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                                  * The `cidrBlock` value for a Service,
-                                                  if you''re setting up a security
-                                                  list rule for traffic coming from
-                                                  a particular `Service` through a
-                                                  service gateway. For example: `oci-phx-objectstorage`.'
+                                                description: |-
+                                                  Conceptually, this is the range of IP addresses that a packet coming into the instance
+                                                  can come from.
+                                                  Allowed values:
+                                                    * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
+                                                      IPv6 addressing is supported for all commercial and government regions. See
+                                                      IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                                    * The `cidrBlock` value for a Service, if you're
+                                                      setting up a security list rule for traffic coming from a particular `Service` through
+                                                      a service gateway. For example: `oci-phx-objectstorage`.
                                                 type: string
                                               sourceType:
-                                                description: 'Type of source for the
-                                                  rule. The default is `CIDR_BLOCK`.
-                                                  * `CIDR_BLOCK`: If the rule''s `source`
-                                                  is an IP address range in CIDR notation.
-                                                  * `SERVICE_CIDR_BLOCK`: If the rule''s
-                                                  `source` is the `cidrBlock` value
-                                                  for a Service (the rule is for traffic
-                                                  coming from a particular `Service`
-                                                  through a service gateway).'
+                                                description: |-
+                                                  Type of source for the rule. The default is `CIDR_BLOCK`.
+                                                    * `CIDR_BLOCK`: If the rule's `source` is an IP address range in CIDR notation.
+                                                    * `SERVICE_CIDR_BLOCK`: If the rule's `source` is the `cidrBlock` value for a
+                                                      Service (the rule is for traffic coming from a
+                                                      particular `Service` through a service gateway).
                                                 type: string
                                               tcpOptions:
-                                                description: TcpOptions Optional and
-                                                  valid only for TCP. Use to specify
-                                                  particular destination ports for
-                                                  TCP rules. If you specify TCP as
-                                                  the protocol but omit this object,
-                                                  then all destination ports are allowed.
+                                                description: |-
+                                                  TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                                  If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                                 properties:
                                                   destinationPortRange:
                                                     description: PortRange The representation
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -1003,13 +852,9 @@ spec:
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -1020,25 +865,18 @@ spec:
                                                     type: object
                                                 type: object
                                               udpOptions:
-                                                description: UdpOptions Optional and
-                                                  valid only for UDP. Use to specify
-                                                  particular destination ports for
-                                                  UDP rules. If you specify UDP as
-                                                  the protocol but omit this object,
-                                                  then all destination ports are allowed.
+                                                description: |-
+                                                  UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                                  If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                                 properties:
                                                   destinationPortRange:
                                                     description: PortRange The representation
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -1052,13 +890,9 @@ spec:
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -1074,6 +908,11 @@ spec:
                                           description: SecurityList Name.
                                           type: string
                                       type: object
+                                    skip:
+                                      description: |-
+                                        Skip specifies whether to skip creating subnets. If set to true (default: false) the ID
+                                        must be specified by the user to a valid Subnet ID.
+                                      type: boolean
                                     type:
                                       description: Type defines the subnet type (e.g.
                                         public, private).
@@ -1091,83 +930,73 @@ spec:
                             description: VCNPeering configuration.
                             properties:
                               drg:
-                                description: DRG configuration refers to the DRG which
-                                  has to be created if required. If management cluster
-                                  and workload cluster shares the same DRG, this fields
-                                  is not required to be specified.
+                                description: |-
+                                  DRG configuration refers to the DRG which has to be created if required. If management cluster
+                                  and workload cluster shares the same DRG, this fields is not required to be specified.
                                 properties:
                                   id:
                                     description: ID is the OCID for the created DRG.
                                     type: string
                                   manage:
-                                    description: Manage defines whether the DRG has
-                                      to be managed(including create). If set to false(the
-                                      default) the ID has to be specified by the user
-                                      to a valid DRG ID to which the VCN has to be
-                                      attached.
+                                    description: |-
+                                      Manage defines whether the DRG has to be managed(including create). If set to false(the default) the ID
+                                      has to be specified by the user to a valid DRG ID to which the VCN has to be attached.
                                     type: boolean
                                   name:
                                     description: Name is the name of the created DRG.
                                     type: string
                                   vcnAttachmentId:
-                                    description: VcnAttachmentId is the ID of the
-                                      VCN attachment of the DRG. The workload cluster
-                                      VCN can be attached to either the management
-                                      cluster VCN if they are sharing the same DRG
+                                    description: |-
+                                      VcnAttachmentId is the ID of the VCN attachment of the DRG.
+                                      The workload cluster VCN can be attached to either the management cluster VCN if they are sharing the same DRG
                                       or to the workload cluster DRG.
                                     type: string
                                 type: object
                               peerRouteRules:
-                                description: PeerRouteRules defines the routing rules
-                                  which will be added to the private route tables
-                                  of the workload cluster VCN. The routes defined
-                                  here will be directed to DRG.
+                                description: |-
+                                  PeerRouteRules defines the routing rules which will be added to the private route tables
+                                  of the workload cluster VCN. The routes defined here will be directed to DRG.
                                 items:
                                   description: PeerRouteRule defines a Route Rule
                                     to be routed via a DRG.
                                   properties:
                                     vcnCIDRRange:
-                                      description: VCNCIDRRange is the CIDR Range
-                                        of peer VCN to which the workload cluster
-                                        VCN will be peered. The CIDR range is required
-                                        to add the route rule in the workload cluster
-                                        VCN, the route rule will forward any traffic
-                                        to the CIDR to the DRG.
+                                      description: |-
+                                        VCNCIDRRange is the CIDR Range of peer VCN to which the
+                                        workload cluster VCN will be peered. The CIDR range is required to add the route rule
+                                        in the workload cluster VCN, the route rule will forward any traffic to the CIDR to the DRG.
                                       type: string
                                   type: object
                                 type: array
                               remotePeeringConnections:
-                                description: RemotePeeringConnections defines the
-                                  RPC connections which be established with the workload
-                                  cluster DRG.
+                                description: |-
+                                  RemotePeeringConnections defines the RPC connections which be established with the
+                                  workload cluster DRG.
                                 items:
-                                  description: RemotePeeringConnection is used to
-                                    peer VCNs residing in different regions(typically).
+                                  description: |-
+                                    RemotePeeringConnection is used to peer VCNs residing in different regions(typically).
                                     Remote VCN Peering is explained here - https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/remoteVCNpeering.htm
                                   properties:
                                     managePeerRPC:
-                                      description: ManagePeerRPC will define if the
-                                        Peer VCN needs to be managed. If set to true
-                                        a Remote Peering Connection will be created
-                                        in the Peer DRG and the connection will be
-                                        created between local and peer RPC.
+                                      description: |-
+                                        ManagePeerRPC will define if the Peer VCN needs to be managed. If set to true
+                                        a Remote Peering Connection will be created in the Peer DRG and the connection
+                                        will be created between local and peer RPC.
                                       type: boolean
                                     name:
-                                      description: A unique name identifying the RPC,
-                                        please note this is to identify the RPC from
-                                        other RPC elements, and will not be used in
-                                        any OCI API call.
+                                      description: |-
+                                        A unique name identifying the RPC, please note this is to identify the RPC
+                                        from other RPC elements, and will not be used in any OCI API call.
                                       type: string
                                     peerDRGId:
                                       description: PeerDRGId defines the DRG ID of
                                         the peer.
                                       type: string
                                     peerRPCConnectionId:
-                                      description: PeerRPCConnectionId defines the
-                                        RPC ID of peer. If ManagePeerRPC is set to
-                                        true this will be created by Cluster API Provider
-                                        for OCI, otherwise this has be defined by
-                                        the user.
+                                      description: |-
+                                        PeerRPCConnectionId defines the RPC ID of peer. If ManagePeerRPC is set to true
+                                        this will be created by Cluster API Provider for OCI, otherwise this has be defined by the
+                                        user.
                                       type: string
                                     peerRegionName:
                                       description: PeerRegionName defined the region
@@ -1183,14 +1012,15 @@ spec:
                             type: object
                         type: object
                       ociResourceIdentifier:
-                        description: The unique ID which will be used to tag all the
-                          resources created by this Cluster. The tag will be used
-                          to identify resources belonging to this cluster. this will
-                          be auto-generated and should not be set by the user.
+                        description: |-
+                          The unique ID which will be used to tag all the resources created by this Cluster.
+                          The tag will be used to identify resources belonging to this cluster.
+                          this will be auto-generated and should not be set by the user.
                         type: string
                       region:
-                        description: Region the cluster operates in. It must be one
-                          of available regions in Region Identifier format. See https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm
+                        description: |-
+                          Region the cluster operates in. It must be one of available regions in Region Identifier format.
+                          See https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm
                         type: string
                     type: object
                 required:
@@ -1209,14 +1039,19 @@ spec:
           API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -1246,10 +1081,9 @@ spec:
                                 Uocm:PHX-AD-1'
                               type: string
                           type: object
-                        description: AvailabilityDomains encapsulates the clusters
-                          Availability Domain (AD) information in a map where the
-                          map key is the AD name and the struct is details about the
-                          AD.
+                        description: |-
+                          AvailabilityDomains encapsulates the clusters Availability Domain (AD) information in a map
+                          where the map key is the AD name and the struct is details about the AD.
                         type: object
                       clientOverrides:
                         description: ClientOverrides allows the default client SDK
@@ -1257,8 +1091,8 @@ spec:
                         nullable: true
                         properties:
                           certOverride:
-                            description: CertOverride is a secret that contains information
-                              about a cert override used by all the OCI SDK clients.
+                            description: |-
+                              CertOverride is a secret that contains information about a cert override used by all the OCI SDK clients.
                               The secret must contain data with a `cert`property.
                             nullable: true
                             properties:
@@ -1321,10 +1155,13 @@ spec:
                           used to communicate with the control plane.
                         properties:
                           host:
-                            description: The hostname on which the API server is serving.
+                            description: host is the hostname on which the API server
+                              is serving.
+                            maxLength: 512
                             type: string
                           port:
-                            description: The port on which the API server is serving.
+                            description: port is the port on which the API server
+                              is serving.
                             format: int32
                             type: integer
                         required:
@@ -1336,10 +1173,10 @@ spec:
                           additionalProperties:
                             type: string
                           type: object
-                        description: 'Defined tags for this resource. Each key is
-                          predefined and scoped to a namespace. For more information,
-                          see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
-                          Example: `{"Operations": {"CostCenter": "42"}}`'
+                        description: |-
+                          Defined tags for this resource. Each key is predefined and scoped to a
+                          namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+                          Example: `{"Operations": {"CostCenter": "42"}}`
                         type: object
                       freeformTags:
                         additionalProperties:
@@ -1354,34 +1191,39 @@ spec:
                             description: API version of the referent.
                             type: string
                           fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
                             type: string
                           kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                             type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                             type: string
                           namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                             type: string
                           resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                             type: string
                           uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
@@ -1416,17 +1258,16 @@ spec:
                                           unhealthy.
                                         properties:
                                           urlPath:
-                                            description: 'The path against which to
-                                              run the health check. Example: `/healthcheck`
-                                              Default value is `/healthz`'
+                                            description: |-
+                                              The path against which to run the health check.
+                                              Example: `/healthcheck`
+                                              Default value is `/healthz`
                                             type: string
                                         type: object
                                       isFailOpen:
-                                        description: If enabled, the network load
-                                          balancer will continue to distribute traffic
-                                          in the configured distribution in the event
-                                          all backends are unhealthy. The value is
-                                          false by default.
+                                        description: |-
+                                          If enabled, the network load balancer will continue to distribute traffic in the configured distribution in the event all backends are unhealthy.
+                                          The value is false by default.
                                         type: boolean
                                       isInstantFailoverEnabled:
                                         description: If enabled existing connections
@@ -1435,29 +1276,30 @@ spec:
                                           unhealthy.
                                         type: boolean
                                       isPreserveSource:
-                                        description: If this parameter is enabled,
-                                          then the network load balancer preserves
-                                          the source IP of the packet when it is forwarded
-                                          to backends. Backends see the original source
-                                          IP. If the isPreserveSourceDestination parameter
-                                          is enabled for the network load balancer
-                                          resource, then this parameter cannot be
-                                          disabled. The value is false by default.
+                                        description: |-
+                                          If this parameter is enabled, then the network load balancer preserves the source IP of the packet when it is forwarded to backends.
+                                          Backends see the original source IP. If the isPreserveSourceDestination parameter is enabled for the network load balancer resource, then this parameter cannot be disabled.
+                                          The value is false by default.
                                         type: boolean
                                     type: object
                                 type: object
                             type: object
+                          compartmentId:
+                            description: CompartmentId where to provision network
+                              resources
+                            type: string
                           skipNetworkManagement:
-                            description: SkipNetworkManagement defines if the networking
-                              spec(VCN related) specified by the user needs to be
-                              reconciled(actioned-upon) or used as it is. APIServerLB
-                              will still be reconciled.
+                            description: |-
+                              SkipNetworkManagement defines if the networking spec(VCN related) specified by the user needs to be reconciled(actioned-upon)
+                              or used as it is. APIServerLB will still be reconciled.
                             type: boolean
                           vcn:
                             description: VCN configuration.
                             properties:
                               cidr:
-                                description: VCN CIDR. Deprecated, please use NetworkDetails.cidrs
+                                description: |-
+                                  VCN CIDR.
+                                  Deprecated, please use NetworkDetails.cidrs
                                 type: string
                               cidrs:
                                 description: VCN CIDRs.
@@ -1465,18 +1307,14 @@ spec:
                                   type: string
                                 type: array
                               dnsLabel:
-                                description: DnsLabel specifies a DNS label for the
-                                  VCN, used in conjunction with the VNIC's hostname
-                                  and subnet's DNS label to form a fully qualified
-                                  domain name (FQDN) for each VNIC within this subnet
-                                  (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
+                                description: |-
+                                  DnsLabel specifies a DNS label for the VCN, used in conjunction with the VNIC's hostname and
+                                  subnet's DNS label to form a fully qualified domain name (FQDN) for each VNIC
+                                  within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
                                 type: string
                               id:
                                 description: VCN OCID.
                                 type: string
-                              skip:
-                                description: Skip specifies whether to skip creating vcn
-                                type: boolean
                               internetGateway:
                                 description: Configuration for Internet Gateway.
                                 properties:
@@ -1484,10 +1322,19 @@ spec:
                                     description: ID of Internet Gateway.
                                     type: string
                                   skip:
-                                    description: Skip specifies whether to skip creating
-                                      internet gateway even if any one Subnet is public.
+                                    description: |-
+                                      Skip specifies whether to skip creating internet gateway even if any one Subnet is public.
+                                      In case of VCN being Skipped (Skip field of VCN set to true), this field must be true also
                                     type: boolean
                                 type: object
+                              isIpv6Enabled:
+                                description: Configuration to enable IPv6.
+                                type: boolean
+                              isOracleGuaAllocationEnabled:
+                                description: Configuration to allow OCI to assign
+                                  IPv6 Prefix. When true will use a /56 IPv6 global
+                                  unicast address (GUA) prefix allocated by Oracle
+                                type: boolean
                               name:
                                 description: VCN Name.
                                 type: string
@@ -1498,8 +1345,9 @@ spec:
                                     description: ID of Nat Gateway.
                                     type: string
                                   skip:
-                                    description: Skip specifies whether to skip creating
-                                      NAT gateway even if any one Subnet is private.
+                                    description: |-
+                                      Skip specifies whether to skip creating NAT gateway even if any one Subnet is private.
+                                      In case of VCN being Skipped (Skip field of VCN set to true), this field must be true also
                                     type: boolean
                                 type: object
                               networkSecurityGroup:
@@ -1510,8 +1358,9 @@ spec:
                                       for the Network Security Groups required in
                                       the VCN.
                                     items:
-                                      description: NSG defines configuration for a
-                                        Network Security Group. https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/networksecuritygroups.htm
+                                      description: |-
+                                        NSG defines configuration for a Network Security Group.
+                                        https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/networksecuritygroups.htm
                                       properties:
                                         egressRules:
                                           description: EgressRules on the NSG.
@@ -1528,64 +1377,39 @@ spec:
                                                       of your choice for the rule.
                                                     type: string
                                                   destination:
-                                                    description: 'Conceptually, this
-                                                      is the range of IP addresses
-                                                      that a packet originating from
-                                                      the instance can go to. Allowed
-                                                      values: * IP address range in
-                                                      CIDR notation. For example:
-                                                      `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-                                                      Note that IPv6 addressing is
-                                                      currently supported only in
-                                                      certain regions. See IPv6 Addresses
-                                                      (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                                      * The `cidrBlock` value for
-                                                      a Service, if you''re setting
-                                                      up a security list rule for
-                                                      traffic destined for a particular
-                                                      `Service` through a service
-                                                      gateway. For example: `oci-phx-objectstorage`.'
+                                                    description: |-
+                                                      Conceptually, this is the range of IP addresses that a packet originating from the instance
+                                                      can go to.
+                                                      Allowed values:
+                                                        * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
+                                                          Note that IPv6 addressing is currently supported only in certain regions. See
+                                                          IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                                        * The `cidrBlock` value for a Service, if you're
+                                                          setting up a security list rule for traffic destined for a particular `Service` through
+                                                          a service gateway. For example: `oci-phx-objectstorage`.
                                                     type: string
                                                   destinationType:
-                                                    description: 'Type of destination
-                                                      for the rule. The default is
-                                                      `CIDR_BLOCK`. Allowed values:
-                                                      * `CIDR_BLOCK`: If the rule''s
-                                                      `destination` is an IP address
-                                                      range in CIDR notation. * `SERVICE_CIDR_BLOCK`:
-                                                      If the rule''s `destination`
-                                                      is the `cidrBlock` value for
-                                                      a Service (the rule is for traffic
-                                                      destined for a particular `Service`
-                                                      through a service gateway).
-                                                      * `NETWORK_SECURITY_GROUP`:
-                                                      If the rule''s `destination`
-                                                      is the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)
-                                                      of a NetworkSecurityGroup.'
+                                                    description: |-
+                                                      Type of destination for the rule. The default is `CIDR_BLOCK`.
+                                                      Allowed values:
+                                                        * `CIDR_BLOCK`: If the rule's `destination` is an IP address range in CIDR notation.
+                                                        * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
+                                                          Service (the rule is for traffic destined for a
+                                                          particular `Service` through a service gateway).
+                                                        * `NETWORK_SECURITY_GROUP`: If the rule's `destination` is the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a
+                                                          NetworkSecurityGroup.
                                                     type: string
                                                   icmpOptions:
-                                                    description: 'IcmpOptions Optional
-                                                      and valid only for ICMP and
-                                                      ICMPv6. Use to specify a particular
-                                                      ICMP type and code as defined
-                                                      in: - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                                    description: |-
+                                                      IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                                      as defined in:
+                                                      - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                                       - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                                      If you specify ICMP or ICMPv6
-                                                      as the protocol but omit this
-                                                      object, then all ICMP types
-                                                      and codes are allowed. If you
-                                                      do provide this object, the
-                                                      type is required and the code
-                                                      is optional. To enable MTU negotiation
-                                                      for ingress internet traffic
-                                                      via IPv4, make sure to allow
-                                                      type 3 ("Destination Unreachable")
-                                                      code 4 ("Fragmentation Needed
-                                                      and Don''t Fragment was Set").
-                                                      If you need to specify multiple
-                                                      codes for a single type, create
-                                                      a separate security list rule
-                                                      for each.'
+                                                      If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                                      codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                                      To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                                      Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                                      multiple codes for a single type, create a separate security list rule for each.
                                                     properties:
                                                       code:
                                                         description: The ICMP code
@@ -1596,52 +1420,33 @@ spec:
                                                         type: integer
                                                     type: object
                                                   isStateless:
-                                                    description: A stateless rule
-                                                      allows traffic in one direction.
-                                                      Remember to add a corresponding
-                                                      stateless rule in the other
-                                                      direction if you need to support
-                                                      bidirectional traffic. For example,
-                                                      if egress traffic allows TCP
-                                                      destination port 80, there should
-                                                      be an ingress rule to allow
-                                                      TCP source port 80. Defaults
-                                                      to false, which means the rule
-                                                      is stateful and a corresponding
-                                                      rule is not necessary for bidirectional
-                                                      traffic.
+                                                    description: |-
+                                                      A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                                      stateless rule in the other direction if you need to support bidirectional traffic. For
+                                                      example, if egress traffic allows TCP destination port 80, there should be an ingress
+                                                      rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                                      and a corresponding rule is not necessary for bidirectional traffic.
                                                     type: boolean
                                                   protocol:
-                                                    description: The transport protocol.
-                                                      Specify either `all` or an IPv4
-                                                      protocol number as defined in
+                                                    description: |-
+                                                      The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                                      defined in
                                                       Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                                      Options are supported only for
-                                                      ICMP ("1"), TCP ("6"), UDP ("17"),
-                                                      and ICMPv6 ("58").
+                                                      Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                                     type: string
                                                   tcpOptions:
-                                                    description: TcpOptions Optional
-                                                      and valid only for TCP. Use
-                                                      to specify particular destination
-                                                      ports for TCP rules. If you
-                                                      specify TCP as the protocol
-                                                      but omit this object, then all
-                                                      destination ports are allowed.
+                                                    description: |-
+                                                      TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                                      If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                                     properties:
                                                       destinationPortRange:
                                                         description: PortRange The
                                                           representation of PortRange.
                                                         properties:
                                                           max:
-                                                            description: The maximum
-                                                              port number, which must
-                                                              not be less than the
-                                                              minimum port number.
-                                                              To specify a single
-                                                              port number, set both
-                                                              the min and max to the
-                                                              same value.
+                                                            description: |-
+                                                              The maximum port number, which must not be less than the minimum port number. To specify
+                                                              a single port number, set both the min and max to the same value.
                                                             type: integer
                                                           min:
                                                             description: The minimum
@@ -1655,14 +1460,9 @@ spec:
                                                           representation of PortRange.
                                                         properties:
                                                           max:
-                                                            description: The maximum
-                                                              port number, which must
-                                                              not be less than the
-                                                              minimum port number.
-                                                              To specify a single
-                                                              port number, set both
-                                                              the min and max to the
-                                                              same value.
+                                                            description: |-
+                                                              The maximum port number, which must not be less than the minimum port number. To specify
+                                                              a single port number, set both the min and max to the same value.
                                                             type: integer
                                                           min:
                                                             description: The minimum
@@ -1673,27 +1473,18 @@ spec:
                                                         type: object
                                                     type: object
                                                   udpOptions:
-                                                    description: UdpOptions Optional
-                                                      and valid only for UDP. Use
-                                                      to specify particular destination
-                                                      ports for UDP rules. If you
-                                                      specify UDP as the protocol
-                                                      but omit this object, then all
-                                                      destination ports are allowed.
+                                                    description: |-
+                                                      UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                                      If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                                     properties:
                                                       destinationPortRange:
                                                         description: PortRange The
                                                           representation of PortRange.
                                                         properties:
                                                           max:
-                                                            description: The maximum
-                                                              port number, which must
-                                                              not be less than the
-                                                              minimum port number.
-                                                              To specify a single
-                                                              port number, set both
-                                                              the min and max to the
-                                                              same value.
+                                                            description: |-
+                                                              The maximum port number, which must not be less than the minimum port number. To specify
+                                                              a single port number, set both the min and max to the same value.
                                                             type: integer
                                                           min:
                                                             description: The minimum
@@ -1707,14 +1498,9 @@ spec:
                                                           representation of PortRange.
                                                         properties:
                                                           max:
-                                                            description: The maximum
-                                                              port number, which must
-                                                              not be less than the
-                                                              minimum port number.
-                                                              To specify a single
-                                                              port number, set both
-                                                              the min and max to the
-                                                              same value.
+                                                            description: |-
+                                                              The maximum port number, which must not be less than the minimum port number. To specify
+                                                              a single port number, set both the min and max to the same value.
                                                             type: integer
                                                           min:
                                                             description: The minimum
@@ -1745,28 +1531,16 @@ spec:
                                                       of your choice for the rule.
                                                     type: string
                                                   icmpOptions:
-                                                    description: 'IcmpOptions Optional
-                                                      and valid only for ICMP and
-                                                      ICMPv6. Use to specify a particular
-                                                      ICMP type and code as defined
-                                                      in: - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                                    description: |-
+                                                      IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                                      as defined in:
+                                                      - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                                       - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                                      If you specify ICMP or ICMPv6
-                                                      as the protocol but omit this
-                                                      object, then all ICMP types
-                                                      and codes are allowed. If you
-                                                      do provide this object, the
-                                                      type is required and the code
-                                                      is optional. To enable MTU negotiation
-                                                      for ingress internet traffic
-                                                      via IPv4, make sure to allow
-                                                      type 3 ("Destination Unreachable")
-                                                      code 4 ("Fragmentation Needed
-                                                      and Don''t Fragment was Set").
-                                                      If you need to specify multiple
-                                                      codes for a single type, create
-                                                      a separate security list rule
-                                                      for each.'
+                                                      If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                                      codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                                      To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                                      Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                                      multiple codes for a single type, create a separate security list rule for each.
                                                     properties:
                                                       code:
                                                         description: The ICMP code
@@ -1777,87 +1551,55 @@ spec:
                                                         type: integer
                                                     type: object
                                                   isStateless:
-                                                    description: A stateless rule
-                                                      allows traffic in one direction.
-                                                      Remember to add a corresponding
-                                                      stateless rule in the other
-                                                      direction if you need to support
-                                                      bidirectional traffic. For example,
-                                                      if ingress traffic allows TCP
-                                                      destination port 80, there should
-                                                      be an egress rule to allow TCP
-                                                      source port 80. Defaults to
-                                                      false, which means the rule
-                                                      is stateful and a corresponding
-                                                      rule is not necessary for bidirectional
-                                                      traffic.
+                                                    description: |-
+                                                      A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                                      stateless rule in the other direction if you need to support bidirectional traffic. For
+                                                      example, if ingress traffic allows TCP destination port 80, there should be an egress
+                                                      rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                                      and a corresponding rule is not necessary for bidirectional traffic.
                                                     type: boolean
                                                   protocol:
-                                                    description: The transport protocol.
-                                                      Specify either `all` or an IPv4
-                                                      protocol number as defined in
+                                                    description: |-
+                                                      The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                                      defined in
                                                       Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                                      Options are supported only for
-                                                      ICMP ("1"), TCP ("6"), UDP ("17"),
-                                                      and ICMPv6 ("58").
+                                                      Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                                     type: string
                                                   source:
-                                                    description: 'Conceptually, this
-                                                      is the range of IP addresses
-                                                      that a packet coming into the
-                                                      instance can come from. Allowed
-                                                      values: * IP address range in
-                                                      CIDR notation. For example:
-                                                      `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
-                                                      IPv6 addressing is supported
-                                                      for all commercial and government
-                                                      regions. See IPv6 Addresses
-                                                      (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                                      * The `cidrBlock` value for
-                                                      a Service, if you''re setting
-                                                      up a security list rule for
-                                                      traffic coming from a particular
-                                                      `Service` through a service
-                                                      gateway. For example: `oci-phx-objectstorage`.'
+                                                    description: |-
+                                                      Conceptually, this is the range of IP addresses that a packet coming into the instance
+                                                      can come from.
+                                                      Allowed values:
+                                                        * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
+                                                          IPv6 addressing is supported for all commercial and government regions. See
+                                                          IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                                        * The `cidrBlock` value for a Service, if you're
+                                                          setting up a security list rule for traffic coming from a particular `Service` through
+                                                          a service gateway. For example: `oci-phx-objectstorage`.
                                                     type: string
                                                   sourceType:
-                                                    description: 'Type of source for
-                                                      the rule. The default is `CIDR_BLOCK`.
-                                                      * `CIDR_BLOCK`: If the rule''s
-                                                      `source` is an IP address range
-                                                      in CIDR notation. * `SERVICE_CIDR_BLOCK`:
-                                                      If the rule''s `source` is the
-                                                      `cidrBlock` value for a Service
-                                                      (the rule is for traffic coming
-                                                      from a particular `Service`
-                                                      through a service gateway).
-                                                      * `NETWORK_SECURITY_GROUP`:
-                                                      If the rule''s `destination`
-                                                      is the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)
-                                                      of a NetworkSecurityGroup.'
+                                                    description: |-
+                                                      Type of source for the rule. The default is `CIDR_BLOCK`.
+                                                        * `CIDR_BLOCK`: If the rule's `source` is an IP address range in CIDR notation.
+                                                        * `SERVICE_CIDR_BLOCK`: If the rule's `source` is the `cidrBlock` value for a
+                                                          Service (the rule is for traffic coming from a
+                                                          particular `Service` through a service gateway).
+                                                        * `NETWORK_SECURITY_GROUP`: If the rule's `destination` is the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a
+                                                          NetworkSecurityGroup.
                                                     type: string
                                                   tcpOptions:
-                                                    description: TcpOptions Optional
-                                                      and valid only for TCP. Use
-                                                      to specify particular destination
-                                                      ports for TCP rules. If you
-                                                      specify TCP as the protocol
-                                                      but omit this object, then all
-                                                      destination ports are allowed.
+                                                    description: |-
+                                                      TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                                      If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                                     properties:
                                                       destinationPortRange:
                                                         description: PortRange The
                                                           representation of PortRange.
                                                         properties:
                                                           max:
-                                                            description: The maximum
-                                                              port number, which must
-                                                              not be less than the
-                                                              minimum port number.
-                                                              To specify a single
-                                                              port number, set both
-                                                              the min and max to the
-                                                              same value.
+                                                            description: |-
+                                                              The maximum port number, which must not be less than the minimum port number. To specify
+                                                              a single port number, set both the min and max to the same value.
                                                             type: integer
                                                           min:
                                                             description: The minimum
@@ -1871,14 +1613,9 @@ spec:
                                                           representation of PortRange.
                                                         properties:
                                                           max:
-                                                            description: The maximum
-                                                              port number, which must
-                                                              not be less than the
-                                                              minimum port number.
-                                                              To specify a single
-                                                              port number, set both
-                                                              the min and max to the
-                                                              same value.
+                                                            description: |-
+                                                              The maximum port number, which must not be less than the minimum port number. To specify
+                                                              a single port number, set both the min and max to the same value.
                                                             type: integer
                                                           min:
                                                             description: The minimum
@@ -1889,27 +1626,18 @@ spec:
                                                         type: object
                                                     type: object
                                                   udpOptions:
-                                                    description: UdpOptions Optional
-                                                      and valid only for UDP. Use
-                                                      to specify particular destination
-                                                      ports for UDP rules. If you
-                                                      specify UDP as the protocol
-                                                      but omit this object, then all
-                                                      destination ports are allowed.
+                                                    description: |-
+                                                      UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                                      If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                                     properties:
                                                       destinationPortRange:
                                                         description: PortRange The
                                                           representation of PortRange.
                                                         properties:
                                                           max:
-                                                            description: The maximum
-                                                              port number, which must
-                                                              not be less than the
-                                                              minimum port number.
-                                                              To specify a single
-                                                              port number, set both
-                                                              the min and max to the
-                                                              same value.
+                                                            description: |-
+                                                              The maximum port number, which must not be less than the minimum port number. To specify
+                                                              a single port number, set both the min and max to the same value.
                                                             type: integer
                                                           min:
                                                             description: The minimum
@@ -1923,14 +1651,9 @@ spec:
                                                           representation of PortRange.
                                                         properties:
                                                           max:
-                                                            description: The maximum
-                                                              port number, which must
-                                                              not be less than the
-                                                              minimum port number.
-                                                              To specify a single
-                                                              port number, set both
-                                                              the min and max to the
-                                                              same value.
+                                                            description: |-
+                                                              The maximum port number, which must not be less than the minimum port number. To specify
+                                                              a single port number, set both the min and max to the same value.
                                                             type: integer
                                                           min:
                                                             description: The minimum
@@ -1973,8 +1696,9 @@ spec:
                                     description: ID of Public Route Table.
                                     type: string
                                   skip:
-                                    description: Skip specifies whether to skip creating
-                                      Route table.
+                                    description: |-
+                                      Skip specifies whether to skip creating Route table.
+                                      In case of VCN being Skipped (Skip field of VCN set to true), this field must be true also
                                     type: boolean
                                 type: object
                               serviceGateway:
@@ -1984,33 +1708,44 @@ spec:
                                     description: ID of Service Gateway.
                                     type: string
                                   skip:
-                                    description: Skip specifies whether to skip creating
-                                      Service gateway.
+                                    description: |-
+                                      Skip specifies whether to skip creating Service gateway.
+                                      In case of VCN being Skipped (Skip field of VCN set to true), this field must be true also
                                     type: boolean
                                 type: object
+                              skip:
+                                description: |-
+                                  Skip specifies whether to skip creating VCN.
+                                  When is set to true, InternetGateway, NatGateway, ServiceGateway, RouteTable must have also Skip set to true
+                                  If set to true(default: false) the ID must be specified by the user to a valid VCN ID.
+                                type: boolean
                               subnets:
                                 description: Subnets is the configuration for subnets
                                   required in the VCN.
                                 items:
-                                  description: Subnet defines the configuration for
-                                    a network's subnet https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingVCNs_topic-Overview_of_VCNs_and_Subnets.htm#Overview
+                                  description: |-
+                                    Subnet defines the configuration for a network's subnet
+                                    https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingVCNs_topic-Overview_of_VCNs_and_Subnets.htm#Overview
                                   properties:
                                     cidr:
                                       description: Subnet CIDR.
                                       type: string
                                     dnsLabel:
-                                      description: DnsLabel DNS label for the subnet,
-                                        used in conjunction with the VNIC's hostname
-                                        and VCN's DNS label to form a fully qualified
-                                        domain name (FQDN) for each VNIC within this
-                                        subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
+                                      description: |-
+                                        DnsLabel DNS label for the subnet, used in conjunction with the VNIC's hostname and
+                                        VCN's DNS label to form a fully qualified domain name (FQDN) for each VNIC
+                                        within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
                                       type: string
                                     id:
                                       description: Subnet OCID.
                                       type: string
-                                    skip:
-                                      description: Skip specifies whether to skip creating subnet
-                                      type: boolean
+                                    ipv6CidrBlockHextet:
+                                      description: |-
+                                        Use this to enable IPv6 hextet for this subnet. The VCN must be enabled for IPv6.
+                                        You can't change this subnet characteristic later. All subnets are /64 in size. The subnet
+                                        portion of the IPv6 address is the fourth hextet from the left (1111 in the following example).
+                                        Example: `2001:0db8:0123:1111::/64`
+                                      type: string
                                     name:
                                       description: Subnet Name.
                                       type: string
@@ -2034,59 +1769,39 @@ spec:
                                                   of your choice for the rule.
                                                 type: string
                                               destination:
-                                                description: 'Conceptually, this is
-                                                  the range of IP addresses that a
-                                                  packet originating from the instance
-                                                  can go to. Allowed values: * IP
-                                                  address range in CIDR notation.
-                                                  For example: `192.168.1.0/24` or
-                                                  `2001:0db8:0123:45::/56` Note that
-                                                  IPv6 addressing is currently supported
-                                                  only in certain regions. See IPv6
-                                                  Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                                  * The `cidrBlock` value for a Service,
-                                                  if you''re setting up a security
-                                                  list rule for traffic destined for
-                                                  a particular `Service` through a
-                                                  service gateway. For example: `oci-phx-objectstorage`.'
+                                                description: |-
+                                                  Conceptually, this is the range of IP addresses that a packet originating from the instance
+                                                  can go to.
+                                                  Allowed values:
+                                                    * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
+                                                      Note that IPv6 addressing is currently supported only in certain regions. See
+                                                      IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                                    * The `cidrBlock` value for a Service, if you're
+                                                      setting up a security list rule for traffic destined for a particular `Service` through
+                                                      a service gateway. For example: `oci-phx-objectstorage`.
                                                 type: string
                                               destinationType:
-                                                description: 'Type of destination
-                                                  for the rule. The default is `CIDR_BLOCK`.
-                                                  Allowed values: * `CIDR_BLOCK`:
-                                                  If the rule''s `destination` is
-                                                  an IP address range in CIDR notation.
-                                                  * `SERVICE_CIDR_BLOCK`: If the rule''s
-                                                  `destination` is the `cidrBlock`
-                                                  value for a Service (the rule is
-                                                  for traffic destined for a particular
-                                                  `Service` through a service gateway).
-                                                  * `NETWORK_SECURITY_GROUP`: If the
-                                                  rule''s `destination` is the OCID
-                                                  (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)
-                                                  of a NetworkSecurityGroup.'
+                                                description: |-
+                                                  Type of destination for the rule. The default is `CIDR_BLOCK`.
+                                                  Allowed values:
+                                                    * `CIDR_BLOCK`: If the rule's `destination` is an IP address range in CIDR notation.
+                                                    * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
+                                                      Service (the rule is for traffic destined for a
+                                                      particular `Service` through a service gateway).
+                                                    * `NETWORK_SECURITY_GROUP`: If the rule's `destination` is the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a
+                                                      NetworkSecurityGroup.
                                                 type: string
                                               icmpOptions:
-                                                description: 'IcmpOptions Optional
-                                                  and valid only for ICMP and ICMPv6.
-                                                  Use to specify a particular ICMP
-                                                  type and code as defined in: - ICMP
-                                                  Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                                description: |-
+                                                  IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                                  as defined in:
+                                                  - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                                   - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                                  If you specify ICMP or ICMPv6 as
-                                                  the protocol but omit this object,
-                                                  then all ICMP types and codes are
-                                                  allowed. If you do provide this
-                                                  object, the type is required and
-                                                  the code is optional. To enable
-                                                  MTU negotiation for ingress internet
-                                                  traffic via IPv4, make sure to allow
-                                                  type 3 ("Destination Unreachable")
-                                                  code 4 ("Fragmentation Needed and
-                                                  Don''t Fragment was Set"). If you
-                                                  need to specify multiple codes for
-                                                  a single type, create a separate
-                                                  security list rule for each.'
+                                                  If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                                  codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                                  To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                                  Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                                  multiple codes for a single type, create a separate security list rule for each.
                                                 properties:
                                                   code:
                                                     description: The ICMP code (optional).
@@ -2096,48 +1811,33 @@ spec:
                                                     type: integer
                                                 type: object
                                               isStateless:
-                                                description: A stateless rule allows
-                                                  traffic in one direction. Remember
-                                                  to add a corresponding stateless
-                                                  rule in the other direction if you
-                                                  need to support bidirectional traffic.
-                                                  For example, if egress traffic allows
-                                                  TCP destination port 80, there should
-                                                  be an ingress rule to allow TCP
-                                                  source port 80. Defaults to false,
-                                                  which means the rule is stateful
-                                                  and a corresponding rule is not
-                                                  necessary for bidirectional traffic.
+                                                description: |-
+                                                  A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                                  stateless rule in the other direction if you need to support bidirectional traffic. For
+                                                  example, if egress traffic allows TCP destination port 80, there should be an ingress
+                                                  rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                                  and a corresponding rule is not necessary for bidirectional traffic.
                                                 type: boolean
                                               protocol:
-                                                description: The transport protocol.
-                                                  Specify either `all` or an IPv4
-                                                  protocol number as defined in Protocol
-                                                  Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                                  Options are supported only for ICMP
-                                                  ("1"), TCP ("6"), UDP ("17"), and
-                                                  ICMPv6 ("58").
+                                                description: |-
+                                                  The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                                  defined in
+                                                  Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                                  Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                                 type: string
                                               tcpOptions:
-                                                description: TcpOptions Optional and
-                                                  valid only for TCP. Use to specify
-                                                  particular destination ports for
-                                                  TCP rules. If you specify TCP as
-                                                  the protocol but omit this object,
-                                                  then all destination ports are allowed.
+                                                description: |-
+                                                  TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                                  If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                                 properties:
                                                   destinationPortRange:
                                                     description: PortRange The representation
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -2151,13 +1851,9 @@ spec:
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -2168,25 +1864,18 @@ spec:
                                                     type: object
                                                 type: object
                                               udpOptions:
-                                                description: UdpOptions Optional and
-                                                  valid only for UDP. Use to specify
-                                                  particular destination ports for
-                                                  UDP rules. If you specify UDP as
-                                                  the protocol but omit this object,
-                                                  then all destination ports are allowed.
+                                                description: |-
+                                                  UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                                  If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                                 properties:
                                                   destinationPortRange:
                                                     description: PortRange The representation
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -2200,13 +1889,9 @@ spec:
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -2232,26 +1917,16 @@ spec:
                                                   of your choice for the rule.
                                                 type: string
                                               icmpOptions:
-                                                description: 'IcmpOptions Optional
-                                                  and valid only for ICMP and ICMPv6.
-                                                  Use to specify a particular ICMP
-                                                  type and code as defined in: - ICMP
-                                                  Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                                description: |-
+                                                  IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                                  as defined in:
+                                                  - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                                   - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                                  If you specify ICMP or ICMPv6 as
-                                                  the protocol but omit this object,
-                                                  then all ICMP types and codes are
-                                                  allowed. If you do provide this
-                                                  object, the type is required and
-                                                  the code is optional. To enable
-                                                  MTU negotiation for ingress internet
-                                                  traffic via IPv4, make sure to allow
-                                                  type 3 ("Destination Unreachable")
-                                                  code 4 ("Fragmentation Needed and
-                                                  Don''t Fragment was Set"). If you
-                                                  need to specify multiple codes for
-                                                  a single type, create a separate
-                                                  security list rule for each.'
+                                                  If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                                  codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                                  To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                                  Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                                  multiple codes for a single type, create a separate security list rule for each.
                                                 properties:
                                                   code:
                                                     description: The ICMP code (optional).
@@ -2261,80 +1936,55 @@ spec:
                                                     type: integer
                                                 type: object
                                               isStateless:
-                                                description: A stateless rule allows
-                                                  traffic in one direction. Remember
-                                                  to add a corresponding stateless
-                                                  rule in the other direction if you
-                                                  need to support bidirectional traffic.
-                                                  For example, if ingress traffic
-                                                  allows TCP destination port 80,
-                                                  there should be an egress rule to
-                                                  allow TCP source port 80. Defaults
-                                                  to false, which means the rule is
-                                                  stateful and a corresponding rule
-                                                  is not necessary for bidirectional
-                                                  traffic.
+                                                description: |-
+                                                  A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                                  stateless rule in the other direction if you need to support bidirectional traffic. For
+                                                  example, if ingress traffic allows TCP destination port 80, there should be an egress
+                                                  rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                                  and a corresponding rule is not necessary for bidirectional traffic.
                                                 type: boolean
                                               protocol:
-                                                description: The transport protocol.
-                                                  Specify either `all` or an IPv4
-                                                  protocol number as defined in Protocol
-                                                  Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                                  Options are supported only for ICMP
-                                                  ("1"), TCP ("6"), UDP ("17"), and
-                                                  ICMPv6 ("58").
+                                                description: |-
+                                                  The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                                  defined in
+                                                  Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                                  Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                                 type: string
                                               source:
-                                                description: 'Conceptually, this is
-                                                  the range of IP addresses that a
-                                                  packet coming into the instance
-                                                  can come from. Allowed values: *
-                                                  IP address range in CIDR notation.
-                                                  For example: `192.168.1.0/24` or
-                                                  `2001:0db8:0123:45::/56`. IPv6 addressing
-                                                  is supported for all commercial
-                                                  and government regions. See IPv6
-                                                  Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                                  * The `cidrBlock` value for a Service,
-                                                  if you''re setting up a security
-                                                  list rule for traffic coming from
-                                                  a particular `Service` through a
-                                                  service gateway. For example: `oci-phx-objectstorage`.'
+                                                description: |-
+                                                  Conceptually, this is the range of IP addresses that a packet coming into the instance
+                                                  can come from.
+                                                  Allowed values:
+                                                    * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
+                                                      IPv6 addressing is supported for all commercial and government regions. See
+                                                      IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                                    * The `cidrBlock` value for a Service, if you're
+                                                      setting up a security list rule for traffic coming from a particular `Service` through
+                                                      a service gateway. For example: `oci-phx-objectstorage`.
                                                 type: string
                                               sourceType:
-                                                description: 'Type of source for the
-                                                  rule. The default is `CIDR_BLOCK`.
-                                                  * `CIDR_BLOCK`: If the rule''s `source`
-                                                  is an IP address range in CIDR notation.
-                                                  * `SERVICE_CIDR_BLOCK`: If the rule''s
-                                                  `source` is the `cidrBlock` value
-                                                  for a Service (the rule is for traffic
-                                                  coming from a particular `Service`
-                                                  through a service gateway). * `NETWORK_SECURITY_GROUP`:
-                                                  If the rule''s `destination` is
-                                                  the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)
-                                                  of a NetworkSecurityGroup.'
+                                                description: |-
+                                                  Type of source for the rule. The default is `CIDR_BLOCK`.
+                                                    * `CIDR_BLOCK`: If the rule's `source` is an IP address range in CIDR notation.
+                                                    * `SERVICE_CIDR_BLOCK`: If the rule's `source` is the `cidrBlock` value for a
+                                                      Service (the rule is for traffic coming from a
+                                                      particular `Service` through a service gateway).
+                                                    * `NETWORK_SECURITY_GROUP`: If the rule's `destination` is the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a
+                                                      NetworkSecurityGroup.
                                                 type: string
                                               tcpOptions:
-                                                description: TcpOptions Optional and
-                                                  valid only for TCP. Use to specify
-                                                  particular destination ports for
-                                                  TCP rules. If you specify TCP as
-                                                  the protocol but omit this object,
-                                                  then all destination ports are allowed.
+                                                description: |-
+                                                  TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                                  If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                                 properties:
                                                   destinationPortRange:
                                                     description: PortRange The representation
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -2348,13 +1998,9 @@ spec:
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -2365,25 +2011,18 @@ spec:
                                                     type: object
                                                 type: object
                                               udpOptions:
-                                                description: UdpOptions Optional and
-                                                  valid only for UDP. Use to specify
-                                                  particular destination ports for
-                                                  UDP rules. If you specify UDP as
-                                                  the protocol but omit this object,
-                                                  then all destination ports are allowed.
+                                                description: |-
+                                                  UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                                  If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                                 properties:
                                                   destinationPortRange:
                                                     description: PortRange The representation
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -2397,13 +2036,9 @@ spec:
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -2419,6 +2054,11 @@ spec:
                                           description: SecurityList Name.
                                           type: string
                                       type: object
+                                    skip:
+                                      description: |-
+                                        Skip specifies whether to skip creating subnets. If set to true(default: false) the ID
+                                        must be specified by the user to a valid Subnet ID.
+                                      type: boolean
                                     type:
                                       description: Type defines the subnet type (e.g.
                                         public, private).
@@ -2436,83 +2076,73 @@ spec:
                             description: VCNPeering configuration.
                             properties:
                               drg:
-                                description: DRG configuration refers to the DRG which
-                                  has to be created if required. If management cluster
-                                  and workload cluster shares the same DRG, this fields
-                                  is not required to be specified.
+                                description: |-
+                                  DRG configuration refers to the DRG which has to be created if required. If management cluster
+                                  and workload cluster shares the same DRG, this fields is not required to be specified.
                                 properties:
                                   id:
                                     description: ID is the OCID for the created DRG.
                                     type: string
                                   manage:
-                                    description: Manage defines whether the DRG has
-                                      to be managed(including create). If set to false(the
-                                      default) the ID has to be specified by the user
-                                      to a valid DRG ID to which the VCN has to be
-                                      attached.
+                                    description: |-
+                                      Manage defines whether the DRG has to be managed(including create). If set to false(the default) the ID
+                                      has to be specified by the user to a valid DRG ID to which the VCN has to be attached.
                                     type: boolean
                                   name:
                                     description: Name is the name of the created DRG.
                                     type: string
                                   vcnAttachmentId:
-                                    description: VcnAttachmentId is the ID of the
-                                      VCN attachment of the DRG. The workload cluster
-                                      VCN can be attached to either the management
-                                      cluster VCN if they are sharing the same DRG
+                                    description: |-
+                                      VcnAttachmentId is the ID of the VCN attachment of the DRG.
+                                      The workload cluster VCN can be attached to either the management cluster VCN if they are sharing the same DRG
                                       or to the workload cluster DRG.
                                     type: string
                                 type: object
                               peerRouteRules:
-                                description: PeerRouteRules defines the routing rules
-                                  which will be added to the private route tables
-                                  of the workload cluster VCN. The routes defined
-                                  here will be directed to DRG.
+                                description: |-
+                                  PeerRouteRules defines the routing rules which will be added to the private route tables
+                                  of the workload cluster VCN. The routes defined here will be directed to DRG.
                                 items:
                                   description: PeerRouteRule defines a Route Rule
                                     to be routed via a DRG.
                                   properties:
                                     vcnCIDRRange:
-                                      description: VCNCIDRRange is the CIDR Range
-                                        of peer VCN to which the workload cluster
-                                        VCN will be peered. The CIDR range is required
-                                        to add the route rule in the workload cluster
-                                        VCN, the route rule will forward any traffic
-                                        to the CIDR to the DRG.
+                                      description: |-
+                                        VCNCIDRRange is the CIDR Range of peer VCN to which the
+                                        workload cluster VCN will be peered. The CIDR range is required to add the route rule
+                                        in the workload cluster VCN, the route rule will forward any traffic to the CIDR to the DRG.
                                       type: string
                                   type: object
                                 type: array
                               remotePeeringConnections:
-                                description: RemotePeeringConnections defines the
-                                  RPC connections which be established with the workload
-                                  cluster DRG.
+                                description: |-
+                                  RemotePeeringConnections defines the RPC connections which be established with the
+                                  workload cluster DRG.
                                 items:
-                                  description: RemotePeeringConnection is used to
-                                    peer VCNs residing in different regions(typically).
+                                  description: |-
+                                    RemotePeeringConnection is used to peer VCNs residing in different regions(typically).
                                     Remote VCN Peering is explained here - https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/remoteVCNpeering.htm
                                   properties:
                                     managePeerRPC:
-                                      description: ManagePeerRPC will define if the
-                                        Peer VCN needs to be managed. If set to true
-                                        a Remote Peering Connection will be created
-                                        in the Peer DRG and the connection will be
-                                        created between local and peer RPC.
+                                      description: |-
+                                        ManagePeerRPC will define if the Peer VCN needs to be managed. If set to true
+                                        a Remote Peering Connection will be created in the Peer DRG and the connection
+                                        will be created between local and peer RPC.
                                       type: boolean
                                     name:
-                                      description: A unique name identifying the RPC,
-                                        please note this is to identify the RPC from
-                                        other RPC elements, and will not be used in
-                                        any OCI API call.
+                                      description: |-
+                                        A unique name identifying the RPC, please note this is to identify the RPC
+                                        from other RPC elements, and will not be used in any OCI API call.
                                       type: string
                                     peerDRGId:
                                       description: PeerDRGId defines the DRG ID of
                                         the peer.
                                       type: string
                                     peerRPCConnectionId:
-                                      description: PeerRPCConnectionId defines the
-                                        RPC ID of peer. If ManagePeerRPC is set to
-                                        true this will be created by Cluster API Provider
-                                        for OCI, otherwise this has be defined by
-                                        the user.
+                                      description: |-
+                                        PeerRPCConnectionId defines the RPC ID of peer. If ManagePeerRPC is set to true
+                                        this will be created by Cluster API Provider for OCI, otherwise this has be defined by the
+                                        user.
                                       type: string
                                     peerRegionName:
                                       description: PeerRegionName defined the region
@@ -2528,14 +2158,15 @@ spec:
                             type: object
                         type: object
                       ociResourceIdentifier:
-                        description: The unique ID which will be used to tag all the
-                          resources created by this Cluster. The tag will be used
-                          to identify resources belonging to this cluster. this will
-                          be auto-generated and should not be set by the user.
+                        description: |-
+                          The unique ID which will be used to tag all the resources created by this Cluster.
+                          The tag will be used to identify resources belonging to this cluster.
+                          this will be auto-generated and should not be set by the user.
                         type: string
                       region:
-                        description: Region the cluster operates in. It must be one
-                          of available regions in Region Identifier format. See https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm
+                        description: |-
+                          Region the cluster operates in. It must be one of available regions in Region Identifier format.
+                          See https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm
                         type: string
                     type: object
                 required:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimachinepoolmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimachinepoolmachines.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: ocimachinepoolmachines.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -19,14 +19,19 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -58,37 +63,44 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
+                      description: status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -110,14 +122,19 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -149,37 +166,44 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
+                      description: status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimachinepools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: ocimachinepools.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -19,14 +19,19 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -42,42 +47,41 @@ spec:
                       Agent software running on the instance.
                     properties:
                       areAllPluginsDisabled:
-                        description: AreAllPluginsDisabled defines whether Oracle
-                          Cloud Agent can run all the available plugins. This includes
-                          the management and monitoring plugins. To get a list of
-                          available plugins, use the ListInstanceagentAvailablePlugins
-                          operation in the Oracle Cloud Agent API. For more information
-                          about the available plugins, see Managing Plugins with Oracle
-                          Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
+                        description: |-
+                          AreAllPluginsDisabled defines whether Oracle Cloud Agent can run all the available plugins.
+                          This includes the management and monitoring plugins.
+                          To get a list of available plugins, use the
+                          ListInstanceagentAvailablePlugins
+                          operation in the Oracle Cloud Agent API. For more information about the available plugins, see
+                          Managing Plugins with Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
                         type: boolean
                       isManagementDisabled:
-                        description: 'IsManagementDisabled defines whether Oracle
-                          Cloud Agent can run all the available management plugins.
+                        description: |-
+                          IsManagementDisabled defines whether Oracle Cloud Agent can run all the available management plugins.
                           Default value is false (management plugins are enabled).
-                          These are the management plugins: OS Management Service
-                          Agent and Compute Instance Run Command. The management plugins
-                          are controlled by this parameter and by the per-plugin configuration
-                          in the `pluginsConfig` object. - If `isManagementDisabled`
-                          is true, all of the management plugins are disabled, regardless
-                          of the per-plugin configuration. - If `isManagementDisabled`
-                          is false, all of the management plugins are enabled. You
-                          can optionally disable individual management plugins by
-                          providing a value in the `pluginsConfig` object.'
+                          These are the management plugins: OS Management Service Agent and Compute Instance
+                          Run Command.
+                          The management plugins are controlled by this parameter and by the per-plugin
+                          configuration in the `pluginsConfig` object.
+                          - If `isManagementDisabled` is true, all of the management plugins are disabled, regardless of
+                          the per-plugin configuration.
+                          - If `isManagementDisabled` is false, all of the management plugins are enabled. You
+                          can optionally disable individual management plugins by providing a value in the `pluginsConfig`
+                          object.
                         type: boolean
                       isMonitoringDisabled:
-                        description: 'IsMonitoringDisabled defines whether Oracle
-                          Cloud Agent can gather performance metrics and monitor the
-                          instance using the monitoring plugins. Default value is
-                          false (monitoring plugins are enabled). These are the monitoring
-                          plugins: Compute Instance Monitoring and Custom Logs Monitoring.
-                          The monitoring plugins are controlled by this parameter
-                          and by the per-plugin configuration in the `pluginsConfig`
-                          object. - If `isMonitoringDisabled` is true, all of the
-                          monitoring plugins are disabled, regardless of the per-plugin
-                          configuration. - If `isMonitoringDisabled` is false, all
-                          of the monitoring plugins are enabled. You can optionally
-                          disable individual monitoring plugins by providing a value
-                          in the `pluginsConfig` object.'
+                        description: |-
+                          IsMonitoringDisabled defines whether Oracle Cloud Agent can gather performance metrics and monitor the instance using the
+                          monitoring plugins. Default value is false (monitoring plugins are enabled).
+                          These are the monitoring plugins: Compute Instance Monitoring
+                          and Custom Logs Monitoring.
+                          The monitoring plugins are controlled by this parameter and by the per-plugin
+                          configuration in the `pluginsConfig` object.
+                          - If `isMonitoringDisabled` is true, all of the monitoring plugins are disabled, regardless of
+                          the per-plugin configuration.
+                          - If `isMonitoringDisabled` is false, all of the monitoring plugins are enabled. You
+                          can optionally disable individual monitoring plugins by providing a value in the `pluginsConfig`
+                          object.
                         type: boolean
                       pluginsConfigs:
                         description: PluginsConfig defines the configuration of plugins
@@ -87,52 +91,48 @@ spec:
                             of plugins associated with this instance.
                           properties:
                             desiredState:
-                              description: 'DesiredState defines whether the plugin
-                                should be enabled or disabled. To enable the monitoring
-                                and management plugins, the `isMonitoringDisabled`
-                                and `isManagementDisabled` attributes must also be
-                                set to false. The following values are supported:
-                                * `ENABLED` * `DISABLED`'
+                              description: |-
+                                DesiredState defines whether the plugin should be enabled or disabled.
+                                To enable the monitoring and management plugins, the `isMonitoringDisabled` and
+                                `isManagementDisabled` attributes must also be set to false.
+                                The following values are supported:
+                                * `ENABLED`
+                                * `DISABLED`
                               type: string
                             name:
-                              description: Name defines the name of the plugin. To
-                                get a list of available plugins, use the ListInstanceagentAvailablePlugins
-                                operation in the Oracle Cloud Agent API. For more
-                                information about the available plugins, see Managing
-                                Plugins with Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
+                              description: |-
+                                Name defines the name of the plugin. To get a list of available plugins, use the
+                                ListInstanceagentAvailablePlugins
+                                operation in the Oracle Cloud Agent API. For more information about the available plugins, see
+                                Managing Plugins with Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
                               type: string
                           type: object
                         type: array
                     type: object
                   availabilityConfig:
-                    description: LaunchInstanceAvailabilityConfig defines the options
-                      for VM migration during infrastructure maintenance events and
-                      for defining the availability of a VM instance after a maintenance
-                      event that impacts the underlying hardware.
+                    description: |-
+                      LaunchInstanceAvailabilityConfig defines the options for VM migration during infrastructure maintenance events and for defining
+                      the availability of a VM instance after a maintenance event that impacts the underlying hardware.
                     properties:
                       isLiveMigrationPreferred:
-                        description: IsLiveMigrationPreferred defines whether to live
-                          migrate supported VM instances to a healthy physical VM
-                          host without disrupting running instances during infrastructure
-                          maintenance events. If null, Oracle chooses the best option
-                          for migrating the VM during infrastructure maintenance events.
+                        description: |-
+                          IsLiveMigrationPreferred defines whether to live migrate supported VM instances to a healthy physical VM host without
+                          disrupting running instances during infrastructure maintenance events. If null, Oracle
+                          chooses the best option for migrating the VM during infrastructure maintenance events.
                         type: boolean
                       recoveryAction:
-                        description: RecoveryAction defines the lifecycle state for
-                          an instance when it is recovered after infrastructure maintenance.
-                          * `RESTORE_INSTANCE` - The instance is restored to the lifecycle
-                          state it was in before the maintenance event. If the instance
-                          was running, it is automatically rebooted. This is the default
-                          action when a value is not set. * `STOP_INSTANCE` - The
-                          instance is recovered in the stopped state.
+                        description: |-
+                          RecoveryAction defines the lifecycle state for an instance when it is recovered after infrastructure maintenance.
+                          * `RESTORE_INSTANCE` - The instance is restored to the lifecycle state it was in before the maintenance event.
+                          If the instance was running, it is automatically rebooted. This is the default action when a value is not set.
+                          * `STOP_INSTANCE` - The instance is recovered in the stopped state.
                         type: string
                     type: object
                   capacityReservationId:
-                    description: CapacityReservationId defines the OCID of the compute
-                      capacity reservation this instance is launched under. You can
-                      opt out of all default reservations by specifying an empty string
-                      as input for this field. For more information, see Capacity
-                      Reservations (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/reserve-capacity.htm#default).
+                    description: |-
+                      CapacityReservationId defines the OCID of the compute capacity reservation this instance is launched under.
+                      You can opt out of all default reservations by specifying an empty string as input for this field.
+                      For more information, see Capacity Reservations (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/reserve-capacity.htm#default).
                     type: string
                   dedicatedVmHostId:
                     description: DedicatedVmHostId defines the OCID of the dedicated
@@ -144,10 +144,10 @@ spec:
                     description: InstanceOptions defines the instance options
                     properties:
                       areLegacyImdsEndpointsDisabled:
-                        description: Whether to disable the legacy (/v1) instance
-                          metadata service endpoints. Customers who have migrated
-                          to /v2 should set this to true for added security. Default
-                          is false.
+                        description: |-
+                          Whether to disable the legacy (/v1) instance metadata service endpoints.
+                          Customers who have migrated to /v2 should set this to true for added security.
+                          Default is false.
                         type: boolean
                     type: object
                   instanceSourceViaImageConfig:
@@ -155,21 +155,21 @@ spec:
                       for booting up instances via images
                     properties:
                       bootVolumeSizeInGBs:
-                        description: The size of boot volume. Please see https://docs.oracle.com/en-us/iaas/Content/Block/Tasks/extendingbootpartition.htm
+                        description: |-
+                          The size of boot volume. Please see https://docs.oracle.com/en-us/iaas/Content/Block/Tasks/extendingbootpartition.htm
                           to extend the boot volume size.
                         format: int64
                         type: integer
                       bootVolumeVpusPerGB:
-                        description: 'BootVolumeVpusPerGB defines the number of volume
-                          performance units (VPUs) that will be applied to this volume
-                          per GB, representing the Block Volume service''s elastic
-                          performance options. See Block Volume Performance Levels
-                          (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels)
-                          for more information. Allowed values: * `10`: Represents
-                          Balanced option. * `20`: Represents Higher Performance option.
-                          * `30`-`120`: Represents the Ultra High Performance option.
-                          For volumes with the auto-tuned performance feature enabled,
-                          this is set to the default (minimum) VPUs/GB.'
+                        description: |-
+                          BootVolumeVpusPerGB defines the number of volume performance units (VPUs) that will be applied to this volume per GB,
+                          representing the Block Volume service's elastic performance options.
+                          See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels) for more information.
+                          Allowed values:
+                            * `10`: Represents Balanced option.
+                            * `20`: Represents Higher Performance option.
+                            * `30`-`120`: Represents the Ultra High Performance option.
+                          For volumes with the auto-tuned performance feature enabled, this is set to the default (minimum) VPUs/GB.
                         format: int64
                         type: integer
                       imageId:
@@ -185,6 +185,9 @@ spec:
                     description: NetworkDetails defines the configuration options
                       for the network
                     properties:
+                      assignIpv6Ip:
+                        description: IPv6 defines if the instance should have an IPv6
+                        type: boolean
                       assignPrivateDnsRecord:
                         description: AssignPrivateDnsRecord defines whether the VNIC
                           should be assigned a DNS record.
@@ -194,18 +197,18 @@ spec:
                           have a public IP address
                         type: boolean
                       displayName:
-                        description: DisplayName defines a user-friendly name. Does
-                          not have to be unique, and it's changeable. Avoid entering
-                          confidential information.
+                        description: |-
+                          DisplayName defines a user-friendly name. Does not have to be unique, and it's changeable.
+                          Avoid entering confidential information.
                         type: string
                       hostnameLabel:
                         description: HostnameLabel defines the hostname for the VNIC's
                           primary private IP. Used for DNS.
                         type: string
                       nsgId:
-                        description: NSGId defines the ID of the NSG to use. This
-                          parameter takes priority over NsgNames. Deprecated, please
-                          use NetworkDetails.NSGIds
+                        description: |-
+                          NSGId defines the ID of the NSG to use. This parameter takes priority over NsgNames.
+                          Deprecated, please use NetworkDetails.NSGIds
                         type: string
                       nsgIds:
                         description: NSGIds defines the list of NSG IDs to use. This
@@ -241,23 +244,23 @@ spec:
                       compatibility and performance of VM shapes
                     properties:
                       bootVolumeType:
-                        description: BootVolumeType defines Emulation type for the
-                          boot volume. * `ISCSI` - ISCSI attached block storage device.
-                          * `SCSI` - Emulated SCSI disk. * `IDE` - Emulated IDE disk.
-                          * `VFIO` - Direct attached Virtual Function storage. This
-                          is the default option for local data volumes on platform
-                          images. * `PARAVIRTUALIZED` - Paravirtualized disk. This
-                          is the default for boot volumes and remote block storage
+                        description: |-
+                          BootVolumeType defines Emulation type for the boot volume.
+                          * `ISCSI` - ISCSI attached block storage device.
+                          * `SCSI` - Emulated SCSI disk.
+                          * `IDE` - Emulated IDE disk.
+                          * `VFIO` - Direct attached Virtual Function storage. This is the default option for local data
                           volumes on platform images.
+                          * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+                          storage volumes on platform images.
                         type: string
                       firmware:
-                        description: Firmware defines the firmware used to boot VM.
-                          Select the option that matches your operating system. *
-                          `BIOS` - Boot VM using BIOS style firmware. This is compatible
-                          with both 32 bit and 64 bit operating systems that boot
-                          using MBR style bootloaders. * `UEFI_64` - Boot VM using
-                          UEFI style firmware compatible with 64 bit operating systems.
-                          This is the default for platform images.
+                        description: |-
+                          Firmware defines the firmware used to boot VM. Select the option that matches your operating system.
+                          * `BIOS` - Boot VM using BIOS style firmware. This is compatible with both 32 bit and 64 bit operating
+                          systems that boot using MBR style bootloaders.
+                          * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems. This is the
+                          default for platform images.
                         type: string
                       isConsistentVolumeNamingEnabled:
                         description: IsConsistentVolumeNamingEnabled defines whether
@@ -265,31 +268,31 @@ spec:
                           false.
                         type: boolean
                       networkType:
-                        description: NetworkType defines the emulation type for the
-                          physical network interface card (NIC). * `E1000` - Emulated
-                          Gigabit ethernet controller. Compatible with Linux e1000
-                          network driver. * `VFIO` - Direct attached Virtual Function
-                          network controller. This is the networking type when you
-                          launch an instance using hardware-assisted (SR-IOV) networking.
-                          * `PARAVIRTUALIZED` - VM instances launch with paravirtualized
-                          devices using VirtIO drivers.
+                        description: |-
+                          NetworkType defines the emulation type for the physical network interface card (NIC).
+                          * `E1000` - Emulated Gigabit ethernet controller. Compatible with Linux e1000 network driver.
+                          * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
+                          when you launch an instance using hardware-assisted (SR-IOV) networking.
+                          * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
                         type: string
                       remoteDataVolumeType:
-                        description: RemoteDataVolumeType defines the emulation type
-                          for volume. * `ISCSI` - ISCSI attached block storage device.
-                          * `SCSI` - Emulated SCSI disk. * `IDE` - Emulated IDE disk.
-                          * `VFIO` - Direct attached Virtual Function storage. This
-                          is the default option for local data volumes on platform
-                          images. * `PARAVIRTUALIZED` - Paravirtualized disk. This
-                          is the default for boot volumes and remote block storage
+                        description: |-
+                          RemoteDataVolumeType defines the emulation type for volume.
+                          * `ISCSI` - ISCSI attached block storage device.
+                          * `SCSI` - Emulated SCSI disk.
+                          * `IDE` - Emulated IDE disk.
+                          * `VFIO` - Direct attached Virtual Function storage. This is the default option for local data
                           volumes on platform images.
+                          * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+                          storage volumes on platform images.
                         type: string
                     type: object
                   metadata:
                     additionalProperties:
                       type: string
-                    description: Custom metadata key/value pairs that you provide,
-                      such as the SSH public key required to connect to the instance.
+                    description: |-
+                      Custom metadata key/value pairs that you provide, such as the SSH public key
+                      required to connect to the instance.
                     type: object
                   platformConfig:
                     description: PlatformConfig defines the platform config parameters
@@ -299,14 +302,14 @@ spec:
                           platform configuration
                         properties:
                           areVirtualInstructionsEnabled:
-                            description: Whether virtualization instructions are available.
-                              For example, Secure Virtual Machine for AMD shapes or
-                              VT-x for Intel shapes.
+                            description: |-
+                              Whether virtualization instructions are available. For example, Secure Virtual Machine for AMD shapes
+                              or VT-x for Intel shapes.
                             type: boolean
                           isAccessControlServiceEnabled:
-                            description: Whether the Access Control Service is enabled
-                              on the instance. When enabled, the platform can enforce
-                              PCIe device isolation, required for VFIO device pass-through.
+                            description: |-
+                              Whether the Access Control Service is enabled on the instance. When enabled,
+                              the platform can enforce PCIe device isolation, required for VFIO device pass-through.
                             type: boolean
                           isInputOutputMemoryManagementUnitEnabled:
                             description: Whether the input-output memory management
@@ -325,37 +328,35 @@ spec:
                             description: Whether Secure Boot is enabled on the instance.
                             type: boolean
                           isSymmetricMultiThreadingEnabled:
-                            description: Whether symmetric multithreading is enabled
-                              on the instance. Symmetric multithreading is also called
-                              simultaneous multithreading (SMT) or Intel Hyper-Threading.
-                              Intel and AMD processors have two hardware execution
-                              threads per core (OCPU). SMT permits multiple independent
-                              threads of execution, to better use the resources and
-                              increase the efficiency of the CPU. When multithreading
-                              is disabled, only one thread is permitted to run on
-                              each core, which can provide higher or more predictable
-                              performance for some workloads.
+                            description: |-
+                              Whether symmetric multithreading is enabled on the instance. Symmetric multithreading is also
+                              called simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                              Intel and AMD processors have two hardware execution threads per core (OCPU). SMT permits multiple
+                              independent threads of execution, to better use the resources and increase the efficiency
+                              of the CPU. When multithreading is disabled, only one thread is permitted to run on each core, which
+                              can provide higher or more predictable performance for some workloads.
                             type: boolean
                           isTrustedPlatformModuleEnabled:
                             description: Whether the Trusted Platform Module (TPM)
                               is enabled on the instance.
                             type: boolean
                           numaNodesPerSocket:
-                            description: 'The number of NUMA nodes per socket (NPS).
-                              The following values are supported: * `NPS0` * `NPS1`
-                              * `NPS2` * `NPS4`'
+                            description: |-
+                              The number of NUMA nodes per socket (NPS).
+                              The following values are supported:
+                              * `NPS0`
+                              * `NPS1`
+                              * `NPS2`
+                              * `NPS4`
                             type: string
                           percentageOfCoresEnabled:
-                            description: The percentage of cores enabled. Value must
-                              be a multiple of 25%. If the requested percentage results
-                              in a fractional number of cores, the system rounds up
-                              the number of cores across processors and provisions
-                              an instance with a whole number of cores. If the applications
-                              that you run on the instance use a core-based licensing
-                              model and need fewer cores than the full size of the
-                              shape, you can disable cores to reduce your licensing
-                              costs. The instance itself is billed for the full shape,
-                              regardless of whether all cores are enabled.
+                            description: |-
+                              The percentage of cores enabled. Value must be a multiple of 25%. If the requested percentage
+                              results in a fractional number of cores, the system rounds up the number of cores across processors
+                              and provisions an instance with a whole number of cores.
+                              If the applications that you run on the instance use a core-based licensing model and need fewer cores
+                              than the full size of the shape, you can disable cores to reduce your licensing costs. The instance
+                              itself is billed for the full shape, regardless of whether all cores are enabled.
                             type: integer
                         type: object
                       amdRomeBmGpuPlatformConfig:
@@ -363,14 +364,14 @@ spec:
                           platform configuration
                         properties:
                           areVirtualInstructionsEnabled:
-                            description: Whether virtualization instructions are available.
-                              For example, Secure Virtual Machine for AMD shapes or
-                              VT-x for Intel shapes.
+                            description: |-
+                              Whether virtualization instructions are available. For example, Secure Virtual Machine for AMD shapes
+                              or VT-x for Intel shapes.
                             type: boolean
                           isAccessControlServiceEnabled:
-                            description: Whether the Access Control Service is enabled
-                              on the instance. When enabled, the platform can enforce
-                              PCIe device isolation, required for VFIO device pass-through.
+                            description: |-
+                              Whether the Access Control Service is enabled on the instance. When enabled,
+                              the platform can enforce PCIe device isolation, required for VFIO device pass-through.
                             type: boolean
                           isInputOutputMemoryManagementUnitEnabled:
                             description: Whether the input-output memory management
@@ -389,25 +390,26 @@ spec:
                             description: Whether Secure Boot is enabled on the instance.
                             type: boolean
                           isSymmetricMultiThreadingEnabled:
-                            description: Whether symmetric multithreading is enabled
-                              on the instance. Symmetric multithreading is also called
-                              simultaneous multithreading (SMT) or Intel Hyper-Threading.
-                              Intel and AMD processors have two hardware execution
-                              threads per core (OCPU). SMT permits multiple independent
-                              threads of execution, to better use the resources and
-                              increase the efficiency of the CPU. When multithreading
-                              is disabled, only one thread is permitted to run on
-                              each core, which can provide higher or more predictable
-                              performance for some workloads.
+                            description: |-
+                              Whether symmetric multithreading is enabled on the instance. Symmetric multithreading is also
+                              called simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                              Intel and AMD processors have two hardware execution threads per core (OCPU). SMT permits multiple
+                              independent threads of execution, to better use the resources and increase the efficiency
+                              of the CPU. When multithreading is disabled, only one thread is permitted to run on each core, which
+                              can provide higher or more predictable performance for some workloads.
                             type: boolean
                           isTrustedPlatformModuleEnabled:
                             description: Whether the Trusted Platform Module (TPM)
                               is enabled on the instance.
                             type: boolean
                           numaNodesPerSocket:
-                            description: 'The number of NUMA nodes per socket (NPS).
-                              The following values are supported: * `NPS0` * `NPS1`
-                              * `NPS2` * `NPS4`'
+                            description: |-
+                              The number of NUMA nodes per socket (NPS).
+                              The following values are supported:
+                              * `NPS0`
+                              * `NPS1`
+                              * `NPS2`
+                              * `NPS4`
                             type: string
                         type: object
                       amdRomeBmPlatformConfig:
@@ -415,14 +417,14 @@ spec:
                           platform configuration
                         properties:
                           areVirtualInstructionsEnabled:
-                            description: Whether virtualization instructions are available.
-                              For example, Secure Virtual Machine for AMD shapes or
-                              VT-x for Intel shapes.
+                            description: |-
+                              Whether virtualization instructions are available. For example, Secure Virtual Machine for AMD shapes
+                              or VT-x for Intel shapes.
                             type: boolean
                           isAccessControlServiceEnabled:
-                            description: Whether the Access Control Service is enabled
-                              on the instance. When enabled, the platform can enforce
-                              PCIe device isolation, required for VFIO device pass-through.
+                            description: |-
+                              Whether the Access Control Service is enabled on the instance. When enabled,
+                              the platform can enforce PCIe device isolation, required for VFIO device pass-through.
                             type: boolean
                           isInputOutputMemoryManagementUnitEnabled:
                             description: Whether the input-output memory management
@@ -441,37 +443,35 @@ spec:
                             description: Whether Secure Boot is enabled on the instance.
                             type: boolean
                           isSymmetricMultiThreadingEnabled:
-                            description: Whether symmetric multithreading is enabled
-                              on the instance. Symmetric multithreading is also called
-                              simultaneous multithreading (SMT) or Intel Hyper-Threading.
-                              Intel and AMD processors have two hardware execution
-                              threads per core (OCPU). SMT permits multiple independent
-                              threads of execution, to better use the resources and
-                              increase the efficiency of the CPU. When multithreading
-                              is disabled, only one thread is permitted to run on
-                              each core, which can provide higher or more predictable
-                              performance for some workloads.
+                            description: |-
+                              Whether symmetric multithreading is enabled on the instance. Symmetric multithreading is also
+                              called simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                              Intel and AMD processors have two hardware execution threads per core (OCPU). SMT permits multiple
+                              independent threads of execution, to better use the resources and increase the efficiency
+                              of the CPU. When multithreading is disabled, only one thread is permitted to run on each core, which
+                              can provide higher or more predictable performance for some workloads.
                             type: boolean
                           isTrustedPlatformModuleEnabled:
                             description: Whether the Trusted Platform Module (TPM)
                               is enabled on the instance.
                             type: boolean
                           numaNodesPerSocket:
-                            description: 'The number of NUMA nodes per socket (NPS).
-                              The following values are supported: * `NPS0` * `NPS1`
-                              * `NPS2` * `NPS4`'
+                            description: |-
+                              The number of NUMA nodes per socket (NPS).
+                              The following values are supported:
+                              * `NPS0`
+                              * `NPS1`
+                              * `NPS2`
+                              * `NPS4`
                             type: string
                           percentageOfCoresEnabled:
-                            description: The percentage of cores enabled. Value must
-                              be a multiple of 25%. If the requested percentage results
-                              in a fractional number of cores, the system rounds up
-                              the number of cores across processors and provisions
-                              an instance with a whole number of cores. If the applications
-                              that you run on the instance use a core-based licensing
-                              model and need fewer cores than the full size of the
-                              shape, you can disable cores to reduce your licensing
-                              costs. The instance itself is billed for the full shape,
-                              regardless of whether all cores are enabled.
+                            description: |-
+                              The percentage of cores enabled. Value must be a multiple of 25%. If the requested percentage
+                              results in a fractional number of cores, the system rounds up the number of cores across processors
+                              and provisions an instance with a whole number of cores.
+                              If the applications that you run on the instance use a core-based licensing model and need fewer cores
+                              than the full size of the shape, you can disable cores to reduce your licensing costs. The instance
+                              itself is billed for the full shape, regardless of whether all cores are enabled.
                             type: integer
                         type: object
                       amdVmPlatformConfig:
@@ -516,36 +516,33 @@ spec:
                             description: Whether Secure Boot is enabled on the instance.
                             type: boolean
                           isSymmetricMultiThreadingEnabled:
-                            description: Whether symmetric multithreading is enabled
-                              on the instance. Symmetric multithreading is also called
-                              simultaneous multithreading (SMT) or Intel Hyper-Threading.
-                              Intel and AMD processors have two hardware execution
-                              threads per core (OCPU). SMT permits multiple independent
-                              threads of execution, to better use the resources and
-                              increase the efficiency of the CPU. When multithreading
-                              is disabled, only one thread is permitted to run on
-                              each core, which can provide higher or more predictable
-                              performance for some workloads.
+                            description: |-
+                              Whether symmetric multithreading is enabled on the instance. Symmetric multithreading is also
+                              called simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                              Intel and AMD processors have two hardware execution threads per core (OCPU). SMT permits multiple
+                              independent threads of execution, to better use the resources and increase the efficiency
+                              of the CPU. When multithreading is disabled, only one thread is permitted to run on each core, which
+                              can provide higher or more predictable performance for some workloads.
                             type: boolean
                           isTrustedPlatformModuleEnabled:
                             description: Whether the Trusted Platform Module (TPM)
                               is enabled on the instance.
                             type: boolean
                           numaNodesPerSocket:
-                            description: 'The number of NUMA nodes per socket (NPS).
-                              The following values are supported: * `NPS1` * `NPS2`'
+                            description: |-
+                              The number of NUMA nodes per socket (NPS).
+                              The following values are supported:
+                              * `NPS1`
+                              * `NPS2`
                             type: string
                           percentageOfCoresEnabled:
-                            description: The percentage of cores enabled. Value must
-                              be a multiple of 25%. If the requested percentage results
-                              in a fractional number of cores, the system rounds up
-                              the number of cores across processors and provisions
-                              an instance with a whole number of cores. If the applications
-                              that you run on the instance use a core-based licensing
-                              model and need fewer cores than the full size of the
-                              shape, you can disable cores to reduce your licensing
-                              costs. The instance itself is billed for the full shape,
-                              regardless of whether all cores are enabled.
+                            description: |-
+                              The percentage of cores enabled. Value must be a multiple of 25%. If the requested percentage
+                              results in a fractional number of cores, the system rounds up the number of cores across processors
+                              and provisions an instance with a whole number of cores.
+                              If the applications that you run on the instance use a core-based licensing model and need fewer cores
+                              than the full size of the shape, you can disable cores to reduce your licensing costs. The instance
+                              itself is billed for the full shape, regardless of whether all cores are enabled.
                             type: integer
                         type: object
                       intelSkylakeBmPlatformConfig:
@@ -591,11 +588,16 @@ spec:
                             type: boolean
                         type: object
                       platformConfigType:
-                        description: The type of platform configuration. Valid values
-                          are * `AMD_ROME_BM_GPU` * `AMD_ROME_BM` * `INTEL_ICELAKE_BM`
-                          * `AMD_VM` * `INTEL_VM` * `INTEL_SKYLAKE_BM` * `AMD_MILAN_BM`
-                          Based on the enum, exactly one of the specific configuration
-                          types must be set
+                        description: |-
+                          The type of platform configuration. Valid values are
+                          * `AMD_ROME_BM_GPU`
+                          * `AMD_ROME_BM`
+                          * `INTEL_ICELAKE_BM`
+                          * `AMD_VM`
+                          * `INTEL_VM`
+                          * `INTEL_SKYLAKE_BM`
+                          * `AMD_MILAN_BM`
+                          Based on the enum, exactly one of the specific configuration types must be set
                         type: string
                     type: object
                   preemptibleInstanceConfig:
@@ -621,14 +623,13 @@ spec:
                       for flex instances.
                     properties:
                       baselineOcpuUtilization:
-                        description: 'The baseline OCPU utilization for a subcore
-                          burstable VM instance. Leave this attribute blank for a
-                          non-burstable instance, or explicitly specify non-burstable
-                          with `BASELINE_1_1`. The following values are supported:
-                          - `BASELINE_1_8` - baseline usage is 1/8 of an OCPU. - `BASELINE_1_2`
-                          - baseline usage is 1/2 of an OCPU. - `BASELINE_1_1` - baseline
-                          usage is an entire OCPU. This represents a non-burstable
-                          instance.'
+                        description: |-
+                          The baseline OCPU utilization for a subcore burstable VM instance. Leave this attribute blank for a
+                          non-burstable instance, or explicitly specify non-burstable with `BASELINE_1_1`.
+                          The following values are supported:
+                          - `BASELINE_1_8` - baseline usage is 1/8 of an OCPU.
+                          - `BASELINE_1_2` - baseline usage is 1/2 of an OCPU.
+                          - `BASELINE_1_1` - baseline usage is an entire OCPU. This represents a non-burstable instance.
                         type: string
                       memoryInGBs:
                         description: The total amount of memory available to the instance,
@@ -663,10 +664,9 @@ spec:
                   in a provider format
                 type: string
               providerIDList:
-                description: ProviderIDList are the identification IDs of machine
-                  instances provided by the provider. This field must match the provider
-                  IDs as seen on the node objects corresponding to a machine pool's
-                  machine instances.
+                description: |-
+                  ProviderIDList are the identification IDs of machine instances provided by the provider.
+                  This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
                 items:
                   type: string
                 type: array
@@ -681,37 +681,44 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
+                      description: status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -722,8 +729,6 @@ spec:
               failureMessage:
                 type: string
               failureReason:
-                description: MachineStatusError defines errors states for Machine
-                  objects.
                 type: string
               infrastructureMachineKind:
                 description: InfrastructureMachineKind is the kind of the infrastructure
@@ -747,14 +752,19 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -770,42 +780,41 @@ spec:
                       Agent software running on the instance.
                     properties:
                       areAllPluginsDisabled:
-                        description: AreAllPluginsDisabled defines whether Oracle
-                          Cloud Agent can run all the available plugins. This includes
-                          the management and monitoring plugins. To get a list of
-                          available plugins, use the ListInstanceagentAvailablePlugins
-                          operation in the Oracle Cloud Agent API. For more information
-                          about the available plugins, see Managing Plugins with Oracle
-                          Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
+                        description: |-
+                          AreAllPluginsDisabled defines whether Oracle Cloud Agent can run all the available plugins.
+                          This includes the management and monitoring plugins.
+                          To get a list of available plugins, use the
+                          ListInstanceagentAvailablePlugins
+                          operation in the Oracle Cloud Agent API. For more information about the available plugins, see
+                          Managing Plugins with Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
                         type: boolean
                       isManagementDisabled:
-                        description: 'IsManagementDisabled defines whether Oracle
-                          Cloud Agent can run all the available management plugins.
+                        description: |-
+                          IsManagementDisabled defines whether Oracle Cloud Agent can run all the available management plugins.
                           Default value is false (management plugins are enabled).
-                          These are the management plugins: OS Management Service
-                          Agent and Compute Instance Run Command. The management plugins
-                          are controlled by this parameter and by the per-plugin configuration
-                          in the `pluginsConfig` object. - If `isManagementDisabled`
-                          is true, all of the management plugins are disabled, regardless
-                          of the per-plugin configuration. - If `isManagementDisabled`
-                          is false, all of the management plugins are enabled. You
-                          can optionally disable individual management plugins by
-                          providing a value in the `pluginsConfig` object.'
+                          These are the management plugins: OS Management Service Agent and Compute Instance
+                          Run Command.
+                          The management plugins are controlled by this parameter and by the per-plugin
+                          configuration in the `pluginsConfig` object.
+                          - If `isManagementDisabled` is true, all of the management plugins are disabled, regardless of
+                          the per-plugin configuration.
+                          - If `isManagementDisabled` is false, all of the management plugins are enabled. You
+                          can optionally disable individual management plugins by providing a value in the `pluginsConfig`
+                          object.
                         type: boolean
                       isMonitoringDisabled:
-                        description: 'IsMonitoringDisabled defines whether Oracle
-                          Cloud Agent can gather performance metrics and monitor the
-                          instance using the monitoring plugins. Default value is
-                          false (monitoring plugins are enabled). These are the monitoring
-                          plugins: Compute Instance Monitoring and Custom Logs Monitoring.
-                          The monitoring plugins are controlled by this parameter
-                          and by the per-plugin configuration in the `pluginsConfig`
-                          object. - If `isMonitoringDisabled` is true, all of the
-                          monitoring plugins are disabled, regardless of the per-plugin
-                          configuration. - If `isMonitoringDisabled` is false, all
-                          of the monitoring plugins are enabled. You can optionally
-                          disable individual monitoring plugins by providing a value
-                          in the `pluginsConfig` object.'
+                        description: |-
+                          IsMonitoringDisabled defines whether Oracle Cloud Agent can gather performance metrics and monitor the instance using the
+                          monitoring plugins. Default value is false (monitoring plugins are enabled).
+                          These are the monitoring plugins: Compute Instance Monitoring
+                          and Custom Logs Monitoring.
+                          The monitoring plugins are controlled by this parameter and by the per-plugin
+                          configuration in the `pluginsConfig` object.
+                          - If `isMonitoringDisabled` is true, all of the monitoring plugins are disabled, regardless of
+                          the per-plugin configuration.
+                          - If `isMonitoringDisabled` is false, all of the monitoring plugins are enabled. You
+                          can optionally disable individual monitoring plugins by providing a value in the `pluginsConfig`
+                          object.
                         type: boolean
                       pluginsConfigs:
                         description: PluginsConfig defines the configuration of plugins
@@ -815,52 +824,48 @@ spec:
                             of plugins associated with this instance.
                           properties:
                             desiredState:
-                              description: 'DesiredState defines whether the plugin
-                                should be enabled or disabled. To enable the monitoring
-                                and management plugins, the `isMonitoringDisabled`
-                                and `isManagementDisabled` attributes must also be
-                                set to false. The following values are supported:
-                                * `ENABLED` * `DISABLED`'
+                              description: |-
+                                DesiredState defines whether the plugin should be enabled or disabled.
+                                To enable the monitoring and management plugins, the `isMonitoringDisabled` and
+                                `isManagementDisabled` attributes must also be set to false.
+                                The following values are supported:
+                                * `ENABLED`
+                                * `DISABLED`
                               type: string
                             name:
-                              description: Name defines the name of the plugin. To
-                                get a list of available plugins, use the ListInstanceagentAvailablePlugins
-                                operation in the Oracle Cloud Agent API. For more
-                                information about the available plugins, see Managing
-                                Plugins with Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
+                              description: |-
+                                Name defines the name of the plugin. To get a list of available plugins, use the
+                                ListInstanceagentAvailablePlugins
+                                operation in the Oracle Cloud Agent API. For more information about the available plugins, see
+                                Managing Plugins with Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
                               type: string
                           type: object
                         type: array
                     type: object
                   availabilityConfig:
-                    description: LaunchInstanceAvailabilityConfig defines the options
-                      for VM migration during infrastructure maintenance events and
-                      for defining the availability of a VM instance after a maintenance
-                      event that impacts the underlying hardware.
+                    description: |-
+                      LaunchInstanceAvailabilityConfig defines the options for VM migration during infrastructure maintenance events and for defining
+                      the availability of a VM instance after a maintenance event that impacts the underlying hardware.
                     properties:
                       isLiveMigrationPreferred:
-                        description: IsLiveMigrationPreferred defines whether to live
-                          migrate supported VM instances to a healthy physical VM
-                          host without disrupting running instances during infrastructure
-                          maintenance events. If null, Oracle chooses the best option
-                          for migrating the VM during infrastructure maintenance events.
+                        description: |-
+                          IsLiveMigrationPreferred defines whether to live migrate supported VM instances to a healthy physical VM host without
+                          disrupting running instances during infrastructure maintenance events. If null, Oracle
+                          chooses the best option for migrating the VM during infrastructure maintenance events.
                         type: boolean
                       recoveryAction:
-                        description: RecoveryAction defines the lifecycle state for
-                          an instance when it is recovered after infrastructure maintenance.
-                          * `RESTORE_INSTANCE` - The instance is restored to the lifecycle
-                          state it was in before the maintenance event. If the instance
-                          was running, it is automatically rebooted. This is the default
-                          action when a value is not set. * `STOP_INSTANCE` - The
-                          instance is recovered in the stopped state.
+                        description: |-
+                          RecoveryAction defines the lifecycle state for an instance when it is recovered after infrastructure maintenance.
+                          * `RESTORE_INSTANCE` - The instance is restored to the lifecycle state it was in before the maintenance event.
+                          If the instance was running, it is automatically rebooted. This is the default action when a value is not set.
+                          * `STOP_INSTANCE` - The instance is recovered in the stopped state.
                         type: string
                     type: object
                   capacityReservationId:
-                    description: CapacityReservationId defines the OCID of the compute
-                      capacity reservation this instance is launched under. You can
-                      opt out of all default reservations by specifying an empty string
-                      as input for this field. For more information, see Capacity
-                      Reservations (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/reserve-capacity.htm#default).
+                    description: |-
+                      CapacityReservationId defines the OCID of the compute capacity reservation this instance is launched under.
+                      You can opt out of all default reservations by specifying an empty string as input for this field.
+                      For more information, see Capacity Reservations (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/reserve-capacity.htm#default).
                     type: string
                   dedicatedVmHostId:
                     description: DedicatedVmHostId defines the OCID of the dedicated
@@ -872,10 +877,10 @@ spec:
                     description: InstanceOptions defines the instance options
                     properties:
                       areLegacyImdsEndpointsDisabled:
-                        description: Whether to disable the legacy (/v1) instance
-                          metadata service endpoints. Customers who have migrated
-                          to /v2 should set this to true for added security. Default
-                          is false.
+                        description: |-
+                          Whether to disable the legacy (/v1) instance metadata service endpoints.
+                          Customers who have migrated to /v2 should set this to true for added security.
+                          Default is false.
                         type: boolean
                     type: object
                   instanceSourceViaImageConfig:
@@ -883,21 +888,21 @@ spec:
                       for booting up instances via images
                     properties:
                       bootVolumeSizeInGBs:
-                        description: The size of boot volume. Please see https://docs.oracle.com/en-us/iaas/Content/Block/Tasks/extendingbootpartition.htm
+                        description: |-
+                          The size of boot volume. Please see https://docs.oracle.com/en-us/iaas/Content/Block/Tasks/extendingbootpartition.htm
                           to extend the boot volume size.
                         format: int64
                         type: integer
                       bootVolumeVpusPerGB:
-                        description: 'BootVolumeVpusPerGB defines the number of volume
-                          performance units (VPUs) that will be applied to this volume
-                          per GB, representing the Block Volume service''s elastic
-                          performance options. See Block Volume Performance Levels
-                          (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels)
-                          for more information. Allowed values: * `10`: Represents
-                          Balanced option. * `20`: Represents Higher Performance option.
-                          * `30`-`120`: Represents the Ultra High Performance option.
-                          For volumes with the auto-tuned performance feature enabled,
-                          this is set to the default (minimum) VPUs/GB.'
+                        description: |-
+                          BootVolumeVpusPerGB defines the number of volume performance units (VPUs) that will be applied to this volume per GB,
+                          representing the Block Volume service's elastic performance options.
+                          See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels) for more information.
+                          Allowed values:
+                            * `10`: Represents Balanced option.
+                            * `20`: Represents Higher Performance option.
+                            * `30`-`120`: Represents the Ultra High Performance option.
+                          For volumes with the auto-tuned performance feature enabled, this is set to the default (minimum) VPUs/GB.
                         format: int64
                         type: integer
                       imageId:
@@ -913,6 +918,10 @@ spec:
                     description: NetworkDetails defines the configuration options
                       for the network
                     properties:
+                      assignIpv6Ip:
+                        description: AssignIPv6 determines whether to assign a IPv6
+                          address to the instance.
+                        type: boolean
                       assignPrivateDnsRecord:
                         description: AssignPrivateDnsRecord defines whether the VNIC
                           should be assigned a DNS record.
@@ -922,18 +931,18 @@ spec:
                           have a public IP address
                         type: boolean
                       displayName:
-                        description: DisplayName defines a user-friendly name. Does
-                          not have to be unique, and it's changeable. Avoid entering
-                          confidential information.
+                        description: |-
+                          DisplayName defines a user-friendly name. Does not have to be unique, and it's changeable.
+                          Avoid entering confidential information.
                         type: string
                       hostnameLabel:
                         description: HostnameLabel defines the hostname for the VNIC's
                           primary private IP. Used for DNS.
                         type: string
                       nsgId:
-                        description: NSGId defines the ID of the NSG to use. This
-                          parameter takes priority over NsgNames. Deprecated, please
-                          use NetworkDetails.NSGIds
+                        description: |-
+                          NSGId defines the ID of the NSG to use. This parameter takes priority over NsgNames.
+                          Deprecated, please use NetworkDetails.NSGIds
                         type: string
                       nsgIds:
                         description: NSGIds defines the list of NSG IDs to use. This
@@ -968,23 +977,23 @@ spec:
                       compatibility and performance of VM shapes
                     properties:
                       bootVolumeType:
-                        description: BootVolumeType defines Emulation type for the
-                          boot volume. * `ISCSI` - ISCSI attached block storage device.
-                          * `SCSI` - Emulated SCSI disk. * `IDE` - Emulated IDE disk.
-                          * `VFIO` - Direct attached Virtual Function storage. This
-                          is the default option for local data volumes on platform
-                          images. * `PARAVIRTUALIZED` - Paravirtualized disk. This
-                          is the default for boot volumes and remote block storage
+                        description: |-
+                          BootVolumeType defines Emulation type for the boot volume.
+                          * `ISCSI` - ISCSI attached block storage device.
+                          * `SCSI` - Emulated SCSI disk.
+                          * `IDE` - Emulated IDE disk.
+                          * `VFIO` - Direct attached Virtual Function storage. This is the default option for local data
                           volumes on platform images.
+                          * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+                          storage volumes on platform images.
                         type: string
                       firmware:
-                        description: Firmware defines the firmware used to boot VM.
-                          Select the option that matches your operating system. *
-                          `BIOS` - Boot VM using BIOS style firmware. This is compatible
-                          with both 32 bit and 64 bit operating systems that boot
-                          using MBR style bootloaders. * `UEFI_64` - Boot VM using
-                          UEFI style firmware compatible with 64 bit operating systems.
-                          This is the default for platform images.
+                        description: |-
+                          Firmware defines the firmware used to boot VM. Select the option that matches your operating system.
+                          * `BIOS` - Boot VM using BIOS style firmware. This is compatible with both 32 bit and 64 bit operating
+                          systems that boot using MBR style bootloaders.
+                          * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems. This is the
+                          default for platform images.
                         type: string
                       isConsistentVolumeNamingEnabled:
                         description: IsConsistentVolumeNamingEnabled defines whether
@@ -992,31 +1001,31 @@ spec:
                           false.
                         type: boolean
                       networkType:
-                        description: NetworkType defines the emulation type for the
-                          physical network interface card (NIC). * `E1000` - Emulated
-                          Gigabit ethernet controller. Compatible with Linux e1000
-                          network driver. * `VFIO` - Direct attached Virtual Function
-                          network controller. This is the networking type when you
-                          launch an instance using hardware-assisted (SR-IOV) networking.
-                          * `PARAVIRTUALIZED` - VM instances launch with paravirtualized
-                          devices using VirtIO drivers.
+                        description: |-
+                          NetworkType defines the emulation type for the physical network interface card (NIC).
+                          * `E1000` - Emulated Gigabit ethernet controller. Compatible with Linux e1000 network driver.
+                          * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
+                          when you launch an instance using hardware-assisted (SR-IOV) networking.
+                          * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
                         type: string
                       remoteDataVolumeType:
-                        description: RemoteDataVolumeType defines the emulation type
-                          for volume. * `ISCSI` - ISCSI attached block storage device.
-                          * `SCSI` - Emulated SCSI disk. * `IDE` - Emulated IDE disk.
-                          * `VFIO` - Direct attached Virtual Function storage. This
-                          is the default option for local data volumes on platform
-                          images. * `PARAVIRTUALIZED` - Paravirtualized disk. This
-                          is the default for boot volumes and remote block storage
+                        description: |-
+                          RemoteDataVolumeType defines the emulation type for volume.
+                          * `ISCSI` - ISCSI attached block storage device.
+                          * `SCSI` - Emulated SCSI disk.
+                          * `IDE` - Emulated IDE disk.
+                          * `VFIO` - Direct attached Virtual Function storage. This is the default option for local data
                           volumes on platform images.
+                          * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+                          storage volumes on platform images.
                         type: string
                     type: object
                   metadata:
                     additionalProperties:
                       type: string
-                    description: Custom metadata key/value pairs that you provide,
-                      such as the SSH public key required to connect to the instance.
+                    description: |-
+                      Custom metadata key/value pairs that you provide, such as the SSH public key
+                      required to connect to the instance.
                     type: object
                   platformConfig:
                     description: PlatformConfig defines the platform config parameters
@@ -1026,14 +1035,14 @@ spec:
                           platform configuration
                         properties:
                           areVirtualInstructionsEnabled:
-                            description: Whether virtualization instructions are available.
-                              For example, Secure Virtual Machine for AMD shapes or
-                              VT-x for Intel shapes.
+                            description: |-
+                              Whether virtualization instructions are available. For example, Secure Virtual Machine for AMD shapes
+                              or VT-x for Intel shapes.
                             type: boolean
                           isAccessControlServiceEnabled:
-                            description: Whether the Access Control Service is enabled
-                              on the instance. When enabled, the platform can enforce
-                              PCIe device isolation, required for VFIO device pass-through.
+                            description: |-
+                              Whether the Access Control Service is enabled on the instance. When enabled,
+                              the platform can enforce PCIe device isolation, required for VFIO device pass-through.
                             type: boolean
                           isInputOutputMemoryManagementUnitEnabled:
                             description: Whether the input-output memory management
@@ -1052,37 +1061,35 @@ spec:
                             description: Whether Secure Boot is enabled on the instance.
                             type: boolean
                           isSymmetricMultiThreadingEnabled:
-                            description: Whether symmetric multithreading is enabled
-                              on the instance. Symmetric multithreading is also called
-                              simultaneous multithreading (SMT) or Intel Hyper-Threading.
-                              Intel and AMD processors have two hardware execution
-                              threads per core (OCPU). SMT permits multiple independent
-                              threads of execution, to better use the resources and
-                              increase the efficiency of the CPU. When multithreading
-                              is disabled, only one thread is permitted to run on
-                              each core, which can provide higher or more predictable
-                              performance for some workloads.
+                            description: |-
+                              Whether symmetric multithreading is enabled on the instance. Symmetric multithreading is also
+                              called simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                              Intel and AMD processors have two hardware execution threads per core (OCPU). SMT permits multiple
+                              independent threads of execution, to better use the resources and increase the efficiency
+                              of the CPU. When multithreading is disabled, only one thread is permitted to run on each core, which
+                              can provide higher or more predictable performance for some workloads.
                             type: boolean
                           isTrustedPlatformModuleEnabled:
                             description: Whether the Trusted Platform Module (TPM)
                               is enabled on the instance.
                             type: boolean
                           numaNodesPerSocket:
-                            description: 'The number of NUMA nodes per socket (NPS).
-                              The following values are supported: * `NPS0` * `NPS1`
-                              * `NPS2` * `NPS4`'
+                            description: |-
+                              The number of NUMA nodes per socket (NPS).
+                              The following values are supported:
+                              * `NPS0`
+                              * `NPS1`
+                              * `NPS2`
+                              * `NPS4`
                             type: string
                           percentageOfCoresEnabled:
-                            description: The percentage of cores enabled. Value must
-                              be a multiple of 25%. If the requested percentage results
-                              in a fractional number of cores, the system rounds up
-                              the number of cores across processors and provisions
-                              an instance with a whole number of cores. If the applications
-                              that you run on the instance use a core-based licensing
-                              model and need fewer cores than the full size of the
-                              shape, you can disable cores to reduce your licensing
-                              costs. The instance itself is billed for the full shape,
-                              regardless of whether all cores are enabled.
+                            description: |-
+                              The percentage of cores enabled. Value must be a multiple of 25%. If the requested percentage
+                              results in a fractional number of cores, the system rounds up the number of cores across processors
+                              and provisions an instance with a whole number of cores.
+                              If the applications that you run on the instance use a core-based licensing model and need fewer cores
+                              than the full size of the shape, you can disable cores to reduce your licensing costs. The instance
+                              itself is billed for the full shape, regardless of whether all cores are enabled.
                             type: integer
                         type: object
                       amdRomeBmGpuPlatformConfig:
@@ -1090,14 +1097,14 @@ spec:
                           platform configuration
                         properties:
                           areVirtualInstructionsEnabled:
-                            description: Whether virtualization instructions are available.
-                              For example, Secure Virtual Machine for AMD shapes or
-                              VT-x for Intel shapes.
+                            description: |-
+                              Whether virtualization instructions are available. For example, Secure Virtual Machine for AMD shapes
+                              or VT-x for Intel shapes.
                             type: boolean
                           isAccessControlServiceEnabled:
-                            description: Whether the Access Control Service is enabled
-                              on the instance. When enabled, the platform can enforce
-                              PCIe device isolation, required for VFIO device pass-through.
+                            description: |-
+                              Whether the Access Control Service is enabled on the instance. When enabled,
+                              the platform can enforce PCIe device isolation, required for VFIO device pass-through.
                             type: boolean
                           isInputOutputMemoryManagementUnitEnabled:
                             description: Whether the input-output memory management
@@ -1116,25 +1123,26 @@ spec:
                             description: Whether Secure Boot is enabled on the instance.
                             type: boolean
                           isSymmetricMultiThreadingEnabled:
-                            description: Whether symmetric multithreading is enabled
-                              on the instance. Symmetric multithreading is also called
-                              simultaneous multithreading (SMT) or Intel Hyper-Threading.
-                              Intel and AMD processors have two hardware execution
-                              threads per core (OCPU). SMT permits multiple independent
-                              threads of execution, to better use the resources and
-                              increase the efficiency of the CPU. When multithreading
-                              is disabled, only one thread is permitted to run on
-                              each core, which can provide higher or more predictable
-                              performance for some workloads.
+                            description: |-
+                              Whether symmetric multithreading is enabled on the instance. Symmetric multithreading is also
+                              called simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                              Intel and AMD processors have two hardware execution threads per core (OCPU). SMT permits multiple
+                              independent threads of execution, to better use the resources and increase the efficiency
+                              of the CPU. When multithreading is disabled, only one thread is permitted to run on each core, which
+                              can provide higher or more predictable performance for some workloads.
                             type: boolean
                           isTrustedPlatformModuleEnabled:
                             description: Whether the Trusted Platform Module (TPM)
                               is enabled on the instance.
                             type: boolean
                           numaNodesPerSocket:
-                            description: 'The number of NUMA nodes per socket (NPS).
-                              The following values are supported: * `NPS0` * `NPS1`
-                              * `NPS2` * `NPS4`'
+                            description: |-
+                              The number of NUMA nodes per socket (NPS).
+                              The following values are supported:
+                              * `NPS0`
+                              * `NPS1`
+                              * `NPS2`
+                              * `NPS4`
                             type: string
                         type: object
                       amdRomeBmPlatformConfig:
@@ -1142,14 +1150,14 @@ spec:
                           platform configuration
                         properties:
                           areVirtualInstructionsEnabled:
-                            description: Whether virtualization instructions are available.
-                              For example, Secure Virtual Machine for AMD shapes or
-                              VT-x for Intel shapes.
+                            description: |-
+                              Whether virtualization instructions are available. For example, Secure Virtual Machine for AMD shapes
+                              or VT-x for Intel shapes.
                             type: boolean
                           isAccessControlServiceEnabled:
-                            description: Whether the Access Control Service is enabled
-                              on the instance. When enabled, the platform can enforce
-                              PCIe device isolation, required for VFIO device pass-through.
+                            description: |-
+                              Whether the Access Control Service is enabled on the instance. When enabled,
+                              the platform can enforce PCIe device isolation, required for VFIO device pass-through.
                             type: boolean
                           isInputOutputMemoryManagementUnitEnabled:
                             description: Whether the input-output memory management
@@ -1168,37 +1176,35 @@ spec:
                             description: Whether Secure Boot is enabled on the instance.
                             type: boolean
                           isSymmetricMultiThreadingEnabled:
-                            description: Whether symmetric multithreading is enabled
-                              on the instance. Symmetric multithreading is also called
-                              simultaneous multithreading (SMT) or Intel Hyper-Threading.
-                              Intel and AMD processors have two hardware execution
-                              threads per core (OCPU). SMT permits multiple independent
-                              threads of execution, to better use the resources and
-                              increase the efficiency of the CPU. When multithreading
-                              is disabled, only one thread is permitted to run on
-                              each core, which can provide higher or more predictable
-                              performance for some workloads.
+                            description: |-
+                              Whether symmetric multithreading is enabled on the instance. Symmetric multithreading is also
+                              called simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                              Intel and AMD processors have two hardware execution threads per core (OCPU). SMT permits multiple
+                              independent threads of execution, to better use the resources and increase the efficiency
+                              of the CPU. When multithreading is disabled, only one thread is permitted to run on each core, which
+                              can provide higher or more predictable performance for some workloads.
                             type: boolean
                           isTrustedPlatformModuleEnabled:
                             description: Whether the Trusted Platform Module (TPM)
                               is enabled on the instance.
                             type: boolean
                           numaNodesPerSocket:
-                            description: 'The number of NUMA nodes per socket (NPS).
-                              The following values are supported: * `NPS0` * `NPS1`
-                              * `NPS2` * `NPS4`'
+                            description: |-
+                              The number of NUMA nodes per socket (NPS).
+                              The following values are supported:
+                              * `NPS0`
+                              * `NPS1`
+                              * `NPS2`
+                              * `NPS4`
                             type: string
                           percentageOfCoresEnabled:
-                            description: The percentage of cores enabled. Value must
-                              be a multiple of 25%. If the requested percentage results
-                              in a fractional number of cores, the system rounds up
-                              the number of cores across processors and provisions
-                              an instance with a whole number of cores. If the applications
-                              that you run on the instance use a core-based licensing
-                              model and need fewer cores than the full size of the
-                              shape, you can disable cores to reduce your licensing
-                              costs. The instance itself is billed for the full shape,
-                              regardless of whether all cores are enabled.
+                            description: |-
+                              The percentage of cores enabled. Value must be a multiple of 25%. If the requested percentage
+                              results in a fractional number of cores, the system rounds up the number of cores across processors
+                              and provisions an instance with a whole number of cores.
+                              If the applications that you run on the instance use a core-based licensing model and need fewer cores
+                              than the full size of the shape, you can disable cores to reduce your licensing costs. The instance
+                              itself is billed for the full shape, regardless of whether all cores are enabled.
                             type: integer
                         type: object
                       amdVmPlatformConfig:
@@ -1243,36 +1249,33 @@ spec:
                             description: Whether Secure Boot is enabled on the instance.
                             type: boolean
                           isSymmetricMultiThreadingEnabled:
-                            description: Whether symmetric multithreading is enabled
-                              on the instance. Symmetric multithreading is also called
-                              simultaneous multithreading (SMT) or Intel Hyper-Threading.
-                              Intel and AMD processors have two hardware execution
-                              threads per core (OCPU). SMT permits multiple independent
-                              threads of execution, to better use the resources and
-                              increase the efficiency of the CPU. When multithreading
-                              is disabled, only one thread is permitted to run on
-                              each core, which can provide higher or more predictable
-                              performance for some workloads.
+                            description: |-
+                              Whether symmetric multithreading is enabled on the instance. Symmetric multithreading is also
+                              called simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                              Intel and AMD processors have two hardware execution threads per core (OCPU). SMT permits multiple
+                              independent threads of execution, to better use the resources and increase the efficiency
+                              of the CPU. When multithreading is disabled, only one thread is permitted to run on each core, which
+                              can provide higher or more predictable performance for some workloads.
                             type: boolean
                           isTrustedPlatformModuleEnabled:
                             description: Whether the Trusted Platform Module (TPM)
                               is enabled on the instance.
                             type: boolean
                           numaNodesPerSocket:
-                            description: 'The number of NUMA nodes per socket (NPS).
-                              The following values are supported: * `NPS1` * `NPS2`'
+                            description: |-
+                              The number of NUMA nodes per socket (NPS).
+                              The following values are supported:
+                              * `NPS1`
+                              * `NPS2`
                             type: string
                           percentageOfCoresEnabled:
-                            description: The percentage of cores enabled. Value must
-                              be a multiple of 25%. If the requested percentage results
-                              in a fractional number of cores, the system rounds up
-                              the number of cores across processors and provisions
-                              an instance with a whole number of cores. If the applications
-                              that you run on the instance use a core-based licensing
-                              model and need fewer cores than the full size of the
-                              shape, you can disable cores to reduce your licensing
-                              costs. The instance itself is billed for the full shape,
-                              regardless of whether all cores are enabled.
+                            description: |-
+                              The percentage of cores enabled. Value must be a multiple of 25%. If the requested percentage
+                              results in a fractional number of cores, the system rounds up the number of cores across processors
+                              and provisions an instance with a whole number of cores.
+                              If the applications that you run on the instance use a core-based licensing model and need fewer cores
+                              than the full size of the shape, you can disable cores to reduce your licensing costs. The instance
+                              itself is billed for the full shape, regardless of whether all cores are enabled.
                             type: integer
                         type: object
                       intelSkylakeBmPlatformConfig:
@@ -1318,11 +1321,16 @@ spec:
                             type: boolean
                         type: object
                       platformConfigType:
-                        description: The type of platform configuration. Valid values
-                          are * `AMD_ROME_BM_GPU` * `AMD_ROME_BM` * `INTEL_ICELAKE_BM`
-                          * `AMD_VM` * `INTEL_VM` * `INTEL_SKYLAKE_BM` * `AMD_MILAN_BM`
-                          Based on the enum, exactly one of the specific configuration
-                          types must be set
+                        description: |-
+                          The type of platform configuration. Valid values are
+                          * `AMD_ROME_BM_GPU`
+                          * `AMD_ROME_BM`
+                          * `INTEL_ICELAKE_BM`
+                          * `AMD_VM`
+                          * `INTEL_VM`
+                          * `INTEL_SKYLAKE_BM`
+                          * `AMD_MILAN_BM`
+                          Based on the enum, exactly one of the specific configuration types must be set
                         type: string
                     type: object
                   preemptibleInstanceConfig:
@@ -1348,14 +1356,13 @@ spec:
                       for flex instances.
                     properties:
                       baselineOcpuUtilization:
-                        description: 'The baseline OCPU utilization for a subcore
-                          burstable VM instance. Leave this attribute blank for a
-                          non-burstable instance, or explicitly specify non-burstable
-                          with `BASELINE_1_1`. The following values are supported:
-                          - `BASELINE_1_8` - baseline usage is 1/8 of an OCPU. - `BASELINE_1_2`
-                          - baseline usage is 1/2 of an OCPU. - `BASELINE_1_1` - baseline
-                          usage is an entire OCPU. This represents a non-burstable
-                          instance.'
+                        description: |-
+                          The baseline OCPU utilization for a subcore burstable VM instance. Leave this attribute blank for a
+                          non-burstable instance, or explicitly specify non-burstable with `BASELINE_1_1`.
+                          The following values are supported:
+                          - `BASELINE_1_8` - baseline usage is 1/8 of an OCPU.
+                          - `BASELINE_1_2` - baseline usage is 1/2 of an OCPU.
+                          - `BASELINE_1_1` - baseline usage is an entire OCPU. This represents a non-burstable instance.
                         type: string
                       memoryInGBs:
                         description: The total amount of memory available to the instance,
@@ -1390,10 +1397,9 @@ spec:
                   in a provider format
                 type: string
               providerIDList:
-                description: ProviderIDList are the identification IDs of machine
-                  instances provided by the provider. This field must match the provider
-                  IDs as seen on the node objects corresponding to a machine pool's
-                  machine instances.
+                description: |-
+                  ProviderIDList are the identification IDs of machine instances provided by the provider.
+                  This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
                 items:
                   type: string
                 type: array
@@ -1408,37 +1414,44 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
+                      description: status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -1449,8 +1462,6 @@ spec:
               failureMessage:
                 type: string
               failureReason:
-                description: MachineStatusError defines errors states for Machine
-                  objects.
                 type: string
               infrastructureMachineKind:
                 description: InfrastructureMachineKind is the kind of the infrastructure

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimachines.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: ocimachines.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -20,20 +20,26 @@ spec:
         description: OCIMachine is the Schema for the ocimachines API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: OCIMachineSpec defines the desired state of OCIMachine Please
-              read the API https://docs.oracle.com/en-us/iaas/api/#/en/iaas/20160918/Instance/LaunchInstance
+            description: |-
+              OCIMachineSpec defines the desired state of OCIMachine
+              Please read the API https://docs.oracle.com/en-us/iaas/api/#/en/iaas/20160918/Instance/LaunchInstance
               for more information about the parameters below
             properties:
               agentConfig:
@@ -41,40 +47,41 @@ spec:
                   Agent software running on the instance.
                 properties:
                   areAllPluginsDisabled:
-                    description: AreAllPluginsDisabled defines whether Oracle Cloud
-                      Agent can run all the available plugins. This includes the management
-                      and monitoring plugins. To get a list of available plugins,
-                      use the ListInstanceagentAvailablePlugins operation in the Oracle
-                      Cloud Agent API. For more information about the available plugins,
-                      see Managing Plugins with Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
+                    description: |-
+                      AreAllPluginsDisabled defines whether Oracle Cloud Agent can run all the available plugins.
+                      This includes the management and monitoring plugins.
+                      To get a list of available plugins, use the
+                      ListInstanceagentAvailablePlugins
+                      operation in the Oracle Cloud Agent API. For more information about the available plugins, see
+                      Managing Plugins with Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
                     type: boolean
                   isManagementDisabled:
-                    description: 'IsManagementDisabled defines whether Oracle Cloud
-                      Agent can run all the available management plugins. Default
-                      value is false (management plugins are enabled). These are the
-                      management plugins: OS Management Service Agent and Compute
-                      Instance Run Command. The management plugins are controlled
-                      by this parameter and by the per-plugin configuration in the
-                      `pluginsConfig` object. - If `isManagementDisabled` is true,
-                      all of the management plugins are disabled, regardless of the
-                      per-plugin configuration. - If `isManagementDisabled` is false,
-                      all of the management plugins are enabled. You can optionally
-                      disable individual management plugins by providing a value in
-                      the `pluginsConfig` object.'
+                    description: |-
+                      IsManagementDisabled defines whether Oracle Cloud Agent can run all the available management plugins.
+                      Default value is false (management plugins are enabled).
+                      These are the management plugins: OS Management Service Agent and Compute Instance
+                      Run Command.
+                      The management plugins are controlled by this parameter and by the per-plugin
+                      configuration in the `pluginsConfig` object.
+                      - If `isManagementDisabled` is true, all of the management plugins are disabled, regardless of
+                      the per-plugin configuration.
+                      - If `isManagementDisabled` is false, all of the management plugins are enabled. You
+                      can optionally disable individual management plugins by providing a value in the `pluginsConfig`
+                      object.
                     type: boolean
                   isMonitoringDisabled:
-                    description: 'IsMonitoringDisabled defines whether Oracle Cloud
-                      Agent can gather performance metrics and monitor the instance
-                      using the monitoring plugins. Default value is false (monitoring
-                      plugins are enabled). These are the monitoring plugins: Compute
-                      Instance Monitoring and Custom Logs Monitoring. The monitoring
-                      plugins are controlled by this parameter and by the per-plugin
-                      configuration in the `pluginsConfig` object. - If `isMonitoringDisabled`
-                      is true, all of the monitoring plugins are disabled, regardless
-                      of the per-plugin configuration. - If `isMonitoringDisabled`
-                      is false, all of the monitoring plugins are enabled. You can
-                      optionally disable individual monitoring plugins by providing
-                      a value in the `pluginsConfig` object.'
+                    description: |-
+                      IsMonitoringDisabled defines whether Oracle Cloud Agent can gather performance metrics and monitor the instance using the
+                      monitoring plugins. Default value is false (monitoring plugins are enabled).
+                      These are the monitoring plugins: Compute Instance Monitoring
+                      and Custom Logs Monitoring.
+                      The monitoring plugins are controlled by this parameter and by the per-plugin
+                      configuration in the `pluginsConfig` object.
+                      - If `isMonitoringDisabled` is true, all of the monitoring plugins are disabled, regardless of
+                      the per-plugin configuration.
+                      - If `isMonitoringDisabled` is false, all of the monitoring plugins are enabled. You
+                      can optionally disable individual monitoring plugins by providing a value in the `pluginsConfig`
+                      object.
                     type: boolean
                   pluginsConfigs:
                     description: PluginsConfig defines the configuration of plugins
@@ -84,63 +91,61 @@ spec:
                         of plugins associated with this instance.
                       properties:
                         desiredState:
-                          description: 'DesiredState defines whether the plugin should
-                            be enabled or disabled. To enable the monitoring and management
-                            plugins, the `isMonitoringDisabled` and `isManagementDisabled`
-                            attributes must also be set to false. The following values
-                            are supported: * `ENABLED` * `DISABLED`'
+                          description: |-
+                            DesiredState defines whether the plugin should be enabled or disabled.
+                            To enable the monitoring and management plugins, the `isMonitoringDisabled` and
+                            `isManagementDisabled` attributes must also be set to false.
+                            The following values are supported:
+                            * `ENABLED`
+                            * `DISABLED`
                           type: string
                         name:
-                          description: Name defines the name of the plugin. To get
-                            a list of available plugins, use the ListInstanceagentAvailablePlugins
-                            operation in the Oracle Cloud Agent API. For more information
-                            about the available plugins, see Managing Plugins with
-                            Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
+                          description: |-
+                            Name defines the name of the plugin. To get a list of available plugins, use the
+                            ListInstanceagentAvailablePlugins
+                            operation in the Oracle Cloud Agent API. For more information about the available plugins, see
+                            Managing Plugins with Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
                           type: string
                       type: object
                     type: array
                 type: object
               availabilityConfig:
-                description: LaunchInstanceAvailabilityConfig defines the options
-                  for VM migration during infrastructure maintenance events and for
-                  defining the availability of a VM instance after a maintenance event
-                  that impacts the underlying hardware.
+                description: |-
+                  LaunchInstanceAvailabilityConfig defines the options for VM migration during infrastructure maintenance events and for defining
+                  the availability of a VM instance after a maintenance event that impacts the underlying hardware.
                 properties:
                   isLiveMigrationPreferred:
-                    description: IsLiveMigrationPreferred defines whether to live
-                      migrate supported VM instances to a healthy physical VM host
-                      without disrupting running instances during infrastructure maintenance
-                      events. If null, Oracle chooses the best option for migrating
-                      the VM during infrastructure maintenance events.
+                    description: |-
+                      IsLiveMigrationPreferred defines whether to live migrate supported VM instances to a healthy physical VM host without
+                      disrupting running instances during infrastructure maintenance events. If null, Oracle
+                      chooses the best option for migrating the VM during infrastructure maintenance events.
                     type: boolean
                   recoveryAction:
-                    description: RecoveryAction defines the lifecycle state for an
-                      instance when it is recovered after infrastructure maintenance.
-                      * `RESTORE_INSTANCE` - The instance is restored to the lifecycle
-                      state it was in before the maintenance event. If the instance
-                      was running, it is automatically rebooted. This is the default
-                      action when a value is not set. * `STOP_INSTANCE` - The instance
-                      is recovered in the stopped state.
+                    description: |-
+                      RecoveryAction defines the lifecycle state for an instance when it is recovered after infrastructure maintenance.
+                      * `RESTORE_INSTANCE` - The instance is restored to the lifecycle state it was in before the maintenance event.
+                      If the instance was running, it is automatically rebooted. This is the default action when a value is not set.
+                      * `STOP_INSTANCE` - The instance is recovered in the stopped state.
                     type: string
                 type: object
               bootVolumeSizeInGBs:
-                description: The size of boot volume. Please see https://docs.oracle.com/en-us/iaas/Content/Block/Tasks/extendingbootpartition.htm
+                description: |-
+                  The size of boot volume. Please see https://docs.oracle.com/en-us/iaas/Content/Block/Tasks/extendingbootpartition.htm
                   to extend the boot volume size.
                 type: string
               capacityReservationId:
-                description: CapacityReservationId defines the OCID of the compute
-                  capacity reservation this instance is launched under. You can opt
-                  out of all default reservations by specifying an empty string as
-                  input for this field. For more information, see Capacity Reservations
-                  (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/reserve-capacity.htm#default).
+                description: |-
+                  CapacityReservationId defines the OCID of the compute capacity reservation this instance is launched under.
+                  You can opt out of all default reservations by specifying an empty string as input for this field.
+                  For more information, see Capacity Reservations (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/reserve-capacity.htm#default).
                 type: string
               compartmentId:
                 description: Compartment to launch the instance in.
                 type: string
               computeClusterId:
-                description: ComputeClusterId refers to OCID of the compute cluster
-                  that the instance will be created in. Please refer https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/compute-clusters.htm
-                  for more details
+                description: |-
+                  ComputeClusterId refers to OCID of the compute cluster that the instance will be created in.
+                  Please refer https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/compute-clusters.htm for more details
                 type: string
               dedicatedVmHostId:
                 description: DedicatedVmHostId defines the OCID of the dedicated VM
@@ -151,10 +156,10 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
-                description: 'Defined tags for this resource. Each key is predefined
-                  and scoped to a namespace. For more information, see Resource Tags
-                  (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
-                  Example: `{"Operations": {"CostCenter": "42"}}`'
+                description: |-
+                  Defined tags for this resource. Each key is predefined and scoped to a
+                  namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+                  Example: `{"Operations": {"CostCenter": "42"}}`
                 type: object
               freeformTags:
                 additionalProperties:
@@ -171,9 +176,10 @@ spec:
                 description: InstanceOptions defines the instance options
                 properties:
                   areLegacyImdsEndpointsDisabled:
-                    description: Whether to disable the legacy (/v1) instance metadata
-                      service endpoints. Customers who have migrated to /v2 should
-                      set this to true for added security. Default is false.
+                    description: |-
+                      Whether to disable the legacy (/v1) instance metadata service endpoints.
+                      Customers who have migrated to /v2 should set this to true for added security.
+                      Default is false.
                     type: boolean
                 type: object
               instanceSourceViaImageConfig:
@@ -181,15 +187,15 @@ spec:
                   booting up instances via images
                 properties:
                   bootVolumeVpusPerGB:
-                    description: 'BootVolumeVpusPerGB defines the number of volume
-                      performance units (VPUs) that will be applied to this volume
-                      per GB, representing the Block Volume service''s elastic performance
-                      options. See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels)
-                      for more information. Allowed values: * `10`: Represents Balanced
-                      option. * `20`: Represents Higher Performance option. * `30`-`120`:
-                      Represents the Ultra High Performance option. For volumes with
-                      the auto-tuned performance feature enabled, this is set to the
-                      default (minimum) VPUs/GB.'
+                    description: |-
+                      BootVolumeVpusPerGB defines the number of volume performance units (VPUs) that will be applied to this volume per GB,
+                      representing the Block Volume service's elastic performance options.
+                      See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels) for more information.
+                      Allowed values:
+                        * `10`: Represents Balanced option.
+                        * `20`: Represents Higher Performance option.
+                        * `30`-`120`: Represents the Ultra High Performance option.
+                      For volumes with the auto-tuned performance feature enabled, this is set to the default (minimum) VPUs/GB.
                     format: int64
                     type: integer
                   kmsKeyId:
@@ -209,43 +215,46 @@ spec:
                   and performance of VM shapes
                 properties:
                   bootVolumeType:
-                    description: BootVolumeType defines Emulation type for the boot
-                      volume. * `ISCSI` - ISCSI attached block storage device. * `SCSI`
-                      - Emulated SCSI disk. * `IDE` - Emulated IDE disk. * `VFIO`
-                      - Direct attached Virtual Function storage. This is the default
-                      option for local data volumes on platform images. * `PARAVIRTUALIZED`
-                      - Paravirtualized disk. This is the default for boot volumes
-                      and remote block storage volumes on platform images.
+                    description: |-
+                      BootVolumeType defines Emulation type for the boot volume.
+                      * `ISCSI` - ISCSI attached block storage device.
+                      * `SCSI` - Emulated SCSI disk.
+                      * `IDE` - Emulated IDE disk.
+                      * `VFIO` - Direct attached Virtual Function storage. This is the default option for local data
+                      volumes on platform images.
+                      * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+                      storage volumes on platform images.
                     type: string
                   firmware:
-                    description: Firmware defines the firmware used to boot VM. Select
-                      the option that matches your operating system. * `BIOS` - Boot
-                      VM using BIOS style firmware. This is compatible with both 32
-                      bit and 64 bit operating systems that boot using MBR style bootloaders.
-                      * `UEFI_64` - Boot VM using UEFI style firmware compatible with
-                      64 bit operating systems. This is the default for platform images.
+                    description: |-
+                      Firmware defines the firmware used to boot VM. Select the option that matches your operating system.
+                      * `BIOS` - Boot VM using BIOS style firmware. This is compatible with both 32 bit and 64 bit operating
+                      systems that boot using MBR style bootloaders.
+                      * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems. This is the
+                      default for platform images.
                     type: string
                   isConsistentVolumeNamingEnabled:
                     description: IsConsistentVolumeNamingEnabled defines whether to
                       enable consistent volume naming feature. Defaults to false.
                     type: boolean
                   networkType:
-                    description: NetworkType defines the emulation type for the physical
-                      network interface card (NIC). * `E1000` - Emulated Gigabit ethernet
-                      controller. Compatible with Linux e1000 network driver. * `VFIO`
-                      - Direct attached Virtual Function network controller. This
-                      is the networking type when you launch an instance using hardware-assisted
-                      (SR-IOV) networking. * `PARAVIRTUALIZED` - VM instances launch
-                      with paravirtualized devices using VirtIO drivers.
+                    description: |-
+                      NetworkType defines the emulation type for the physical network interface card (NIC).
+                      * `E1000` - Emulated Gigabit ethernet controller. Compatible with Linux e1000 network driver.
+                      * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
+                      when you launch an instance using hardware-assisted (SR-IOV) networking.
+                      * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
                     type: string
                   remoteDataVolumeType:
-                    description: RemoteDataVolumeType defines the emulation type for
-                      volume. * `ISCSI` - ISCSI attached block storage device. * `SCSI`
-                      - Emulated SCSI disk. * `IDE` - Emulated IDE disk. * `VFIO`
-                      - Direct attached Virtual Function storage. This is the default
-                      option for local data volumes on platform images. * `PARAVIRTUALIZED`
-                      - Paravirtualized disk. This is the default for boot volumes
-                      and remote block storage volumes on platform images.
+                    description: |-
+                      RemoteDataVolumeType defines the emulation type for volume.
+                      * `ISCSI` - ISCSI attached block storage device.
+                      * `SCSI` - Emulated SCSI disk.
+                      * `IDE` - Emulated IDE disk.
+                      * `VFIO` - Direct attached Virtual Function storage. This is the default option for local data
+                      volumes on platform images.
+                      * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+                      storage volumes on platform images.
                     type: string
                 type: object
               launchVolumeAttachments:
@@ -261,11 +270,13 @@ spec:
                             for a given instance, see ListInstanceDevices.
                           type: string
                         displayName:
-                          description: A user-friendly name. Does not have to be unique,
-                            and it's changeable. Avoid entering confidential information.
+                          description: |-
+                            A user-friendly name. Does not have to be unique, and it's changeable.
+                            Avoid entering confidential information.
                           type: string
                         encryptionInTransitType:
-                          description: Refer the top-level definition of encryptionInTransitType.
+                          description: |-
+                            Refer the top-level definition of encryptionInTransitType.
                             The default value is NONE.
                           type: string
                         isAgentAutoIscsiLoginEnabled:
@@ -278,44 +289,45 @@ spec:
                             mode.
                           type: boolean
                         isShareable:
-                          description: Whether the attachment should be created in
-                            shareable mode. If an attachment is created in shareable
-                            mode, then other instances can attach the same volume,
-                            provided that they also create their attachments in shareable
-                            mode. Only certain volume types can be attached in shareable
-                            mode. Defaults to false if not specified.
+                          description: |-
+                            Whether the attachment should be created in shareable mode. If an attachment
+                            is created in shareable mode, then other instances can attach the same volume, provided
+                            that they also create their attachments in shareable mode. Only certain volume types can
+                            be attached in shareable mode. Defaults to false if not specified.
                           type: boolean
                         launchCreateVolumeFromAttributes:
                           description: LaunchCreateVolumeFromAttributes The details
                             of the volume to create for CreateVolume operation.
                           properties:
                             compartmentId:
-                              description: The OCID of the compartment that contains
-                                the volume. If not provided, it will be inherited
-                                from the instance.
+                              description: |-
+                                The OCID of the compartment that contains the volume. If not provided,
+                                it will be inherited from the instance.
                               type: string
                             displayName:
-                              description: A user-friendly name. Does not have to
-                                be unique, and it's changeable. Avoid entering confidential
-                                information.
+                              description: |-
+                                A user-friendly name. Does not have to be unique, and it's changeable.
+                                Avoid entering confidential information.
                               type: string
                             kmsKeyId:
-                              description: The OCID of the Vault service key to assign
-                                as the master encryption key for the volume.
+                              description: |-
+                                The OCID of the Vault service key to assign as the master encryption key
+                                for the volume.
                               type: string
                             sizeInGBs:
                               description: The size of the volume in GBs.
                               format: int64
                               type: integer
                             vpusPerGB:
-                              description: 'The number of volume performance units
-                                (VPUs) that will be applied to this volume per GB,
-                                representing the Block Volume service''s elastic performance
-                                options. See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels)
-                                for more information. Allowed values: * `0`: Represents
-                                Lower Cost option. * `10`: Represents Balanced option.
-                                * `20`: Represents Higher Performance option. * `30`-`120`:
-                                Represents the Ultra High Performance option.'
+                              description: |-
+                                The number of volume performance units (VPUs) that will be applied to this volume per GB,
+                                representing the Block Volume service's elastic performance options.
+                                See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels) for more information.
+                                Allowed values:
+                                  * `0`: Represents Lower Cost option.
+                                  * `10`: Represents Balanced option.
+                                  * `20`: Represents Higher Performance option.
+                                  * `30`-`120`: Represents the Ultra High Performance option.
                               format: int64
                               type: integer
                           type: object
@@ -329,18 +341,22 @@ spec:
                           type: string
                       type: object
                     launchParavirtualizedVolumeAttachment:
-                      description: The details of paravirtualized volume attachment.
+                      description: LaunchParavirtualizedVolumeAttachment specifies
+                        the paravirtualized volume attachments to create as part of
+                        the launch instance operation.
                       properties:
                         device:
                           description: The device name. To retrieve a list of devices
                             for a given instance, see ListInstanceDevices.
                           type: string
                         displayName:
-                          description: A user-friendly name. Does not have to be unique,
-                            and it's changeable. Avoid entering confidential information.
+                          description: |-
+                            A user-friendly name. Does not have to be unique, and it's changeable.
+                            Avoid entering confidential information.
                           type: string
                         isPvEncryptionInTransitEnabled:
-                          description: Refer the top-level definition of isPvEncryptionInTransitEnabled.
+                          description: |-
+                            Refer the top-level definition of isPvEncryptionInTransitEnabled.
                             The default value is False.
                           type: boolean
                         isReadOnly:
@@ -348,44 +364,45 @@ spec:
                             mode.
                           type: boolean
                         isShareable:
-                          description: Whether the attachment should be created in
-                            shareable mode. If an attachment is created in shareable
-                            mode, then other instances can attach the same volume,
-                            provided that they also create their attachments in shareable
-                            mode. Only certain volume types can be attached in shareable
-                            mode. Defaults to false if not specified.
+                          description: |-
+                            Whether the attachment should be created in shareable mode. If an attachment
+                            is created in shareable mode, then other instances can attach the same volume, provided
+                            that they also create their attachments in shareable mode. Only certain volume types can
+                            be attached in shareable mode. Defaults to false if not specified.
                           type: boolean
                         launchCreateVolumeFromAttributes:
                           description: LaunchCreateVolumeFromAttributes The details
                             of the volume to create for CreateVolume operation.
                           properties:
                             compartmentId:
-                              description: The OCID of the compartment that contains
-                                the volume. If not provided, it will be inherited
-                                from the instance.
+                              description: |-
+                                The OCID of the compartment that contains the volume. If not provided,
+                                it will be inherited from the instance.
                               type: string
                             displayName:
-                              description: A user-friendly name. Does not have to
-                                be unique, and it's changeable. Avoid entering confidential
-                                information.
+                              description: |-
+                                A user-friendly name. Does not have to be unique, and it's changeable.
+                                Avoid entering confidential information.
                               type: string
                             kmsKeyId:
-                              description: The OCID of the Vault service key to assign
-                                as the master encryption key for the volume.
+                              description: |-
+                                The OCID of the Vault service key to assign as the master encryption key
+                                for the volume.
                               type: string
                             sizeInGBs:
                               description: The size of the volume in GBs.
                               format: int64
                               type: integer
                             vpusPerGB:
-                              description: 'The number of volume performance units
-                                (VPUs) that will be applied to this volume per GB,
-                                representing the Block Volume service''s elastic performance
-                                options. See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels)
-                                for more information. Allowed values: * `0`: Represents
-                                Lower Cost option. * `10`: Represents Balanced option.
-                                * `20`: Represents Higher Performance option. * `30`-`120`:
-                                Represents the Ultra High Performance option.'
+                              description: |-
+                                The number of volume performance units (VPUs) that will be applied to this volume per GB,
+                                representing the Block Volume service's elastic performance options.
+                                See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels) for more information.
+                                Allowed values:
+                                  * `0`: Represents Lower Cost option.
+                                  * `10`: Represents Balanced option.
+                                  * `20`: Represents Higher Performance option.
+                                  * `30`-`120`: Represents the Ultra High Performance option.
                               format: int64
                               type: integer
                           type: object
@@ -395,43 +412,45 @@ spec:
                           type: string
                       type: object
                     volumeType:
-                      description: The type of volume. Valid value is iscsi/paravirtualized.
+                      description: The type of volume. Valid value is iscsi.
                       type: string
                   type: object
                 type: array
               metadata:
                 additionalProperties:
                   type: string
-                description: Custom metadata key/value pairs that you provide, such
-                  as the SSH public key required to connect to the instance.
+                description: |-
+                  Custom metadata key/value pairs that you provide, such as the SSH public key
+                  required to connect to the instance.
                 type: object
               networkDetails:
                 description: NetworkDetails defines the configuration options for
                   the network
                 properties:
+                  assignIpv6Ip:
+                    description: IPv6 defines if the instance should have an IPv6
+                    type: boolean
                   assignPrivateDnsRecord:
                     description: AssignPrivateDnsRecord defines whether the VNIC should
                       be assigned a DNS record.
-                    type: boolean
-                  assignIpv6Ip:
-                    description: assignIpv6Ip defines if the instance should have an IPv6
                     type: boolean
                   assignPublicIp:
                     description: AssignPublicIp defines whether the instance should
                       have a public IP address
                     type: boolean
                   displayName:
-                    description: DisplayName defines a user-friendly name. Does not
-                      have to be unique, and it's changeable. Avoid entering confidential
-                      information.
+                    description: |-
+                      DisplayName defines a user-friendly name. Does not have to be unique, and it's changeable.
+                      Avoid entering confidential information.
                     type: string
                   hostnameLabel:
                     description: HostnameLabel defines the hostname for the VNIC's
                       primary private IP. Used for DNS.
                     type: string
                   nsgId:
-                    description: NSGId defines the ID of the NSG to use. This parameter
-                      takes priority over NsgNames. Deprecated, please use NetworkDetails.NSGIds
+                    description: |-
+                      NSGId defines the ID of the NSG to use. This parameter takes priority over NsgNames.
+                      Deprecated, please use NetworkDetails.NSGIds
                     type: string
                   nsgIds:
                     description: NSGIds defines the list of NSG IDs to use. This parameter
@@ -459,10 +478,11 @@ spec:
                     type: string
                 type: object
               nsgName:
-                description: The name of NSG to use. The name here refers to the NSGs
-                  defined in the OCICluster Spec. Optional, only if multiple NSGs
-                  of a type is defined, else the first element is used. Deprecated,
-                  please use NetworkDetails.NSGNames
+                description: |-
+                  The name of NSG to use. The name here refers to the NSGs
+                  defined in the OCICluster Spec. Optional, only if multiple NSGs of a type
+                  is defined, else the first element is used.
+                  Deprecated, please use NetworkDetails.NSGNames
                 type: string
               platformConfig:
                 description: PlatformConfig defines the platform config parameters
@@ -472,14 +492,14 @@ spec:
                       configuration
                     properties:
                       areVirtualInstructionsEnabled:
-                        description: Whether virtualization instructions are available.
-                          For example, Secure Virtual Machine for AMD shapes or VT-x
-                          for Intel shapes.
+                        description: |-
+                          Whether virtualization instructions are available. For example, Secure Virtual Machine for AMD shapes
+                          or VT-x for Intel shapes.
                         type: boolean
                       isAccessControlServiceEnabled:
-                        description: Whether the Access Control Service is enabled
-                          on the instance. When enabled, the platform can enforce
-                          PCIe device isolation, required for VFIO device pass-through.
+                        description: |-
+                          Whether the Access Control Service is enabled on the instance. When enabled,
+                          the platform can enforce PCIe device isolation, required for VFIO device pass-through.
                         type: boolean
                       isInputOutputMemoryManagementUnitEnabled:
                         description: Whether the input-output memory management unit
@@ -498,36 +518,35 @@ spec:
                         description: Whether Secure Boot is enabled on the instance.
                         type: boolean
                       isSymmetricMultiThreadingEnabled:
-                        description: Whether symmetric multithreading is enabled on
-                          the instance. Symmetric multithreading is also called simultaneous
-                          multithreading (SMT) or Intel Hyper-Threading. Intel and
-                          AMD processors have two hardware execution threads per core
-                          (OCPU). SMT permits multiple independent threads of execution,
-                          to better use the resources and increase the efficiency
-                          of the CPU. When multithreading is disabled, only one thread
-                          is permitted to run on each core, which can provide higher
-                          or more predictable performance for some workloads.
+                        description: |-
+                          Whether symmetric multithreading is enabled on the instance. Symmetric multithreading is also
+                          called simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                          Intel and AMD processors have two hardware execution threads per core (OCPU). SMT permits multiple
+                          independent threads of execution, to better use the resources and increase the efficiency
+                          of the CPU. When multithreading is disabled, only one thread is permitted to run on each core, which
+                          can provide higher or more predictable performance for some workloads.
                         type: boolean
                       isTrustedPlatformModuleEnabled:
                         description: Whether the Trusted Platform Module (TPM) is
                           enabled on the instance.
                         type: boolean
                       numaNodesPerSocket:
-                        description: 'The number of NUMA nodes per socket (NPS). The
-                          following values are supported: * `NPS0` * `NPS1` * `NPS2`
-                          * `NPS4`'
+                        description: |-
+                          The number of NUMA nodes per socket (NPS).
+                          The following values are supported:
+                          * `NPS0`
+                          * `NPS1`
+                          * `NPS2`
+                          * `NPS4`
                         type: string
                       percentageOfCoresEnabled:
-                        description: The percentage of cores enabled. Value must be
-                          a multiple of 25%. If the requested percentage results in
-                          a fractional number of cores, the system rounds up the number
-                          of cores across processors and provisions an instance with
-                          a whole number of cores. If the applications that you run
-                          on the instance use a core-based licensing model and need
-                          fewer cores than the full size of the shape, you can disable
-                          cores to reduce your licensing costs. The instance itself
-                          is billed for the full shape, regardless of whether all
-                          cores are enabled.
+                        description: |-
+                          The percentage of cores enabled. Value must be a multiple of 25%. If the requested percentage
+                          results in a fractional number of cores, the system rounds up the number of cores across processors
+                          and provisions an instance with a whole number of cores.
+                          If the applications that you run on the instance use a core-based licensing model and need fewer cores
+                          than the full size of the shape, you can disable cores to reduce your licensing costs. The instance
+                          itself is billed for the full shape, regardless of whether all cores are enabled.
                         type: integer
                     type: object
                   amdRomeBmGpuPlatformConfig:
@@ -535,14 +554,14 @@ spec:
                       configuration
                     properties:
                       areVirtualInstructionsEnabled:
-                        description: Whether virtualization instructions are available.
-                          For example, Secure Virtual Machine for AMD shapes or VT-x
-                          for Intel shapes.
+                        description: |-
+                          Whether virtualization instructions are available. For example, Secure Virtual Machine for AMD shapes
+                          or VT-x for Intel shapes.
                         type: boolean
                       isAccessControlServiceEnabled:
-                        description: Whether the Access Control Service is enabled
-                          on the instance. When enabled, the platform can enforce
-                          PCIe device isolation, required for VFIO device pass-through.
+                        description: |-
+                          Whether the Access Control Service is enabled on the instance. When enabled,
+                          the platform can enforce PCIe device isolation, required for VFIO device pass-through.
                         type: boolean
                       isInputOutputMemoryManagementUnitEnabled:
                         description: Whether the input-output memory management unit
@@ -561,24 +580,26 @@ spec:
                         description: Whether Secure Boot is enabled on the instance.
                         type: boolean
                       isSymmetricMultiThreadingEnabled:
-                        description: Whether symmetric multithreading is enabled on
-                          the instance. Symmetric multithreading is also called simultaneous
-                          multithreading (SMT) or Intel Hyper-Threading. Intel and
-                          AMD processors have two hardware execution threads per core
-                          (OCPU). SMT permits multiple independent threads of execution,
-                          to better use the resources and increase the efficiency
-                          of the CPU. When multithreading is disabled, only one thread
-                          is permitted to run on each core, which can provide higher
-                          or more predictable performance for some workloads.
+                        description: |-
+                          Whether symmetric multithreading is enabled on the instance. Symmetric multithreading is also
+                          called simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                          Intel and AMD processors have two hardware execution threads per core (OCPU). SMT permits multiple
+                          independent threads of execution, to better use the resources and increase the efficiency
+                          of the CPU. When multithreading is disabled, only one thread is permitted to run on each core, which
+                          can provide higher or more predictable performance for some workloads.
                         type: boolean
                       isTrustedPlatformModuleEnabled:
                         description: Whether the Trusted Platform Module (TPM) is
                           enabled on the instance.
                         type: boolean
                       numaNodesPerSocket:
-                        description: 'The number of NUMA nodes per socket (NPS). The
-                          following values are supported: * `NPS0` * `NPS1` * `NPS2`
-                          * `NPS4`'
+                        description: |-
+                          The number of NUMA nodes per socket (NPS).
+                          The following values are supported:
+                          * `NPS0`
+                          * `NPS1`
+                          * `NPS2`
+                          * `NPS4`
                         type: string
                     type: object
                   amdRomeBmPlatformConfig:
@@ -586,14 +607,14 @@ spec:
                       configuration
                     properties:
                       areVirtualInstructionsEnabled:
-                        description: Whether virtualization instructions are available.
-                          For example, Secure Virtual Machine for AMD shapes or VT-x
-                          for Intel shapes.
+                        description: |-
+                          Whether virtualization instructions are available. For example, Secure Virtual Machine for AMD shapes
+                          or VT-x for Intel shapes.
                         type: boolean
                       isAccessControlServiceEnabled:
-                        description: Whether the Access Control Service is enabled
-                          on the instance. When enabled, the platform can enforce
-                          PCIe device isolation, required for VFIO device pass-through.
+                        description: |-
+                          Whether the Access Control Service is enabled on the instance. When enabled,
+                          the platform can enforce PCIe device isolation, required for VFIO device pass-through.
                         type: boolean
                       isInputOutputMemoryManagementUnitEnabled:
                         description: Whether the input-output memory management unit
@@ -612,36 +633,35 @@ spec:
                         description: Whether Secure Boot is enabled on the instance.
                         type: boolean
                       isSymmetricMultiThreadingEnabled:
-                        description: Whether symmetric multithreading is enabled on
-                          the instance. Symmetric multithreading is also called simultaneous
-                          multithreading (SMT) or Intel Hyper-Threading. Intel and
-                          AMD processors have two hardware execution threads per core
-                          (OCPU). SMT permits multiple independent threads of execution,
-                          to better use the resources and increase the efficiency
-                          of the CPU. When multithreading is disabled, only one thread
-                          is permitted to run on each core, which can provide higher
-                          or more predictable performance for some workloads.
+                        description: |-
+                          Whether symmetric multithreading is enabled on the instance. Symmetric multithreading is also
+                          called simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                          Intel and AMD processors have two hardware execution threads per core (OCPU). SMT permits multiple
+                          independent threads of execution, to better use the resources and increase the efficiency
+                          of the CPU. When multithreading is disabled, only one thread is permitted to run on each core, which
+                          can provide higher or more predictable performance for some workloads.
                         type: boolean
                       isTrustedPlatformModuleEnabled:
                         description: Whether the Trusted Platform Module (TPM) is
                           enabled on the instance.
                         type: boolean
                       numaNodesPerSocket:
-                        description: 'The number of NUMA nodes per socket (NPS). The
-                          following values are supported: * `NPS0` * `NPS1` * `NPS2`
-                          * `NPS4`'
+                        description: |-
+                          The number of NUMA nodes per socket (NPS).
+                          The following values are supported:
+                          * `NPS0`
+                          * `NPS1`
+                          * `NPS2`
+                          * `NPS4`
                         type: string
                       percentageOfCoresEnabled:
-                        description: The percentage of cores enabled. Value must be
-                          a multiple of 25%. If the requested percentage results in
-                          a fractional number of cores, the system rounds up the number
-                          of cores across processors and provisions an instance with
-                          a whole number of cores. If the applications that you run
-                          on the instance use a core-based licensing model and need
-                          fewer cores than the full size of the shape, you can disable
-                          cores to reduce your licensing costs. The instance itself
-                          is billed for the full shape, regardless of whether all
-                          cores are enabled.
+                        description: |-
+                          The percentage of cores enabled. Value must be a multiple of 25%. If the requested percentage
+                          results in a fractional number of cores, the system rounds up the number of cores across processors
+                          and provisions an instance with a whole number of cores.
+                          If the applications that you run on the instance use a core-based licensing model and need fewer cores
+                          than the full size of the shape, you can disable cores to reduce your licensing costs. The instance
+                          itself is billed for the full shape, regardless of whether all cores are enabled.
                         type: integer
                     type: object
                   amdVmPlatformConfig:
@@ -686,35 +706,33 @@ spec:
                         description: Whether Secure Boot is enabled on the instance.
                         type: boolean
                       isSymmetricMultiThreadingEnabled:
-                        description: Whether symmetric multithreading is enabled on
-                          the instance. Symmetric multithreading is also called simultaneous
-                          multithreading (SMT) or Intel Hyper-Threading. Intel and
-                          AMD processors have two hardware execution threads per core
-                          (OCPU). SMT permits multiple independent threads of execution,
-                          to better use the resources and increase the efficiency
-                          of the CPU. When multithreading is disabled, only one thread
-                          is permitted to run on each core, which can provide higher
-                          or more predictable performance for some workloads.
+                        description: |-
+                          Whether symmetric multithreading is enabled on the instance. Symmetric multithreading is also
+                          called simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                          Intel and AMD processors have two hardware execution threads per core (OCPU). SMT permits multiple
+                          independent threads of execution, to better use the resources and increase the efficiency
+                          of the CPU. When multithreading is disabled, only one thread is permitted to run on each core, which
+                          can provide higher or more predictable performance for some workloads.
                         type: boolean
                       isTrustedPlatformModuleEnabled:
                         description: Whether the Trusted Platform Module (TPM) is
                           enabled on the instance.
                         type: boolean
                       numaNodesPerSocket:
-                        description: 'The number of NUMA nodes per socket (NPS). The
-                          following values are supported: * `NPS1` * `NPS2`'
+                        description: |-
+                          The number of NUMA nodes per socket (NPS).
+                          The following values are supported:
+                          * `NPS1`
+                          * `NPS2`
                         type: string
                       percentageOfCoresEnabled:
-                        description: The percentage of cores enabled. Value must be
-                          a multiple of 25%. If the requested percentage results in
-                          a fractional number of cores, the system rounds up the number
-                          of cores across processors and provisions an instance with
-                          a whole number of cores. If the applications that you run
-                          on the instance use a core-based licensing model and need
-                          fewer cores than the full size of the shape, you can disable
-                          cores to reduce your licensing costs. The instance itself
-                          is billed for the full shape, regardless of whether all
-                          cores are enabled.
+                        description: |-
+                          The percentage of cores enabled. Value must be a multiple of 25%. If the requested percentage
+                          results in a fractional number of cores, the system rounds up the number of cores across processors
+                          and provisions an instance with a whole number of cores.
+                          If the applications that you run on the instance use a core-based licensing model and need fewer cores
+                          than the full size of the shape, you can disable cores to reduce your licensing costs. The instance
+                          itself is billed for the full shape, regardless of whether all cores are enabled.
                         type: integer
                     type: object
                   intelSkylakeBmPlatformConfig:
@@ -760,11 +778,16 @@ spec:
                         type: boolean
                     type: object
                   platformConfigType:
-                    description: The type of platform configuration. Valid values
-                      are * `AMD_ROME_BM_GPU` * `AMD_ROME_BM` * `INTEL_ICELAKE_BM`
-                      * `AMD_VM` * `INTEL_VM` * `INTEL_SKYLAKE_BM` * `AMD_MILAN_BM`
-                      Based on the enum, exactly one of the specific configuration
-                      types must be set
+                    description: |-
+                      The type of platform configuration. Valid values are
+                      * `AMD_ROME_BM_GPU`
+                      * `AMD_ROME_BM`
+                      * `INTEL_ICELAKE_BM`
+                      * `AMD_VM`
+                      * `INTEL_VM`
+                      * `INTEL_SKYLAKE_BM`
+                      * `AMD_MILAN_BM`
+                      Based on the enum, exactly one of the specific configuration types must be set
                     type: string
                 type: object
               preemptibleInstanceConfig:
@@ -784,18 +807,19 @@ spec:
                     type: object
                 type: object
               preserveBootVolume:
-                description: Specifies whether to delete or preserve the boot volume
-                  when terminating an instance. When set to true, the boot volume
-                  is preserved. The default value is false.
+                description: |-
+                  Specifies whether to delete or preserve the boot volume when terminating an instance.
+                  When set to true, the boot volume is preserved. The default value is false.
                 type: boolean
               preserveDataVolumesCreatedAtLaunch:
-                description: Specifies whether to delete or preserve the data volumes
-                  created during launch when terminating an instance. When set to
-                  true, the data volumes are preserved. The default value is true.
+                description: |-
+                  Specifies whether to delete or preserve the data volumes created during launch when
+                  terminating an instance. When set to true, the data volumes are preserved. The default value is true.
                 type: boolean
               providerID:
-                description: Provider ID of the instance, this will be set by Cluster
-                  API provider itself, users should not set this parameter.
+                description: |-
+                  Provider ID of the instance, this will be set by Cluster API provider itself,
+                  users should not set this parameter.
                 type: string
               shape:
                 description: Shape of the instance.
@@ -805,13 +829,13 @@ spec:
                   flex instances.
                 properties:
                   baselineOcpuUtilization:
-                    description: 'The baseline OCPU utilization for a subcore burstable
-                      VM instance. Leave this attribute blank for a non-burstable
-                      instance, or explicitly specify non-burstable with `BASELINE_1_1`.
-                      The following values are supported: - `BASELINE_1_8` - baseline
-                      usage is 1/8 of an OCPU. - `BASELINE_1_2` - baseline usage is
-                      1/2 of an OCPU. - `BASELINE_1_1` - baseline usage is an entire
-                      OCPU. This represents a non-burstable instance.'
+                    description: |-
+                      The baseline OCPU utilization for a subcore burstable VM instance. Leave this attribute blank for a
+                      non-burstable instance, or explicitly specify non-burstable with `BASELINE_1_1`.
+                      The following values are supported:
+                      - `BASELINE_1_8` - baseline usage is 1/8 of an OCPU.
+                      - `BASELINE_1_2` - baseline usage is 1/2 of an OCPU.
+                      - `BASELINE_1_1` - baseline usage is an entire OCPU. This represents a non-burstable instance.
                     type: string
                   memoryInGBs:
                     description: The total amount of memory available to the instance,
@@ -826,36 +850,36 @@ spec:
                     type: string
                 type: object
               subnetName:
-                description: The name of the subnet to use. The name here refers to
-                  the subnets defined in the OCICluster Spec. Optional, only if multiple
-                  subnets of a type is defined, else the first element is used.
+                description: |-
+                  The name of the subnet to use. The name here refers to the subnets
+                  defined in the OCICluster Spec. Optional, only if multiple subnets of a type
+                  is defined, else the first element is used.
                 type: string
               vnicAttachments:
-                description: VnicAttachments defines the configuration options for
-                  the vnic(s) attached to the machine The network bandwidth and number
-                  of VNICs scale proportionately with the number of OCPUs.
+                description: |-
+                  VnicAttachments defines the configuration options for the vnic(s) attached to the machine
+                  The network bandwidth and number of VNICs scale proportionately with the number of OCPUs.
                 items:
                   properties:
-                    assignIpv6Ip:
-                      description: assignIpv6Ip defines whether the VNIC should
-                        be assigned a IPv6.
-                      type: boolean
                     assignPublicIp:
                       description: AssignPublicIp defines whether the vnic should
                         have a public IP address
                       type: boolean
                     displayName:
-                      description: DisplayName defines a user-friendly name. Does
-                        not have to be unique. Avoid entering confidential information.
+                      description: |-
+                        DisplayName defines a user-friendly name. Does not have to be unique.
+                        Avoid entering confidential information.
                       type: string
                     nicIndex:
-                      description: NicIndex defines which physical Network Interface
-                        Card (NIC) to use You can determine which NICs are active
-                        for a shape by reviewing the https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm
+                      description: |-
+                        NicIndex defines which physical Network Interface Card (NIC) to use
+                        You can determine which NICs are active for a shape by reviewing the
+                        https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm
                       type: integer
                     subnetName:
-                      description: SubnetName defines the subnet name to use for the
-                        VNIC Defaults to the "worker" subnet if not provided
+                      description: |-
+                        SubnetName defines the subnet name to use for the VNIC
+                        Defaults to the "worker" subnet if not provided
                       type: string
                     vnicAttachmentId:
                       description: VnicAttachmentId defines the ID of the VnicAttachment
@@ -876,11 +900,19 @@ spec:
                     address.
                   properties:
                     address:
-                      description: The machine address.
+                      description: address is the machine address.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     type:
-                      description: Machine address type, one of Hostname, ExternalIP,
-                        InternalIP, ExternalDNS or InternalDNS.
+                      description: type is the machine address type, one of Hostname,
+                        ExternalIP, InternalIP, ExternalDNS or InternalDNS.
+                      enum:
+                      - Hostname
+                      - ExternalIP
+                      - InternalIP
+                      - ExternalDNS
+                      - InternalDNS
                       type: string
                   required:
                   - address
@@ -894,37 +926,44 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
+                      description: status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -962,20 +1001,26 @@ spec:
         description: OCIMachine is the Schema for the ocimachines API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: OCIMachineSpec defines the desired state of OCIMachine Please
-              read the API https://docs.oracle.com/en-us/iaas/api/#/en/iaas/20160918/Instance/LaunchInstance
+            description: |-
+              OCIMachineSpec defines the desired state of OCIMachine
+              Please read the API https://docs.oracle.com/en-us/iaas/api/#/en/iaas/20160918/Instance/LaunchInstance
               for more information about the parameters below
             properties:
               agentConfig:
@@ -983,40 +1028,41 @@ spec:
                   Agent software running on the instance.
                 properties:
                   areAllPluginsDisabled:
-                    description: AreAllPluginsDisabled defines whether Oracle Cloud
-                      Agent can run all the available plugins. This includes the management
-                      and monitoring plugins. To get a list of available plugins,
-                      use the ListInstanceagentAvailablePlugins operation in the Oracle
-                      Cloud Agent API. For more information about the available plugins,
-                      see Managing Plugins with Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
+                    description: |-
+                      AreAllPluginsDisabled defines whether Oracle Cloud Agent can run all the available plugins.
+                      This includes the management and monitoring plugins.
+                      To get a list of available plugins, use the
+                      ListInstanceagentAvailablePlugins
+                      operation in the Oracle Cloud Agent API. For more information about the available plugins, see
+                      Managing Plugins with Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
                     type: boolean
                   isManagementDisabled:
-                    description: 'IsManagementDisabled defines whether Oracle Cloud
-                      Agent can run all the available management plugins. Default
-                      value is false (management plugins are enabled). These are the
-                      management plugins: OS Management Service Agent and Compute
-                      Instance Run Command. The management plugins are controlled
-                      by this parameter and by the per-plugin configuration in the
-                      `pluginsConfig` object. - If `isManagementDisabled` is true,
-                      all of the management plugins are disabled, regardless of the
-                      per-plugin configuration. - If `isManagementDisabled` is false,
-                      all of the management plugins are enabled. You can optionally
-                      disable individual management plugins by providing a value in
-                      the `pluginsConfig` object.'
+                    description: |-
+                      IsManagementDisabled defines whether Oracle Cloud Agent can run all the available management plugins.
+                      Default value is false (management plugins are enabled).
+                      These are the management plugins: OS Management Service Agent and Compute Instance
+                      Run Command.
+                      The management plugins are controlled by this parameter and by the per-plugin
+                      configuration in the `pluginsConfig` object.
+                      - If `isManagementDisabled` is true, all of the management plugins are disabled, regardless of
+                      the per-plugin configuration.
+                      - If `isManagementDisabled` is false, all of the management plugins are enabled. You
+                      can optionally disable individual management plugins by providing a value in the `pluginsConfig`
+                      object.
                     type: boolean
                   isMonitoringDisabled:
-                    description: 'IsMonitoringDisabled defines whether Oracle Cloud
-                      Agent can gather performance metrics and monitor the instance
-                      using the monitoring plugins. Default value is false (monitoring
-                      plugins are enabled). These are the monitoring plugins: Compute
-                      Instance Monitoring and Custom Logs Monitoring. The monitoring
-                      plugins are controlled by this parameter and by the per-plugin
-                      configuration in the `pluginsConfig` object. - If `isMonitoringDisabled`
-                      is true, all of the monitoring plugins are disabled, regardless
-                      of the per-plugin configuration. - If `isMonitoringDisabled`
-                      is false, all of the monitoring plugins are enabled. You can
-                      optionally disable individual monitoring plugins by providing
-                      a value in the `pluginsConfig` object.'
+                    description: |-
+                      IsMonitoringDisabled defines whether Oracle Cloud Agent can gather performance metrics and monitor the instance using the
+                      monitoring plugins. Default value is false (monitoring plugins are enabled).
+                      These are the monitoring plugins: Compute Instance Monitoring
+                      and Custom Logs Monitoring.
+                      The monitoring plugins are controlled by this parameter and by the per-plugin
+                      configuration in the `pluginsConfig` object.
+                      - If `isMonitoringDisabled` is true, all of the monitoring plugins are disabled, regardless of
+                      the per-plugin configuration.
+                      - If `isMonitoringDisabled` is false, all of the monitoring plugins are enabled. You
+                      can optionally disable individual monitoring plugins by providing a value in the `pluginsConfig`
+                      object.
                     type: boolean
                   pluginsConfigs:
                     description: PluginsConfig defines the configuration of plugins
@@ -1026,63 +1072,61 @@ spec:
                         of plugins associated with this instance.
                       properties:
                         desiredState:
-                          description: 'DesiredState defines whether the plugin should
-                            be enabled or disabled. To enable the monitoring and management
-                            plugins, the `isMonitoringDisabled` and `isManagementDisabled`
-                            attributes must also be set to false. The following values
-                            are supported: * `ENABLED` * `DISABLED`'
+                          description: |-
+                            DesiredState defines whether the plugin should be enabled or disabled.
+                            To enable the monitoring and management plugins, the `isMonitoringDisabled` and
+                            `isManagementDisabled` attributes must also be set to false.
+                            The following values are supported:
+                            * `ENABLED`
+                            * `DISABLED`
                           type: string
                         name:
-                          description: Name defines the name of the plugin. To get
-                            a list of available plugins, use the ListInstanceagentAvailablePlugins
-                            operation in the Oracle Cloud Agent API. For more information
-                            about the available plugins, see Managing Plugins with
-                            Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
+                          description: |-
+                            Name defines the name of the plugin. To get a list of available plugins, use the
+                            ListInstanceagentAvailablePlugins
+                            operation in the Oracle Cloud Agent API. For more information about the available plugins, see
+                            Managing Plugins with Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
                           type: string
                       type: object
                     type: array
                 type: object
               availabilityConfig:
-                description: LaunchInstanceAvailabilityConfig defines the options
-                  for VM migration during infrastructure maintenance events and for
-                  defining the availability of a VM instance after a maintenance event
-                  that impacts the underlying hardware.
+                description: |-
+                  LaunchInstanceAvailabilityConfig defines the options for VM migration during infrastructure maintenance events and for defining
+                  the availability of a VM instance after a maintenance event that impacts the underlying hardware.
                 properties:
                   isLiveMigrationPreferred:
-                    description: IsLiveMigrationPreferred defines whether to live
-                      migrate supported VM instances to a healthy physical VM host
-                      without disrupting running instances during infrastructure maintenance
-                      events. If null, Oracle chooses the best option for migrating
-                      the VM during infrastructure maintenance events.
+                    description: |-
+                      IsLiveMigrationPreferred defines whether to live migrate supported VM instances to a healthy physical VM host without
+                      disrupting running instances during infrastructure maintenance events. If null, Oracle
+                      chooses the best option for migrating the VM during infrastructure maintenance events.
                     type: boolean
                   recoveryAction:
-                    description: RecoveryAction defines the lifecycle state for an
-                      instance when it is recovered after infrastructure maintenance.
-                      * `RESTORE_INSTANCE` - The instance is restored to the lifecycle
-                      state it was in before the maintenance event. If the instance
-                      was running, it is automatically rebooted. This is the default
-                      action when a value is not set. * `STOP_INSTANCE` - The instance
-                      is recovered in the stopped state.
+                    description: |-
+                      RecoveryAction defines the lifecycle state for an instance when it is recovered after infrastructure maintenance.
+                      * `RESTORE_INSTANCE` - The instance is restored to the lifecycle state it was in before the maintenance event.
+                      If the instance was running, it is automatically rebooted. This is the default action when a value is not set.
+                      * `STOP_INSTANCE` - The instance is recovered in the stopped state.
                     type: string
                 type: object
               bootVolumeSizeInGBs:
-                description: The size of boot volume. Please see https://docs.oracle.com/en-us/iaas/Content/Block/Tasks/extendingbootpartition.htm
+                description: |-
+                  The size of boot volume. Please see https://docs.oracle.com/en-us/iaas/Content/Block/Tasks/extendingbootpartition.htm
                   to extend the boot volume size.
                 type: string
               capacityReservationId:
-                description: CapacityReservationId defines the OCID of the compute
-                  capacity reservation this instance is launched under. You can opt
-                  out of all default reservations by specifying an empty string as
-                  input for this field. For more information, see Capacity Reservations
-                  (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/reserve-capacity.htm#default).
+                description: |-
+                  CapacityReservationId defines the OCID of the compute capacity reservation this instance is launched under.
+                  You can opt out of all default reservations by specifying an empty string as input for this field.
+                  For more information, see Capacity Reservations (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/reserve-capacity.htm#default).
                 type: string
               compartmentId:
                 description: Compartment to launch the instance in.
                 type: string
               computeClusterId:
-                description: ComputeClusterId refers to OCID of the compute cluster
-                  that the instance will be created in. Please refer https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/compute-clusters.htm
-                  for more details
+                description: |-
+                  ComputeClusterId refers to OCID of the compute cluster that the instance will be created in.
+                  Please refer https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/compute-clusters.htm for more details
                 type: string
               dedicatedVmHostId:
                 description: DedicatedVmHostId defines the OCID of the dedicated VM
@@ -1093,10 +1137,10 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
-                description: 'Defined tags for this resource. Each key is predefined
-                  and scoped to a namespace. For more information, see Resource Tags
-                  (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
-                  Example: `{"Operations": {"CostCenter": "42"}}`'
+                description: |-
+                  Defined tags for this resource. Each key is predefined and scoped to a
+                  namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+                  Example: `{"Operations": {"CostCenter": "42"}}`
                 type: object
               freeformTags:
                 additionalProperties:
@@ -1113,9 +1157,10 @@ spec:
                 description: InstanceOptions defines the instance options
                 properties:
                   areLegacyImdsEndpointsDisabled:
-                    description: Whether to disable the legacy (/v1) instance metadata
-                      service endpoints. Customers who have migrated to /v2 should
-                      set this to true for added security. Default is false.
+                    description: |-
+                      Whether to disable the legacy (/v1) instance metadata service endpoints.
+                      Customers who have migrated to /v2 should set this to true for added security.
+                      Default is false.
                     type: boolean
                 type: object
               instanceSourceViaImageConfig:
@@ -1123,15 +1168,15 @@ spec:
                   booting up instances via images
                 properties:
                   bootVolumeVpusPerGB:
-                    description: 'BootVolumeVpusPerGB defines the number of volume
-                      performance units (VPUs) that will be applied to this volume
-                      per GB, representing the Block Volume service''s elastic performance
-                      options. See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels)
-                      for more information. Allowed values: * `10`: Represents Balanced
-                      option. * `20`: Represents Higher Performance option. * `30`-`120`:
-                      Represents the Ultra High Performance option. For volumes with
-                      the auto-tuned performance feature enabled, this is set to the
-                      default (minimum) VPUs/GB.'
+                    description: |-
+                      BootVolumeVpusPerGB defines the number of volume performance units (VPUs) that will be applied to this volume per GB,
+                      representing the Block Volume service's elastic performance options.
+                      See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels) for more information.
+                      Allowed values:
+                        * `10`: Represents Balanced option.
+                        * `20`: Represents Higher Performance option.
+                        * `30`-`120`: Represents the Ultra High Performance option.
+                      For volumes with the auto-tuned performance feature enabled, this is set to the default (minimum) VPUs/GB.
                     format: int64
                     type: integer
                   kmsKeyId:
@@ -1151,43 +1196,46 @@ spec:
                   and performance of VM shapes
                 properties:
                   bootVolumeType:
-                    description: BootVolumeType defines Emulation type for the boot
-                      volume. * `ISCSI` - ISCSI attached block storage device. * `SCSI`
-                      - Emulated SCSI disk. * `IDE` - Emulated IDE disk. * `VFIO`
-                      - Direct attached Virtual Function storage. This is the default
-                      option for local data volumes on platform images. * `PARAVIRTUALIZED`
-                      - Paravirtualized disk. This is the default for boot volumes
-                      and remote block storage volumes on platform images.
+                    description: |-
+                      BootVolumeType defines Emulation type for the boot volume.
+                      * `ISCSI` - ISCSI attached block storage device.
+                      * `SCSI` - Emulated SCSI disk.
+                      * `IDE` - Emulated IDE disk.
+                      * `VFIO` - Direct attached Virtual Function storage. This is the default option for local data
+                      volumes on platform images.
+                      * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+                      storage volumes on platform images.
                     type: string
                   firmware:
-                    description: Firmware defines the firmware used to boot VM. Select
-                      the option that matches your operating system. * `BIOS` - Boot
-                      VM using BIOS style firmware. This is compatible with both 32
-                      bit and 64 bit operating systems that boot using MBR style bootloaders.
-                      * `UEFI_64` - Boot VM using UEFI style firmware compatible with
-                      64 bit operating systems. This is the default for platform images.
+                    description: |-
+                      Firmware defines the firmware used to boot VM. Select the option that matches your operating system.
+                      * `BIOS` - Boot VM using BIOS style firmware. This is compatible with both 32 bit and 64 bit operating
+                      systems that boot using MBR style bootloaders.
+                      * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems. This is the
+                      default for platform images.
                     type: string
                   isConsistentVolumeNamingEnabled:
                     description: IsConsistentVolumeNamingEnabled defines whether to
                       enable consistent volume naming feature. Defaults to false.
                     type: boolean
                   networkType:
-                    description: NetworkType defines the emulation type for the physical
-                      network interface card (NIC). * `E1000` - Emulated Gigabit ethernet
-                      controller. Compatible with Linux e1000 network driver. * `VFIO`
-                      - Direct attached Virtual Function network controller. This
-                      is the networking type when you launch an instance using hardware-assisted
-                      (SR-IOV) networking. * `PARAVIRTUALIZED` - VM instances launch
-                      with paravirtualized devices using VirtIO drivers.
+                    description: |-
+                      NetworkType defines the emulation type for the physical network interface card (NIC).
+                      * `E1000` - Emulated Gigabit ethernet controller. Compatible with Linux e1000 network driver.
+                      * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
+                      when you launch an instance using hardware-assisted (SR-IOV) networking.
+                      * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
                     type: string
                   remoteDataVolumeType:
-                    description: RemoteDataVolumeType defines the emulation type for
-                      volume. * `ISCSI` - ISCSI attached block storage device. * `SCSI`
-                      - Emulated SCSI disk. * `IDE` - Emulated IDE disk. * `VFIO`
-                      - Direct attached Virtual Function storage. This is the default
-                      option for local data volumes on platform images. * `PARAVIRTUALIZED`
-                      - Paravirtualized disk. This is the default for boot volumes
-                      and remote block storage volumes on platform images.
+                    description: |-
+                      RemoteDataVolumeType defines the emulation type for volume.
+                      * `ISCSI` - ISCSI attached block storage device.
+                      * `SCSI` - Emulated SCSI disk.
+                      * `IDE` - Emulated IDE disk.
+                      * `VFIO` - Direct attached Virtual Function storage. This is the default option for local data
+                      volumes on platform images.
+                      * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+                      storage volumes on platform images.
                     type: string
                 type: object
               launchVolumeAttachments:
@@ -1205,11 +1253,13 @@ spec:
                             for a given instance, see ListInstanceDevices.
                           type: string
                         displayName:
-                          description: A user-friendly name. Does not have to be unique,
-                            and it's changeable. Avoid entering confidential information.
+                          description: |-
+                            A user-friendly name. Does not have to be unique, and it's changeable.
+                            Avoid entering confidential information.
                           type: string
                         encryptionInTransitType:
-                          description: Refer the top-level definition of encryptionInTransitType.
+                          description: |-
+                            Refer the top-level definition of encryptionInTransitType.
                             The default value is NONE.
                           type: string
                         isAgentAutoIscsiLoginEnabled:
@@ -1222,44 +1272,45 @@ spec:
                             mode.
                           type: boolean
                         isShareable:
-                          description: Whether the attachment should be created in
-                            shareable mode. If an attachment is created in shareable
-                            mode, then other instances can attach the same volume,
-                            provided that they also create their attachments in shareable
-                            mode. Only certain volume types can be attached in shareable
-                            mode. Defaults to false if not specified.
+                          description: |-
+                            Whether the attachment should be created in shareable mode. If an attachment
+                            is created in shareable mode, then other instances can attach the same volume, provided
+                            that they also create their attachments in shareable mode. Only certain volume types can
+                            be attached in shareable mode. Defaults to false if not specified.
                           type: boolean
                         launchCreateVolumeFromAttributes:
                           description: LaunchCreateVolumeFromAttributes The details
                             of the volume to create for CreateVolume operation.
                           properties:
                             compartmentId:
-                              description: The OCID of the compartment that contains
-                                the volume. If not provided, it will be inherited
-                                from the instance.
+                              description: |-
+                                The OCID of the compartment that contains the volume. If not provided,
+                                it will be inherited from the instance.
                               type: string
                             displayName:
-                              description: A user-friendly name. Does not have to
-                                be unique, and it's changeable. Avoid entering confidential
-                                information.
+                              description: |-
+                                A user-friendly name. Does not have to be unique, and it's changeable.
+                                Avoid entering confidential information.
                               type: string
                             kmsKeyId:
-                              description: The OCID of the Vault service key to assign
-                                as the master encryption key for the volume.
+                              description: |-
+                                The OCID of the Vault service key to assign as the master encryption key
+                                for the volume.
                               type: string
                             sizeInGBs:
                               description: The size of the volume in GBs.
                               format: int64
                               type: integer
                             vpusPerGB:
-                              description: 'The number of volume performance units
-                                (VPUs) that will be applied to this volume per GB,
-                                representing the Block Volume service''s elastic performance
-                                options. See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels)
-                                for more information. Allowed values: * `0`: Represents
-                                Lower Cost option. * `10`: Represents Balanced option.
-                                * `20`: Represents Higher Performance option. * `30`-`120`:
-                                Represents the Ultra High Performance option.'
+                              description: |-
+                                The number of volume performance units (VPUs) that will be applied to this volume per GB,
+                                representing the Block Volume service's elastic performance options.
+                                See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels) for more information.
+                                Allowed values:
+                                  * `0`: Represents Lower Cost option.
+                                  * `10`: Represents Balanced option.
+                                  * `20`: Represents Higher Performance option.
+                                  * `30`-`120`: Represents the Ultra High Performance option.
                               format: int64
                               type: integer
                           type: object
@@ -1273,18 +1324,22 @@ spec:
                           type: string
                       type: object
                     launchParavirtualizedVolumeAttachment:
-                      description: The details of paravirtualized volume attachment.
+                      description: LaunchParavirtualizedVolumeAttachment specifies
+                        the paravirtualized volume attachments to create as part of
+                        the launch instance operation.
                       properties:
                         device:
                           description: The device name. To retrieve a list of devices
                             for a given instance, see ListInstanceDevices.
                           type: string
                         displayName:
-                          description: A user-friendly name. Does not have to be unique,
-                            and it's changeable. Avoid entering confidential information.
+                          description: |-
+                            A user-friendly name. Does not have to be unique, and it's changeable.
+                            Avoid entering confidential information.
                           type: string
                         isPvEncryptionInTransitEnabled:
-                          description: Refer the top-level definition of isPvEncryptionInTransitEnabled.
+                          description: |-
+                            Refer the top-level definition of encryptionInTransitType.
                             The default value is False.
                           type: boolean
                         isReadOnly:
@@ -1292,44 +1347,45 @@ spec:
                             mode.
                           type: boolean
                         isShareable:
-                          description: Whether the attachment should be created in
-                            shareable mode. If an attachment is created in shareable
-                            mode, then other instances can attach the same volume,
-                            provided that they also create their attachments in shareable
-                            mode. Only certain volume types can be attached in shareable
-                            mode. Defaults to false if not specified.
+                          description: |-
+                            Whether the attachment should be created in shareable mode. If an attachment
+                            is created in shareable mode, then other instances can attach the same volume, provided
+                            that they also create their attachments in shareable mode. Only certain volume types can
+                            be attached in shareable mode. Defaults to false if not specified.
                           type: boolean
                         launchCreateVolumeFromAttributes:
                           description: LaunchCreateVolumeFromAttributes The details
                             of the volume to create for CreateVolume operation.
                           properties:
                             compartmentId:
-                              description: The OCID of the compartment that contains
-                                the volume. If not provided, it will be inherited
-                                from the instance.
+                              description: |-
+                                The OCID of the compartment that contains the volume. If not provided,
+                                it will be inherited from the instance.
                               type: string
                             displayName:
-                              description: A user-friendly name. Does not have to
-                                be unique, and it's changeable. Avoid entering confidential
-                                information.
+                              description: |-
+                                A user-friendly name. Does not have to be unique, and it's changeable.
+                                Avoid entering confidential information.
                               type: string
                             kmsKeyId:
-                              description: The OCID of the Vault service key to assign
-                                as the master encryption key for the volume.
+                              description: |-
+                                The OCID of the Vault service key to assign as the master encryption key
+                                for the volume.
                               type: string
                             sizeInGBs:
                               description: The size of the volume in GBs.
                               format: int64
                               type: integer
                             vpusPerGB:
-                              description: 'The number of volume performance units
-                                (VPUs) that will be applied to this volume per GB,
-                                representing the Block Volume service''s elastic performance
-                                options. See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels)
-                                for more information. Allowed values: * `0`: Represents
-                                Lower Cost option. * `10`: Represents Balanced option.
-                                * `20`: Represents Higher Performance option. * `30`-`120`:
-                                Represents the Ultra High Performance option.'
+                              description: |-
+                                The number of volume performance units (VPUs) that will be applied to this volume per GB,
+                                representing the Block Volume service's elastic performance options.
+                                See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels) for more information.
+                                Allowed values:
+                                  * `0`: Represents Lower Cost option.
+                                  * `10`: Represents Balanced option.
+                                  * `20`: Represents Higher Performance option.
+                                  * `30`-`120`: Represents the Ultra High Performance option.
                               format: int64
                               type: integer
                           type: object
@@ -1346,36 +1402,39 @@ spec:
               metadata:
                 additionalProperties:
                   type: string
-                description: Custom metadata key/value pairs that you provide, such
-                  as the SSH public key required to connect to the instance.
+                description: |-
+                  Custom metadata key/value pairs that you provide, such as the SSH public key
+                  required to connect to the instance.
                 type: object
               networkDetails:
                 description: NetworkDetails defines the configuration options for
                   the network
                 properties:
+                  assignIpv6Ip:
+                    description: AssignIPv6 determines whether to assign a IPv6 address
+                      to the instance.
+                    type: boolean
                   assignPrivateDnsRecord:
                     description: AssignPrivateDnsRecord defines whether the VNIC should
                       be assigned a DNS record.
-                    type: boolean
-                  assignIpv6Ip:
-                    description: assignIpv6Ip defines if the instance should have an IPv6
                     type: boolean
                   assignPublicIp:
                     description: AssignPublicIp defines whether the instance should
                       have a public IP address
                     type: boolean
                   displayName:
-                    description: DisplayName defines a user-friendly name. Does not
-                      have to be unique, and it's changeable. Avoid entering confidential
-                      information.
+                    description: |-
+                      DisplayName defines a user-friendly name. Does not have to be unique, and it's changeable.
+                      Avoid entering confidential information.
                     type: string
                   hostnameLabel:
                     description: HostnameLabel defines the hostname for the VNIC's
                       primary private IP. Used for DNS.
                     type: string
                   nsgId:
-                    description: NSGId defines the ID of the NSG to use. This parameter
-                      takes priority over NsgNames. Deprecated, please use NetworkDetails.NSGIds
+                    description: |-
+                      NSGId defines the ID of the NSG to use. This parameter takes priority over NsgNames.
+                      Deprecated, please use NetworkDetails.NSGIds
                     type: string
                   nsgIds:
                     description: NSGIds defines the list of NSG IDs to use. This parameter
@@ -1410,14 +1469,14 @@ spec:
                       configuration
                     properties:
                       areVirtualInstructionsEnabled:
-                        description: Whether virtualization instructions are available.
-                          For example, Secure Virtual Machine for AMD shapes or VT-x
-                          for Intel shapes.
+                        description: |-
+                          Whether virtualization instructions are available. For example, Secure Virtual Machine for AMD shapes
+                          or VT-x for Intel shapes.
                         type: boolean
                       isAccessControlServiceEnabled:
-                        description: Whether the Access Control Service is enabled
-                          on the instance. When enabled, the platform can enforce
-                          PCIe device isolation, required for VFIO device pass-through.
+                        description: |-
+                          Whether the Access Control Service is enabled on the instance. When enabled,
+                          the platform can enforce PCIe device isolation, required for VFIO device pass-through.
                         type: boolean
                       isInputOutputMemoryManagementUnitEnabled:
                         description: Whether the input-output memory management unit
@@ -1436,36 +1495,35 @@ spec:
                         description: Whether Secure Boot is enabled on the instance.
                         type: boolean
                       isSymmetricMultiThreadingEnabled:
-                        description: Whether symmetric multithreading is enabled on
-                          the instance. Symmetric multithreading is also called simultaneous
-                          multithreading (SMT) or Intel Hyper-Threading. Intel and
-                          AMD processors have two hardware execution threads per core
-                          (OCPU). SMT permits multiple independent threads of execution,
-                          to better use the resources and increase the efficiency
-                          of the CPU. When multithreading is disabled, only one thread
-                          is permitted to run on each core, which can provide higher
-                          or more predictable performance for some workloads.
+                        description: |-
+                          Whether symmetric multithreading is enabled on the instance. Symmetric multithreading is also
+                          called simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                          Intel and AMD processors have two hardware execution threads per core (OCPU). SMT permits multiple
+                          independent threads of execution, to better use the resources and increase the efficiency
+                          of the CPU. When multithreading is disabled, only one thread is permitted to run on each core, which
+                          can provide higher or more predictable performance for some workloads.
                         type: boolean
                       isTrustedPlatformModuleEnabled:
                         description: Whether the Trusted Platform Module (TPM) is
                           enabled on the instance.
                         type: boolean
                       numaNodesPerSocket:
-                        description: 'The number of NUMA nodes per socket (NPS). The
-                          following values are supported: * `NPS0` * `NPS1` * `NPS2`
-                          * `NPS4`'
+                        description: |-
+                          The number of NUMA nodes per socket (NPS).
+                          The following values are supported:
+                          * `NPS0`
+                          * `NPS1`
+                          * `NPS2`
+                          * `NPS4`
                         type: string
                       percentageOfCoresEnabled:
-                        description: The percentage of cores enabled. Value must be
-                          a multiple of 25%. If the requested percentage results in
-                          a fractional number of cores, the system rounds up the number
-                          of cores across processors and provisions an instance with
-                          a whole number of cores. If the applications that you run
-                          on the instance use a core-based licensing model and need
-                          fewer cores than the full size of the shape, you can disable
-                          cores to reduce your licensing costs. The instance itself
-                          is billed for the full shape, regardless of whether all
-                          cores are enabled.
+                        description: |-
+                          The percentage of cores enabled. Value must be a multiple of 25%. If the requested percentage
+                          results in a fractional number of cores, the system rounds up the number of cores across processors
+                          and provisions an instance with a whole number of cores.
+                          If the applications that you run on the instance use a core-based licensing model and need fewer cores
+                          than the full size of the shape, you can disable cores to reduce your licensing costs. The instance
+                          itself is billed for the full shape, regardless of whether all cores are enabled.
                         type: integer
                     type: object
                   amdRomeBmGpuPlatformConfig:
@@ -1473,14 +1531,14 @@ spec:
                       configuration
                     properties:
                       areVirtualInstructionsEnabled:
-                        description: Whether virtualization instructions are available.
-                          For example, Secure Virtual Machine for AMD shapes or VT-x
-                          for Intel shapes.
+                        description: |-
+                          Whether virtualization instructions are available. For example, Secure Virtual Machine for AMD shapes
+                          or VT-x for Intel shapes.
                         type: boolean
                       isAccessControlServiceEnabled:
-                        description: Whether the Access Control Service is enabled
-                          on the instance. When enabled, the platform can enforce
-                          PCIe device isolation, required for VFIO device pass-through.
+                        description: |-
+                          Whether the Access Control Service is enabled on the instance. When enabled,
+                          the platform can enforce PCIe device isolation, required for VFIO device pass-through.
                         type: boolean
                       isInputOutputMemoryManagementUnitEnabled:
                         description: Whether the input-output memory management unit
@@ -1499,24 +1557,26 @@ spec:
                         description: Whether Secure Boot is enabled on the instance.
                         type: boolean
                       isSymmetricMultiThreadingEnabled:
-                        description: Whether symmetric multithreading is enabled on
-                          the instance. Symmetric multithreading is also called simultaneous
-                          multithreading (SMT) or Intel Hyper-Threading. Intel and
-                          AMD processors have two hardware execution threads per core
-                          (OCPU). SMT permits multiple independent threads of execution,
-                          to better use the resources and increase the efficiency
-                          of the CPU. When multithreading is disabled, only one thread
-                          is permitted to run on each core, which can provide higher
-                          or more predictable performance for some workloads.
+                        description: |-
+                          Whether symmetric multithreading is enabled on the instance. Symmetric multithreading is also
+                          called simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                          Intel and AMD processors have two hardware execution threads per core (OCPU). SMT permits multiple
+                          independent threads of execution, to better use the resources and increase the efficiency
+                          of the CPU. When multithreading is disabled, only one thread is permitted to run on each core, which
+                          can provide higher or more predictable performance for some workloads.
                         type: boolean
                       isTrustedPlatformModuleEnabled:
                         description: Whether the Trusted Platform Module (TPM) is
                           enabled on the instance.
                         type: boolean
                       numaNodesPerSocket:
-                        description: 'The number of NUMA nodes per socket (NPS). The
-                          following values are supported: * `NPS0` * `NPS1` * `NPS2`
-                          * `NPS4`'
+                        description: |-
+                          The number of NUMA nodes per socket (NPS).
+                          The following values are supported:
+                          * `NPS0`
+                          * `NPS1`
+                          * `NPS2`
+                          * `NPS4`
                         type: string
                     type: object
                   amdRomeBmPlatformConfig:
@@ -1524,14 +1584,14 @@ spec:
                       configuration
                     properties:
                       areVirtualInstructionsEnabled:
-                        description: Whether virtualization instructions are available.
-                          For example, Secure Virtual Machine for AMD shapes or VT-x
-                          for Intel shapes.
+                        description: |-
+                          Whether virtualization instructions are available. For example, Secure Virtual Machine for AMD shapes
+                          or VT-x for Intel shapes.
                         type: boolean
                       isAccessControlServiceEnabled:
-                        description: Whether the Access Control Service is enabled
-                          on the instance. When enabled, the platform can enforce
-                          PCIe device isolation, required for VFIO device pass-through.
+                        description: |-
+                          Whether the Access Control Service is enabled on the instance. When enabled,
+                          the platform can enforce PCIe device isolation, required for VFIO device pass-through.
                         type: boolean
                       isInputOutputMemoryManagementUnitEnabled:
                         description: Whether the input-output memory management unit
@@ -1550,36 +1610,35 @@ spec:
                         description: Whether Secure Boot is enabled on the instance.
                         type: boolean
                       isSymmetricMultiThreadingEnabled:
-                        description: Whether symmetric multithreading is enabled on
-                          the instance. Symmetric multithreading is also called simultaneous
-                          multithreading (SMT) or Intel Hyper-Threading. Intel and
-                          AMD processors have two hardware execution threads per core
-                          (OCPU). SMT permits multiple independent threads of execution,
-                          to better use the resources and increase the efficiency
-                          of the CPU. When multithreading is disabled, only one thread
-                          is permitted to run on each core, which can provide higher
-                          or more predictable performance for some workloads.
+                        description: |-
+                          Whether symmetric multithreading is enabled on the instance. Symmetric multithreading is also
+                          called simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                          Intel and AMD processors have two hardware execution threads per core (OCPU). SMT permits multiple
+                          independent threads of execution, to better use the resources and increase the efficiency
+                          of the CPU. When multithreading is disabled, only one thread is permitted to run on each core, which
+                          can provide higher or more predictable performance for some workloads.
                         type: boolean
                       isTrustedPlatformModuleEnabled:
                         description: Whether the Trusted Platform Module (TPM) is
                           enabled on the instance.
                         type: boolean
                       numaNodesPerSocket:
-                        description: 'The number of NUMA nodes per socket (NPS). The
-                          following values are supported: * `NPS0` * `NPS1` * `NPS2`
-                          * `NPS4`'
+                        description: |-
+                          The number of NUMA nodes per socket (NPS).
+                          The following values are supported:
+                          * `NPS0`
+                          * `NPS1`
+                          * `NPS2`
+                          * `NPS4`
                         type: string
                       percentageOfCoresEnabled:
-                        description: The percentage of cores enabled. Value must be
-                          a multiple of 25%. If the requested percentage results in
-                          a fractional number of cores, the system rounds up the number
-                          of cores across processors and provisions an instance with
-                          a whole number of cores. If the applications that you run
-                          on the instance use a core-based licensing model and need
-                          fewer cores than the full size of the shape, you can disable
-                          cores to reduce your licensing costs. The instance itself
-                          is billed for the full shape, regardless of whether all
-                          cores are enabled.
+                        description: |-
+                          The percentage of cores enabled. Value must be a multiple of 25%. If the requested percentage
+                          results in a fractional number of cores, the system rounds up the number of cores across processors
+                          and provisions an instance with a whole number of cores.
+                          If the applications that you run on the instance use a core-based licensing model and need fewer cores
+                          than the full size of the shape, you can disable cores to reduce your licensing costs. The instance
+                          itself is billed for the full shape, regardless of whether all cores are enabled.
                         type: integer
                     type: object
                   amdVmPlatformConfig:
@@ -1624,35 +1683,33 @@ spec:
                         description: Whether Secure Boot is enabled on the instance.
                         type: boolean
                       isSymmetricMultiThreadingEnabled:
-                        description: Whether symmetric multithreading is enabled on
-                          the instance. Symmetric multithreading is also called simultaneous
-                          multithreading (SMT) or Intel Hyper-Threading. Intel and
-                          AMD processors have two hardware execution threads per core
-                          (OCPU). SMT permits multiple independent threads of execution,
-                          to better use the resources and increase the efficiency
-                          of the CPU. When multithreading is disabled, only one thread
-                          is permitted to run on each core, which can provide higher
-                          or more predictable performance for some workloads.
+                        description: |-
+                          Whether symmetric multithreading is enabled on the instance. Symmetric multithreading is also
+                          called simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                          Intel and AMD processors have two hardware execution threads per core (OCPU). SMT permits multiple
+                          independent threads of execution, to better use the resources and increase the efficiency
+                          of the CPU. When multithreading is disabled, only one thread is permitted to run on each core, which
+                          can provide higher or more predictable performance for some workloads.
                         type: boolean
                       isTrustedPlatformModuleEnabled:
                         description: Whether the Trusted Platform Module (TPM) is
                           enabled on the instance.
                         type: boolean
                       numaNodesPerSocket:
-                        description: 'The number of NUMA nodes per socket (NPS). The
-                          following values are supported: * `NPS1` * `NPS2`'
+                        description: |-
+                          The number of NUMA nodes per socket (NPS).
+                          The following values are supported:
+                          * `NPS1`
+                          * `NPS2`
                         type: string
                       percentageOfCoresEnabled:
-                        description: The percentage of cores enabled. Value must be
-                          a multiple of 25%. If the requested percentage results in
-                          a fractional number of cores, the system rounds up the number
-                          of cores across processors and provisions an instance with
-                          a whole number of cores. If the applications that you run
-                          on the instance use a core-based licensing model and need
-                          fewer cores than the full size of the shape, you can disable
-                          cores to reduce your licensing costs. The instance itself
-                          is billed for the full shape, regardless of whether all
-                          cores are enabled.
+                        description: |-
+                          The percentage of cores enabled. Value must be a multiple of 25%. If the requested percentage
+                          results in a fractional number of cores, the system rounds up the number of cores across processors
+                          and provisions an instance with a whole number of cores.
+                          If the applications that you run on the instance use a core-based licensing model and need fewer cores
+                          than the full size of the shape, you can disable cores to reduce your licensing costs. The instance
+                          itself is billed for the full shape, regardless of whether all cores are enabled.
                         type: integer
                     type: object
                   intelSkylakeBmPlatformConfig:
@@ -1698,11 +1755,16 @@ spec:
                         type: boolean
                     type: object
                   platformConfigType:
-                    description: The type of platform configuration. Valid values
-                      are * `AMD_ROME_BM_GPU` * `AMD_ROME_BM` * `INTEL_ICELAKE_BM`
-                      * `AMD_VM` * `INTEL_VM` * `INTEL_SKYLAKE_BM` * `AMD_MILAN_BM`
-                      Based on the enum, exactly one of the specific configuration
-                      types must be set
+                    description: |-
+                      The type of platform configuration. Valid values are
+                      * `AMD_ROME_BM_GPU`
+                      * `AMD_ROME_BM`
+                      * `INTEL_ICELAKE_BM`
+                      * `AMD_VM`
+                      * `INTEL_VM`
+                      * `INTEL_SKYLAKE_BM`
+                      * `AMD_MILAN_BM`
+                      Based on the enum, exactly one of the specific configuration types must be set
                     type: string
                 type: object
               preemptibleInstanceConfig:
@@ -1722,18 +1784,19 @@ spec:
                     type: object
                 type: object
               preserveBootVolume:
-                description: Specifies whether to delete or preserve the boot volume
-                  when terminating an instance. When set to true, the boot volume
-                  is preserved. The default value is false.
+                description: |-
+                  Specifies whether to delete or preserve the boot volume when terminating an instance.
+                  When set to true, the boot volume is preserved. The default value is false.
                 type: boolean
               preserveDataVolumesCreatedAtLaunch:
-                description: Specifies whether to delete or preserve the data volumes
-                  created during launch when terminating an instance. When set to
-                  true, the data volumes are preserved. The default value is true.
+                description: |-
+                  Specifies whether to delete or preserve the data volumes created during launch when
+                  terminating an instance. When set to true, the data volumes are preserved. The default value is true.
                 type: boolean
               providerID:
-                description: Provider ID of the instance, this will be set by Cluster
-                  API provider itself, users should not set this parameter.
+                description: |-
+                  Provider ID of the instance, this will be set by Cluster API provider itself,
+                  users should not set this parameter.
                 type: string
               shape:
                 description: Shape of the instance.
@@ -1743,13 +1806,13 @@ spec:
                   flex instances.
                 properties:
                   baselineOcpuUtilization:
-                    description: 'The baseline OCPU utilization for a subcore burstable
-                      VM instance. Leave this attribute blank for a non-burstable
-                      instance, or explicitly specify non-burstable with `BASELINE_1_1`.
-                      The following values are supported: - `BASELINE_1_8` - baseline
-                      usage is 1/8 of an OCPU. - `BASELINE_1_2` - baseline usage is
-                      1/2 of an OCPU. - `BASELINE_1_1` - baseline usage is an entire
-                      OCPU. This represents a non-burstable instance.'
+                    description: |-
+                      The baseline OCPU utilization for a subcore burstable VM instance. Leave this attribute blank for a
+                      non-burstable instance, or explicitly specify non-burstable with `BASELINE_1_1`.
+                      The following values are supported:
+                      - `BASELINE_1_8` - baseline usage is 1/8 of an OCPU.
+                      - `BASELINE_1_2` - baseline usage is 1/2 of an OCPU.
+                      - `BASELINE_1_1` - baseline usage is an entire OCPU. This represents a non-burstable instance.
                     type: string
                   memoryInGBs:
                     description: The total amount of memory available to the instance,
@@ -1764,36 +1827,36 @@ spec:
                     type: string
                 type: object
               subnetName:
-                description: The name of the subnet to use. The name here refers to
-                  the subnets defined in the OCICluster Spec. Optional, only if multiple
-                  subnets of a type is defined, else the first element is used.
+                description: |-
+                  The name of the subnet to use. The name here refers to the subnets
+                  defined in the OCICluster Spec. Optional, only if multiple subnets of a type
+                  is defined, else the first element is used.
                 type: string
               vnicAttachments:
-                description: VnicAttachments defines the configuration options for
-                  the vnic(s) attached to the machine The network bandwidth and number
-                  of VNICs scale proportionately with the number of OCPUs.
+                description: |-
+                  VnicAttachments defines the configuration options for the vnic(s) attached to the machine
+                  The network bandwidth and number of VNICs scale proportionately with the number of OCPUs.
                 items:
                   properties:
-                    assignIpv6Ip:
-                      description: assignIpv6Ip defines whether the VNIC should
-                        be assigned a IPv6.
-                      type: boolean
                     assignPublicIp:
                       description: AssignPublicIp defines whether the vnic should
                         have a public IP address
                       type: boolean
                     displayName:
-                      description: DisplayName defines a user-friendly name. Does
-                        not have to be unique. Avoid entering confidential information.
+                      description: |-
+                        DisplayName defines a user-friendly name. Does not have to be unique.
+                        Avoid entering confidential information.
                       type: string
                     nicIndex:
-                      description: NicIndex defines which physical Network Interface
-                        Card (NIC) to use You can determine which NICs are active
-                        for a shape by reviewing the https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm
+                      description: |-
+                        NicIndex defines which physical Network Interface Card (NIC) to use
+                        You can determine which NICs are active for a shape by reviewing the
+                        https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm
                       type: integer
                     subnetName:
-                      description: SubnetName defines the subnet name to use for the
-                        VNIC Defaults to the "worker" subnet if not provided
+                      description: |-
+                        SubnetName defines the subnet name to use for the VNIC
+                        Defaults to the "worker" subnet if not provided
                       type: string
                     vnicAttachmentId:
                       description: VnicAttachmentId defines the ID of the VnicAttachment
@@ -1814,11 +1877,19 @@ spec:
                     address.
                   properties:
                     address:
-                      description: The machine address.
+                      description: address is the machine address.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     type:
-                      description: Machine address type, one of Hostname, ExternalIP,
-                        InternalIP, ExternalDNS or InternalDNS.
+                      description: type is the machine address type, one of Hostname,
+                        ExternalIP, InternalIP, ExternalDNS or InternalDNS.
+                      enum:
+                      - Hostname
+                      - ExternalIP
+                      - InternalIP
+                      - ExternalDNS
+                      - InternalDNS
                       type: string
                   required:
                   - address
@@ -1832,37 +1903,44 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
+                      description: status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimachinetemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: ocimachinetemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -23,14 +23,19 @@ spec:
           machine template.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -50,43 +55,41 @@ spec:
                           Cloud Agent software running on the instance.
                         properties:
                           areAllPluginsDisabled:
-                            description: AreAllPluginsDisabled defines whether Oracle
-                              Cloud Agent can run all the available plugins. This
-                              includes the management and monitoring plugins. To get
-                              a list of available plugins, use the ListInstanceagentAvailablePlugins
-                              operation in the Oracle Cloud Agent API. For more information
-                              about the available plugins, see Managing Plugins with
-                              Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
+                            description: |-
+                              AreAllPluginsDisabled defines whether Oracle Cloud Agent can run all the available plugins.
+                              This includes the management and monitoring plugins.
+                              To get a list of available plugins, use the
+                              ListInstanceagentAvailablePlugins
+                              operation in the Oracle Cloud Agent API. For more information about the available plugins, see
+                              Managing Plugins with Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
                             type: boolean
                           isManagementDisabled:
-                            description: 'IsManagementDisabled defines whether Oracle
-                              Cloud Agent can run all the available management plugins.
+                            description: |-
+                              IsManagementDisabled defines whether Oracle Cloud Agent can run all the available management plugins.
                               Default value is false (management plugins are enabled).
-                              These are the management plugins: OS Management Service
-                              Agent and Compute Instance Run Command. The management
-                              plugins are controlled by this parameter and by the
-                              per-plugin configuration in the `pluginsConfig` object.
-                              - If `isManagementDisabled` is true, all of the management
-                              plugins are disabled, regardless of the per-plugin configuration.
-                              - If `isManagementDisabled` is false, all of the management
-                              plugins are enabled. You can optionally disable individual
-                              management plugins by providing a value in the `pluginsConfig`
-                              object.'
+                              These are the management plugins: OS Management Service Agent and Compute Instance
+                              Run Command.
+                              The management plugins are controlled by this parameter and by the per-plugin
+                              configuration in the `pluginsConfig` object.
+                              - If `isManagementDisabled` is true, all of the management plugins are disabled, regardless of
+                              the per-plugin configuration.
+                              - If `isManagementDisabled` is false, all of the management plugins are enabled. You
+                              can optionally disable individual management plugins by providing a value in the `pluginsConfig`
+                              object.
                             type: boolean
                           isMonitoringDisabled:
-                            description: 'IsMonitoringDisabled defines whether Oracle
-                              Cloud Agent can gather performance metrics and monitor
-                              the instance using the monitoring plugins. Default value
-                              is false (monitoring plugins are enabled). These are
-                              the monitoring plugins: Compute Instance Monitoring
-                              and Custom Logs Monitoring. The monitoring plugins are
-                              controlled by this parameter and by the per-plugin configuration
-                              in the `pluginsConfig` object. - If `isMonitoringDisabled`
-                              is true, all of the monitoring plugins are disabled,
-                              regardless of the per-plugin configuration. - If `isMonitoringDisabled`
-                              is false, all of the monitoring plugins are enabled.
-                              You can optionally disable individual monitoring plugins
-                              by providing a value in the `pluginsConfig` object.'
+                            description: |-
+                              IsMonitoringDisabled defines whether Oracle Cloud Agent can gather performance metrics and monitor the instance using the
+                              monitoring plugins. Default value is false (monitoring plugins are enabled).
+                              These are the monitoring plugins: Compute Instance Monitoring
+                              and Custom Logs Monitoring.
+                              The monitoring plugins are controlled by this parameter and by the per-plugin
+                              configuration in the `pluginsConfig` object.
+                              - If `isMonitoringDisabled` is true, all of the monitoring plugins are disabled, regardless of
+                              the per-plugin configuration.
+                              - If `isMonitoringDisabled` is false, all of the monitoring plugins are enabled. You
+                              can optionally disable individual monitoring plugins by providing a value in the `pluginsConfig`
+                              object.
                             type: boolean
                           pluginsConfigs:
                             description: PluginsConfig defines the configuration of
@@ -96,67 +99,61 @@ spec:
                                 of plugins associated with this instance.
                               properties:
                                 desiredState:
-                                  description: 'DesiredState defines whether the plugin
-                                    should be enabled or disabled. To enable the monitoring
-                                    and management plugins, the `isMonitoringDisabled`
-                                    and `isManagementDisabled` attributes must also
-                                    be set to false. The following values are supported:
-                                    * `ENABLED` * `DISABLED`'
+                                  description: |-
+                                    DesiredState defines whether the plugin should be enabled or disabled.
+                                    To enable the monitoring and management plugins, the `isMonitoringDisabled` and
+                                    `isManagementDisabled` attributes must also be set to false.
+                                    The following values are supported:
+                                    * `ENABLED`
+                                    * `DISABLED`
                                   type: string
                                 name:
-                                  description: Name defines the name of the plugin.
-                                    To get a list of available plugins, use the ListInstanceagentAvailablePlugins
-                                    operation in the Oracle Cloud Agent API. For more
-                                    information about the available plugins, see Managing
-                                    Plugins with Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
+                                  description: |-
+                                    Name defines the name of the plugin. To get a list of available plugins, use the
+                                    ListInstanceagentAvailablePlugins
+                                    operation in the Oracle Cloud Agent API. For more information about the available plugins, see
+                                    Managing Plugins with Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
                                   type: string
                               type: object
                             type: array
                         type: object
                       availabilityConfig:
-                        description: LaunchInstanceAvailabilityConfig defines the
-                          options for VM migration during infrastructure maintenance
-                          events and for defining the availability of a VM instance
-                          after a maintenance event that impacts the underlying hardware.
+                        description: |-
+                          LaunchInstanceAvailabilityConfig defines the options for VM migration during infrastructure maintenance events and for defining
+                          the availability of a VM instance after a maintenance event that impacts the underlying hardware.
                         properties:
                           isLiveMigrationPreferred:
-                            description: IsLiveMigrationPreferred defines whether
-                              to live migrate supported VM instances to a healthy
-                              physical VM host without disrupting running instances
-                              during infrastructure maintenance events. If null, Oracle
-                              chooses the best option for migrating the VM during
-                              infrastructure maintenance events.
+                            description: |-
+                              IsLiveMigrationPreferred defines whether to live migrate supported VM instances to a healthy physical VM host without
+                              disrupting running instances during infrastructure maintenance events. If null, Oracle
+                              chooses the best option for migrating the VM during infrastructure maintenance events.
                             type: boolean
                           recoveryAction:
-                            description: RecoveryAction defines the lifecycle state
-                              for an instance when it is recovered after infrastructure
-                              maintenance. * `RESTORE_INSTANCE` - The instance is
-                              restored to the lifecycle state it was in before the
-                              maintenance event. If the instance was running, it is
-                              automatically rebooted. This is the default action when
-                              a value is not set. * `STOP_INSTANCE` - The instance
-                              is recovered in the stopped state.
+                            description: |-
+                              RecoveryAction defines the lifecycle state for an instance when it is recovered after infrastructure maintenance.
+                              * `RESTORE_INSTANCE` - The instance is restored to the lifecycle state it was in before the maintenance event.
+                              If the instance was running, it is automatically rebooted. This is the default action when a value is not set.
+                              * `STOP_INSTANCE` - The instance is recovered in the stopped state.
                             type: string
                         type: object
                       bootVolumeSizeInGBs:
-                        description: The size of boot volume. Please see https://docs.oracle.com/en-us/iaas/Content/Block/Tasks/extendingbootpartition.htm
+                        description: |-
+                          The size of boot volume. Please see https://docs.oracle.com/en-us/iaas/Content/Block/Tasks/extendingbootpartition.htm
                           to extend the boot volume size.
                         type: string
                       capacityReservationId:
-                        description: CapacityReservationId defines the OCID of the
-                          compute capacity reservation this instance is launched under.
-                          You can opt out of all default reservations by specifying
-                          an empty string as input for this field. For more information,
-                          see Capacity Reservations (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/reserve-capacity.htm#default).
+                        description: |-
+                          CapacityReservationId defines the OCID of the compute capacity reservation this instance is launched under.
+                          You can opt out of all default reservations by specifying an empty string as input for this field.
+                          For more information, see Capacity Reservations (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/reserve-capacity.htm#default).
                         type: string
                       compartmentId:
                         description: Compartment to launch the instance in.
                         type: string
                       computeClusterId:
-                        description: ComputeClusterId refers to OCID of the compute
-                          cluster that the instance will be created in. Please refer
-                          https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/compute-clusters.htm
-                          for more details
+                        description: |-
+                          ComputeClusterId refers to OCID of the compute cluster that the instance will be created in.
+                          Please refer https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/compute-clusters.htm for more details
                         type: string
                       dedicatedVmHostId:
                         description: DedicatedVmHostId defines the OCID of the dedicated
@@ -167,10 +164,10 @@ spec:
                           additionalProperties:
                             type: string
                           type: object
-                        description: 'Defined tags for this resource. Each key is
-                          predefined and scoped to a namespace. For more information,
-                          see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
-                          Example: `{"Operations": {"CostCenter": "42"}}`'
+                        description: |-
+                          Defined tags for this resource. Each key is predefined and scoped to a
+                          namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+                          Example: `{"Operations": {"CostCenter": "42"}}`
                         type: object
                       freeformTags:
                         additionalProperties:
@@ -187,10 +184,10 @@ spec:
                         description: InstanceOptions defines the instance options
                         properties:
                           areLegacyImdsEndpointsDisabled:
-                            description: Whether to disable the legacy (/v1) instance
-                              metadata service endpoints. Customers who have migrated
-                              to /v2 should set this to true for added security. Default
-                              is false.
+                            description: |-
+                              Whether to disable the legacy (/v1) instance metadata service endpoints.
+                              Customers who have migrated to /v2 should set this to true for added security.
+                              Default is false.
                             type: boolean
                         type: object
                       instanceSourceViaImageConfig:
@@ -198,17 +195,15 @@ spec:
                           for booting up instances via images
                         properties:
                           bootVolumeVpusPerGB:
-                            description: 'BootVolumeVpusPerGB defines the number of
-                              volume performance units (VPUs) that will be applied
-                              to this volume per GB, representing the Block Volume
-                              service''s elastic performance options. See Block Volume
-                              Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels)
-                              for more information. Allowed values: * `10`: Represents
-                              Balanced option. * `20`: Represents Higher Performance
-                              option. * `30`-`120`: Represents the Ultra High Performance
-                              option. For volumes with the auto-tuned performance
-                              feature enabled, this is set to the default (minimum)
-                              VPUs/GB.'
+                            description: |-
+                              BootVolumeVpusPerGB defines the number of volume performance units (VPUs) that will be applied to this volume per GB,
+                              representing the Block Volume service's elastic performance options.
+                              See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels) for more information.
+                              Allowed values:
+                                * `10`: Represents Balanced option.
+                                * `20`: Represents Higher Performance option.
+                                * `30`-`120`: Represents the Ultra High Performance option.
+                              For volumes with the auto-tuned performance feature enabled, this is set to the default (minimum) VPUs/GB.
                             format: int64
                             type: integer
                           kmsKeyId:
@@ -229,24 +224,23 @@ spec:
                           the compatibility and performance of VM shapes
                         properties:
                           bootVolumeType:
-                            description: BootVolumeType defines Emulation type for
-                              the boot volume. * `ISCSI` - ISCSI attached block storage
-                              device. * `SCSI` - Emulated SCSI disk. * `IDE` - Emulated
-                              IDE disk. * `VFIO` - Direct attached Virtual Function
-                              storage. This is the default option for local data volumes
-                              on platform images. * `PARAVIRTUALIZED` - Paravirtualized
-                              disk. This is the default for boot volumes and remote
-                              block storage volumes on platform images.
+                            description: |-
+                              BootVolumeType defines Emulation type for the boot volume.
+                              * `ISCSI` - ISCSI attached block storage device.
+                              * `SCSI` - Emulated SCSI disk.
+                              * `IDE` - Emulated IDE disk.
+                              * `VFIO` - Direct attached Virtual Function storage. This is the default option for local data
+                              volumes on platform images.
+                              * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+                              storage volumes on platform images.
                             type: string
                           firmware:
-                            description: Firmware defines the firmware used to boot
-                              VM. Select the option that matches your operating system.
-                              * `BIOS` - Boot VM using BIOS style firmware. This is
-                              compatible with both 32 bit and 64 bit operating systems
-                              that boot using MBR style bootloaders. * `UEFI_64` -
-                              Boot VM using UEFI style firmware compatible with 64
-                              bit operating systems. This is the default for platform
-                              images.
+                            description: |-
+                              Firmware defines the firmware used to boot VM. Select the option that matches your operating system.
+                              * `BIOS` - Boot VM using BIOS style firmware. This is compatible with both 32 bit and 64 bit operating
+                              systems that boot using MBR style bootloaders.
+                              * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems. This is the
+                              default for platform images.
                             type: string
                           isConsistentVolumeNamingEnabled:
                             description: IsConsistentVolumeNamingEnabled defines whether
@@ -254,24 +248,23 @@ spec:
                               to false.
                             type: boolean
                           networkType:
-                            description: NetworkType defines the emulation type for
-                              the physical network interface card (NIC). * `E1000`
-                              - Emulated Gigabit ethernet controller. Compatible with
-                              Linux e1000 network driver. * `VFIO` - Direct attached
-                              Virtual Function network controller. This is the networking
-                              type when you launch an instance using hardware-assisted
-                              (SR-IOV) networking. * `PARAVIRTUALIZED` - VM instances
-                              launch with paravirtualized devices using VirtIO drivers.
+                            description: |-
+                              NetworkType defines the emulation type for the physical network interface card (NIC).
+                              * `E1000` - Emulated Gigabit ethernet controller. Compatible with Linux e1000 network driver.
+                              * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
+                              when you launch an instance using hardware-assisted (SR-IOV) networking.
+                              * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
                             type: string
                           remoteDataVolumeType:
-                            description: RemoteDataVolumeType defines the emulation
-                              type for volume. * `ISCSI` - ISCSI attached block storage
-                              device. * `SCSI` - Emulated SCSI disk. * `IDE` - Emulated
-                              IDE disk. * `VFIO` - Direct attached Virtual Function
-                              storage. This is the default option for local data volumes
-                              on platform images. * `PARAVIRTUALIZED` - Paravirtualized
-                              disk. This is the default for boot volumes and remote
-                              block storage volumes on platform images.
+                            description: |-
+                              RemoteDataVolumeType defines the emulation type for volume.
+                              * `ISCSI` - ISCSI attached block storage device.
+                              * `SCSI` - Emulated SCSI disk.
+                              * `IDE` - Emulated IDE disk.
+                              * `VFIO` - Direct attached Virtual Function storage. This is the default option for local data
+                              volumes on platform images.
+                              * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+                              storage volumes on platform images.
                             type: string
                         type: object
                       launchVolumeAttachments:
@@ -287,12 +280,13 @@ spec:
                                     of devices for a given instance, see ListInstanceDevices.
                                   type: string
                                 displayName:
-                                  description: A user-friendly name. Does not have
-                                    to be unique, and it's changeable. Avoid entering
-                                    confidential information.
+                                  description: |-
+                                    A user-friendly name. Does not have to be unique, and it's changeable.
+                                    Avoid entering confidential information.
                                   type: string
                                 encryptionInTransitType:
-                                  description: Refer the top-level definition of encryptionInTransitType.
+                                  description: |-
+                                    Refer the top-level definition of encryptionInTransitType.
                                     The default value is NONE.
                                   type: string
                                 isAgentAutoIscsiLoginEnabled:
@@ -306,13 +300,11 @@ spec:
                                     in read-only mode.
                                   type: boolean
                                 isShareable:
-                                  description: Whether the attachment should be created
-                                    in shareable mode. If an attachment is created
-                                    in shareable mode, then other instances can attach
-                                    the same volume, provided that they also create
-                                    their attachments in shareable mode. Only certain
-                                    volume types can be attached in shareable mode.
-                                    Defaults to false if not specified.
+                                  description: |-
+                                    Whether the attachment should be created in shareable mode. If an attachment
+                                    is created in shareable mode, then other instances can attach the same volume, provided
+                                    that they also create their attachments in shareable mode. Only certain volume types can
+                                    be attached in shareable mode. Defaults to false if not specified.
                                   type: boolean
                                 launchCreateVolumeFromAttributes:
                                   description: LaunchCreateVolumeFromAttributes The
@@ -320,35 +312,34 @@ spec:
                                     operation.
                                   properties:
                                     compartmentId:
-                                      description: The OCID of the compartment that
-                                        contains the volume. If not provided, it will
-                                        be inherited from the instance.
+                                      description: |-
+                                        The OCID of the compartment that contains the volume. If not provided,
+                                        it will be inherited from the instance.
                                       type: string
                                     displayName:
-                                      description: A user-friendly name. Does not
-                                        have to be unique, and it's changeable. Avoid
-                                        entering confidential information.
+                                      description: |-
+                                        A user-friendly name. Does not have to be unique, and it's changeable.
+                                        Avoid entering confidential information.
                                       type: string
                                     kmsKeyId:
-                                      description: The OCID of the Vault service key
-                                        to assign as the master encryption key for
-                                        the volume.
+                                      description: |-
+                                        The OCID of the Vault service key to assign as the master encryption key
+                                        for the volume.
                                       type: string
                                     sizeInGBs:
                                       description: The size of the volume in GBs.
                                       format: int64
                                       type: integer
                                     vpusPerGB:
-                                      description: 'The number of volume performance
-                                        units (VPUs) that will be applied to this
-                                        volume per GB, representing the Block Volume
-                                        service''s elastic performance options. See
-                                        Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels)
-                                        for more information. Allowed values: * `0`:
-                                        Represents Lower Cost option. * `10`: Represents
-                                        Balanced option. * `20`: Represents Higher
-                                        Performance option. * `30`-`120`: Represents
-                                        the Ultra High Performance option.'
+                                      description: |-
+                                        The number of volume performance units (VPUs) that will be applied to this volume per GB,
+                                        representing the Block Volume service's elastic performance options.
+                                        See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels) for more information.
+                                        Allowed values:
+                                          * `0`: Represents Lower Cost option.
+                                          * `10`: Represents Balanced option.
+                                          * `20`: Represents Higher Performance option.
+                                          * `30`-`120`: Represents the Ultra High Performance option.
                                       format: int64
                                       type: integer
                                   type: object
@@ -363,69 +354,76 @@ spec:
                                   type: string
                               type: object
                             launchParavirtualizedVolumeAttachment:
-                              description: The details of paravirtualized volume attachment.
+                              description: LaunchParavirtualizedVolumeAttachment specifies
+                                the paravirtualized volume attachments to create as
+                                part of the launch instance operation.
                               properties:
                                 device:
-                                  description: The device name. To retrieve a list of devices
-                                    for a given instance, see ListInstanceDevices.
+                                  description: The device name. To retrieve a list
+                                    of devices for a given instance, see ListInstanceDevices.
                                   type: string
                                 displayName:
-                                  description: A user-friendly name. Does not have to be unique,
-                                    and it's changeable. Avoid entering confidential information.
+                                  description: |-
+                                    A user-friendly name. Does not have to be unique, and it's changeable.
+                                    Avoid entering confidential information.
                                   type: string
                                 isPvEncryptionInTransitEnabled:
-                                  description: Refer the top-level definition of isPvEncryptionInTransitEnabled.
+                                  description: |-
+                                    Refer the top-level definition of isPvEncryptionInTransitEnabled.
                                     The default value is False.
                                   type: boolean
                                 isReadOnly:
-                                  description: Whether the attachment was created in read-only
-                                    mode.
+                                  description: Whether the attachment was created
+                                    in read-only mode.
                                   type: boolean
                                 isShareable:
-                                  description: Whether the attachment should be created in
-                                    shareable mode. If an attachment is created in shareable
-                                    mode, then other instances can attach the same volume,
-                                    provided that they also create their attachments in shareable
-                                    mode. Only certain volume types can be attached in shareable
-                                    mode. Defaults to false if not specified.
+                                  description: |-
+                                    Whether the attachment should be created in shareable mode. If an attachment
+                                    is created in shareable mode, then other instances can attach the same volume, provided
+                                    that they also create their attachments in shareable mode. Only certain volume types can
+                                    be attached in shareable mode. Defaults to false if not specified.
                                   type: boolean
                                 launchCreateVolumeFromAttributes:
-                                  description: LaunchCreateVolumeFromAttributes The details
-                                    of the volume to create for CreateVolume operation.
+                                  description: LaunchCreateVolumeFromAttributes The
+                                    details of the volume to create for CreateVolume
+                                    operation.
                                   properties:
                                     compartmentId:
-                                      description: The OCID of the compartment that contains
-                                        the volume. If not provided, it will be inherited
-                                        from the instance.
+                                      description: |-
+                                        The OCID of the compartment that contains the volume. If not provided,
+                                        it will be inherited from the instance.
                                       type: string
                                     displayName:
-                                      description: A user-friendly name. Does not have to
-                                        be unique, and it's changeable. Avoid entering confidential
-                                        information.
+                                      description: |-
+                                        A user-friendly name. Does not have to be unique, and it's changeable.
+                                        Avoid entering confidential information.
                                       type: string
                                     kmsKeyId:
-                                      description: The OCID of the Vault service key to assign
-                                        as the master encryption key for the volume.
+                                      description: |-
+                                        The OCID of the Vault service key to assign as the master encryption key
+                                        for the volume.
                                       type: string
                                     sizeInGBs:
                                       description: The size of the volume in GBs.
                                       format: int64
                                       type: integer
                                     vpusPerGB:
-                                      description: 'The number of volume performance units
-                                        (VPUs) that will be applied to this volume per GB,
-                                        representing the Block Volume service''s elastic performance
-                                        options. See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels)
-                                        for more information. Allowed values: * `0`: Represents
-                                        Lower Cost option. * `10`: Represents Balanced option.
-                                        * `20`: Represents Higher Performance option. * `30`-`120`:
-                                        Represents the Ultra High Performance option.'
+                                      description: |-
+                                        The number of volume performance units (VPUs) that will be applied to this volume per GB,
+                                        representing the Block Volume service's elastic performance options.
+                                        See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels) for more information.
+                                        Allowed values:
+                                          * `0`: Represents Lower Cost option.
+                                          * `10`: Represents Balanced option.
+                                          * `20`: Represents Higher Performance option.
+                                          * `30`-`120`: Represents the Ultra High Performance option.
                                       format: int64
                                       type: integer
                                   type: object
                                 volumeId:
                                   description: The OCID of the volume. If CreateVolumeDetails
-                                    is specified, this field must be omitted from the request.
+                                    is specified, this field must be omitted from
+                                    the request.
                                   type: string
                               type: object
                             volumeType:
@@ -436,38 +434,39 @@ spec:
                       metadata:
                         additionalProperties:
                           type: string
-                        description: Custom metadata key/value pairs that you provide,
-                          such as the SSH public key required to connect to the instance.
+                        description: |-
+                          Custom metadata key/value pairs that you provide, such as the SSH public key
+                          required to connect to the instance.
                         type: object
                       networkDetails:
                         description: NetworkDetails defines the configuration options
                           for the network
                         properties:
+                          assignIpv6Ip:
+                            description: IPv6 defines if the instance should have
+                              an IPv6
+                            type: boolean
                           assignPrivateDnsRecord:
                             description: AssignPrivateDnsRecord defines whether the
                               VNIC should be assigned a DNS record.
-                            type: boolean
-                          assignIpv6Ip:
-                            description: assignIpv6Ip defines whether the VNIC should
-                              be assigned a IPv6.
                             type: boolean
                           assignPublicIp:
                             description: AssignPublicIp defines whether the instance
                               should have a public IP address
                             type: boolean
                           displayName:
-                            description: DisplayName defines a user-friendly name.
-                              Does not have to be unique, and it's changeable. Avoid
-                              entering confidential information.
+                            description: |-
+                              DisplayName defines a user-friendly name. Does not have to be unique, and it's changeable.
+                              Avoid entering confidential information.
                             type: string
                           hostnameLabel:
                             description: HostnameLabel defines the hostname for the
                               VNIC's primary private IP. Used for DNS.
                             type: string
                           nsgId:
-                            description: NSGId defines the ID of the NSG to use. This
-                              parameter takes priority over NsgNames. Deprecated,
-                              please use NetworkDetails.NSGIds
+                            description: |-
+                              NSGId defines the ID of the NSG to use. This parameter takes priority over NsgNames.
+                              Deprecated, please use NetworkDetails.NSGIds
                             type: string
                           nsgIds:
                             description: NSGIds defines the list of NSG IDs to use.
@@ -496,10 +495,11 @@ spec:
                             type: string
                         type: object
                       nsgName:
-                        description: The name of NSG to use. The name here refers
-                          to the NSGs defined in the OCICluster Spec. Optional, only
-                          if multiple NSGs of a type is defined, else the first element
-                          is used. Deprecated, please use NetworkDetails.NSGNames
+                        description: |-
+                          The name of NSG to use. The name here refers to the NSGs
+                          defined in the OCICluster Spec. Optional, only if multiple NSGs of a type
+                          is defined, else the first element is used.
+                          Deprecated, please use NetworkDetails.NSGNames
                         type: string
                       platformConfig:
                         description: PlatformConfig defines the platform config parameters
@@ -509,15 +509,14 @@ spec:
                               BM platform configuration
                             properties:
                               areVirtualInstructionsEnabled:
-                                description: Whether virtualization instructions are
-                                  available. For example, Secure Virtual Machine for
-                                  AMD shapes or VT-x for Intel shapes.
+                                description: |-
+                                  Whether virtualization instructions are available. For example, Secure Virtual Machine for AMD shapes
+                                  or VT-x for Intel shapes.
                                 type: boolean
                               isAccessControlServiceEnabled:
-                                description: Whether the Access Control Service is
-                                  enabled on the instance. When enabled, the platform
-                                  can enforce PCIe device isolation, required for
-                                  VFIO device pass-through.
+                                description: |-
+                                  Whether the Access Control Service is enabled on the instance. When enabled,
+                                  the platform can enforce PCIe device isolation, required for VFIO device pass-through.
                                 type: boolean
                               isInputOutputMemoryManagementUnitEnabled:
                                 description: Whether the input-output memory management
@@ -538,39 +537,35 @@ spec:
                                   instance.
                                 type: boolean
                               isSymmetricMultiThreadingEnabled:
-                                description: Whether symmetric multithreading is enabled
-                                  on the instance. Symmetric multithreading is also
-                                  called simultaneous multithreading (SMT) or Intel
-                                  Hyper-Threading. Intel and AMD processors have two
-                                  hardware execution threads per core (OCPU). SMT
-                                  permits multiple independent threads of execution,
-                                  to better use the resources and increase the efficiency
-                                  of the CPU. When multithreading is disabled, only
-                                  one thread is permitted to run on each core, which
-                                  can provide higher or more predictable performance
-                                  for some workloads.
+                                description: |-
+                                  Whether symmetric multithreading is enabled on the instance. Symmetric multithreading is also
+                                  called simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                                  Intel and AMD processors have two hardware execution threads per core (OCPU). SMT permits multiple
+                                  independent threads of execution, to better use the resources and increase the efficiency
+                                  of the CPU. When multithreading is disabled, only one thread is permitted to run on each core, which
+                                  can provide higher or more predictable performance for some workloads.
                                 type: boolean
                               isTrustedPlatformModuleEnabled:
                                 description: Whether the Trusted Platform Module (TPM)
                                   is enabled on the instance.
                                 type: boolean
                               numaNodesPerSocket:
-                                description: 'The number of NUMA nodes per socket
-                                  (NPS). The following values are supported: * `NPS0`
-                                  * `NPS1` * `NPS2` * `NPS4`'
+                                description: |-
+                                  The number of NUMA nodes per socket (NPS).
+                                  The following values are supported:
+                                  * `NPS0`
+                                  * `NPS1`
+                                  * `NPS2`
+                                  * `NPS4`
                                 type: string
                               percentageOfCoresEnabled:
-                                description: The percentage of cores enabled. Value
-                                  must be a multiple of 25%. If the requested percentage
-                                  results in a fractional number of cores, the system
-                                  rounds up the number of cores across processors
-                                  and provisions an instance with a whole number of
-                                  cores. If the applications that you run on the instance
-                                  use a core-based licensing model and need fewer
-                                  cores than the full size of the shape, you can disable
-                                  cores to reduce your licensing costs. The instance
-                                  itself is billed for the full shape, regardless
-                                  of whether all cores are enabled.
+                                description: |-
+                                  The percentage of cores enabled. Value must be a multiple of 25%. If the requested percentage
+                                  results in a fractional number of cores, the system rounds up the number of cores across processors
+                                  and provisions an instance with a whole number of cores.
+                                  If the applications that you run on the instance use a core-based licensing model and need fewer cores
+                                  than the full size of the shape, you can disable cores to reduce your licensing costs. The instance
+                                  itself is billed for the full shape, regardless of whether all cores are enabled.
                                 type: integer
                             type: object
                           amdRomeBmGpuPlatformConfig:
@@ -578,15 +573,14 @@ spec:
                               BM platform configuration
                             properties:
                               areVirtualInstructionsEnabled:
-                                description: Whether virtualization instructions are
-                                  available. For example, Secure Virtual Machine for
-                                  AMD shapes or VT-x for Intel shapes.
+                                description: |-
+                                  Whether virtualization instructions are available. For example, Secure Virtual Machine for AMD shapes
+                                  or VT-x for Intel shapes.
                                 type: boolean
                               isAccessControlServiceEnabled:
-                                description: Whether the Access Control Service is
-                                  enabled on the instance. When enabled, the platform
-                                  can enforce PCIe device isolation, required for
-                                  VFIO device pass-through.
+                                description: |-
+                                  Whether the Access Control Service is enabled on the instance. When enabled,
+                                  the platform can enforce PCIe device isolation, required for VFIO device pass-through.
                                 type: boolean
                               isInputOutputMemoryManagementUnitEnabled:
                                 description: Whether the input-output memory management
@@ -607,26 +601,26 @@ spec:
                                   instance.
                                 type: boolean
                               isSymmetricMultiThreadingEnabled:
-                                description: Whether symmetric multithreading is enabled
-                                  on the instance. Symmetric multithreading is also
-                                  called simultaneous multithreading (SMT) or Intel
-                                  Hyper-Threading. Intel and AMD processors have two
-                                  hardware execution threads per core (OCPU). SMT
-                                  permits multiple independent threads of execution,
-                                  to better use the resources and increase the efficiency
-                                  of the CPU. When multithreading is disabled, only
-                                  one thread is permitted to run on each core, which
-                                  can provide higher or more predictable performance
-                                  for some workloads.
+                                description: |-
+                                  Whether symmetric multithreading is enabled on the instance. Symmetric multithreading is also
+                                  called simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                                  Intel and AMD processors have two hardware execution threads per core (OCPU). SMT permits multiple
+                                  independent threads of execution, to better use the resources and increase the efficiency
+                                  of the CPU. When multithreading is disabled, only one thread is permitted to run on each core, which
+                                  can provide higher or more predictable performance for some workloads.
                                 type: boolean
                               isTrustedPlatformModuleEnabled:
                                 description: Whether the Trusted Platform Module (TPM)
                                   is enabled on the instance.
                                 type: boolean
                               numaNodesPerSocket:
-                                description: 'The number of NUMA nodes per socket
-                                  (NPS). The following values are supported: * `NPS0`
-                                  * `NPS1` * `NPS2` * `NPS4`'
+                                description: |-
+                                  The number of NUMA nodes per socket (NPS).
+                                  The following values are supported:
+                                  * `NPS0`
+                                  * `NPS1`
+                                  * `NPS2`
+                                  * `NPS4`
                                 type: string
                             type: object
                           amdRomeBmPlatformConfig:
@@ -634,15 +628,14 @@ spec:
                               BM platform configuration
                             properties:
                               areVirtualInstructionsEnabled:
-                                description: Whether virtualization instructions are
-                                  available. For example, Secure Virtual Machine for
-                                  AMD shapes or VT-x for Intel shapes.
+                                description: |-
+                                  Whether virtualization instructions are available. For example, Secure Virtual Machine for AMD shapes
+                                  or VT-x for Intel shapes.
                                 type: boolean
                               isAccessControlServiceEnabled:
-                                description: Whether the Access Control Service is
-                                  enabled on the instance. When enabled, the platform
-                                  can enforce PCIe device isolation, required for
-                                  VFIO device pass-through.
+                                description: |-
+                                  Whether the Access Control Service is enabled on the instance. When enabled,
+                                  the platform can enforce PCIe device isolation, required for VFIO device pass-through.
                                 type: boolean
                               isInputOutputMemoryManagementUnitEnabled:
                                 description: Whether the input-output memory management
@@ -663,39 +656,35 @@ spec:
                                   instance.
                                 type: boolean
                               isSymmetricMultiThreadingEnabled:
-                                description: Whether symmetric multithreading is enabled
-                                  on the instance. Symmetric multithreading is also
-                                  called simultaneous multithreading (SMT) or Intel
-                                  Hyper-Threading. Intel and AMD processors have two
-                                  hardware execution threads per core (OCPU). SMT
-                                  permits multiple independent threads of execution,
-                                  to better use the resources and increase the efficiency
-                                  of the CPU. When multithreading is disabled, only
-                                  one thread is permitted to run on each core, which
-                                  can provide higher or more predictable performance
-                                  for some workloads.
+                                description: |-
+                                  Whether symmetric multithreading is enabled on the instance. Symmetric multithreading is also
+                                  called simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                                  Intel and AMD processors have two hardware execution threads per core (OCPU). SMT permits multiple
+                                  independent threads of execution, to better use the resources and increase the efficiency
+                                  of the CPU. When multithreading is disabled, only one thread is permitted to run on each core, which
+                                  can provide higher or more predictable performance for some workloads.
                                 type: boolean
                               isTrustedPlatformModuleEnabled:
                                 description: Whether the Trusted Platform Module (TPM)
                                   is enabled on the instance.
                                 type: boolean
                               numaNodesPerSocket:
-                                description: 'The number of NUMA nodes per socket
-                                  (NPS). The following values are supported: * `NPS0`
-                                  * `NPS1` * `NPS2` * `NPS4`'
+                                description: |-
+                                  The number of NUMA nodes per socket (NPS).
+                                  The following values are supported:
+                                  * `NPS0`
+                                  * `NPS1`
+                                  * `NPS2`
+                                  * `NPS4`
                                 type: string
                               percentageOfCoresEnabled:
-                                description: The percentage of cores enabled. Value
-                                  must be a multiple of 25%. If the requested percentage
-                                  results in a fractional number of cores, the system
-                                  rounds up the number of cores across processors
-                                  and provisions an instance with a whole number of
-                                  cores. If the applications that you run on the instance
-                                  use a core-based licensing model and need fewer
-                                  cores than the full size of the shape, you can disable
-                                  cores to reduce your licensing costs. The instance
-                                  itself is billed for the full shape, regardless
-                                  of whether all cores are enabled.
+                                description: |-
+                                  The percentage of cores enabled. Value must be a multiple of 25%. If the requested percentage
+                                  results in a fractional number of cores, the system rounds up the number of cores across processors
+                                  and provisions an instance with a whole number of cores.
+                                  If the applications that you run on the instance use a core-based licensing model and need fewer cores
+                                  than the full size of the shape, you can disable cores to reduce your licensing costs. The instance
+                                  itself is billed for the full shape, regardless of whether all cores are enabled.
                                 type: integer
                             type: object
                           amdVmPlatformConfig:
@@ -744,39 +733,33 @@ spec:
                                   instance.
                                 type: boolean
                               isSymmetricMultiThreadingEnabled:
-                                description: Whether symmetric multithreading is enabled
-                                  on the instance. Symmetric multithreading is also
-                                  called simultaneous multithreading (SMT) or Intel
-                                  Hyper-Threading. Intel and AMD processors have two
-                                  hardware execution threads per core (OCPU). SMT
-                                  permits multiple independent threads of execution,
-                                  to better use the resources and increase the efficiency
-                                  of the CPU. When multithreading is disabled, only
-                                  one thread is permitted to run on each core, which
-                                  can provide higher or more predictable performance
-                                  for some workloads.
+                                description: |-
+                                  Whether symmetric multithreading is enabled on the instance. Symmetric multithreading is also
+                                  called simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                                  Intel and AMD processors have two hardware execution threads per core (OCPU). SMT permits multiple
+                                  independent threads of execution, to better use the resources and increase the efficiency
+                                  of the CPU. When multithreading is disabled, only one thread is permitted to run on each core, which
+                                  can provide higher or more predictable performance for some workloads.
                                 type: boolean
                               isTrustedPlatformModuleEnabled:
                                 description: Whether the Trusted Platform Module (TPM)
                                   is enabled on the instance.
                                 type: boolean
                               numaNodesPerSocket:
-                                description: 'The number of NUMA nodes per socket
-                                  (NPS). The following values are supported: * `NPS1`
-                                  * `NPS2`'
+                                description: |-
+                                  The number of NUMA nodes per socket (NPS).
+                                  The following values are supported:
+                                  * `NPS1`
+                                  * `NPS2`
                                 type: string
                               percentageOfCoresEnabled:
-                                description: The percentage of cores enabled. Value
-                                  must be a multiple of 25%. If the requested percentage
-                                  results in a fractional number of cores, the system
-                                  rounds up the number of cores across processors
-                                  and provisions an instance with a whole number of
-                                  cores. If the applications that you run on the instance
-                                  use a core-based licensing model and need fewer
-                                  cores than the full size of the shape, you can disable
-                                  cores to reduce your licensing costs. The instance
-                                  itself is billed for the full shape, regardless
-                                  of whether all cores are enabled.
+                                description: |-
+                                  The percentage of cores enabled. Value must be a multiple of 25%. If the requested percentage
+                                  results in a fractional number of cores, the system rounds up the number of cores across processors
+                                  and provisions an instance with a whole number of cores.
+                                  If the applications that you run on the instance use a core-based licensing model and need fewer cores
+                                  than the full size of the shape, you can disable cores to reduce your licensing costs. The instance
+                                  itself is billed for the full shape, regardless of whether all cores are enabled.
                                 type: integer
                             type: object
                           intelSkylakeBmPlatformConfig:
@@ -826,11 +809,16 @@ spec:
                                 type: boolean
                             type: object
                           platformConfigType:
-                            description: The type of platform configuration. Valid
-                              values are * `AMD_ROME_BM_GPU` * `AMD_ROME_BM` * `INTEL_ICELAKE_BM`
-                              * `AMD_VM` * `INTEL_VM` * `INTEL_SKYLAKE_BM` * `AMD_MILAN_BM`
-                              Based on the enum, exactly one of the specific configuration
-                              types must be set
+                            description: |-
+                              The type of platform configuration. Valid values are
+                              * `AMD_ROME_BM_GPU`
+                              * `AMD_ROME_BM`
+                              * `INTEL_ICELAKE_BM`
+                              * `AMD_VM`
+                              * `INTEL_VM`
+                              * `INTEL_SKYLAKE_BM`
+                              * `AMD_MILAN_BM`
+                              Based on the enum, exactly one of the specific configuration types must be set
                             type: string
                         type: object
                       preemptibleInstanceConfig:
@@ -850,20 +838,19 @@ spec:
                             type: object
                         type: object
                       preserveBootVolume:
-                        description: Specifies whether to delete or preserve the boot
-                          volume when terminating an instance. When set to true, the
-                          boot volume is preserved. The default value is false.
+                        description: |-
+                          Specifies whether to delete or preserve the boot volume when terminating an instance.
+                          When set to true, the boot volume is preserved. The default value is false.
                         type: boolean
                       preserveDataVolumesCreatedAtLaunch:
-                        description: Specifies whether to delete or preserve the data
-                          volumes created during launch when terminating an instance.
-                          When set to true, the data volumes are preserved. The default
-                          value is true.
+                        description: |-
+                          Specifies whether to delete or preserve the data volumes created during launch when
+                          terminating an instance. When set to true, the data volumes are preserved. The default value is true.
                         type: boolean
                       providerID:
-                        description: Provider ID of the instance, this will be set
-                          by Cluster API provider itself, users should not set this
-                          parameter.
+                        description: |-
+                          Provider ID of the instance, this will be set by Cluster API provider itself,
+                          users should not set this parameter.
                         type: string
                       shape:
                         description: Shape of the instance.
@@ -873,14 +860,13 @@ spec:
                           for flex instances.
                         properties:
                           baselineOcpuUtilization:
-                            description: 'The baseline OCPU utilization for a subcore
-                              burstable VM instance. Leave this attribute blank for
-                              a non-burstable instance, or explicitly specify non-burstable
-                              with `BASELINE_1_1`. The following values are supported:
+                            description: |-
+                              The baseline OCPU utilization for a subcore burstable VM instance. Leave this attribute blank for a
+                              non-burstable instance, or explicitly specify non-burstable with `BASELINE_1_1`.
+                              The following values are supported:
                               - `BASELINE_1_8` - baseline usage is 1/8 of an OCPU.
                               - `BASELINE_1_2` - baseline usage is 1/2 of an OCPU.
-                              - `BASELINE_1_1` - baseline usage is an entire OCPU.
-                              This represents a non-burstable instance.'
+                              - `BASELINE_1_1` - baseline usage is an entire OCPU. This represents a non-burstable instance.
                             type: string
                           memoryInGBs:
                             description: The total amount of memory available to the
@@ -896,40 +882,36 @@ spec:
                             type: string
                         type: object
                       subnetName:
-                        description: The name of the subnet to use. The name here
-                          refers to the subnets defined in the OCICluster Spec. Optional,
-                          only if multiple subnets of a type is defined, else the
-                          first element is used.
+                        description: |-
+                          The name of the subnet to use. The name here refers to the subnets
+                          defined in the OCICluster Spec. Optional, only if multiple subnets of a type
+                          is defined, else the first element is used.
                         type: string
                       vnicAttachments:
-                        description: VnicAttachments defines the configuration options
-                          for the vnic(s) attached to the machine The network bandwidth
-                          and number of VNICs scale proportionately with the number
-                          of OCPUs.
+                        description: |-
+                          VnicAttachments defines the configuration options for the vnic(s) attached to the machine
+                          The network bandwidth and number of VNICs scale proportionately with the number of OCPUs.
                         items:
                           properties:
-                            assignIpv6Ip:
-                              description: assignIpv6Ip defines whether the VNIC should
-                                be assigned a IPv6.
-                              type: boolean
                             assignPublicIp:
                               description: AssignPublicIp defines whether the vnic
                                 should have a public IP address
                               type: boolean
                             displayName:
-                              description: DisplayName defines a user-friendly name.
-                                Does not have to be unique. Avoid entering confidential
-                                information.
+                              description: |-
+                                DisplayName defines a user-friendly name. Does not have to be unique.
+                                Avoid entering confidential information.
                               type: string
                             nicIndex:
-                              description: NicIndex defines which physical Network
-                                Interface Card (NIC) to use You can determine which
-                                NICs are active for a shape by reviewing the https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm
+                              description: |-
+                                NicIndex defines which physical Network Interface Card (NIC) to use
+                                You can determine which NICs are active for a shape by reviewing the
+                                https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm
                               type: integer
                             subnetName:
-                              description: SubnetName defines the subnet name to use
-                                for the VNIC Defaults to the "worker" subnet if not
-                                provided
+                              description: |-
+                                SubnetName defines the subnet name to use for the VNIC
+                                Defaults to the "worker" subnet if not provided
                               type: string
                             vnicAttachmentId:
                               description: VnicAttachmentId defines the ID of the
@@ -956,14 +938,19 @@ spec:
           machine template.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -983,43 +970,41 @@ spec:
                           Cloud Agent software running on the instance.
                         properties:
                           areAllPluginsDisabled:
-                            description: AreAllPluginsDisabled defines whether Oracle
-                              Cloud Agent can run all the available plugins. This
-                              includes the management and monitoring plugins. To get
-                              a list of available plugins, use the ListInstanceagentAvailablePlugins
-                              operation in the Oracle Cloud Agent API. For more information
-                              about the available plugins, see Managing Plugins with
-                              Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
+                            description: |-
+                              AreAllPluginsDisabled defines whether Oracle Cloud Agent can run all the available plugins.
+                              This includes the management and monitoring plugins.
+                              To get a list of available plugins, use the
+                              ListInstanceagentAvailablePlugins
+                              operation in the Oracle Cloud Agent API. For more information about the available plugins, see
+                              Managing Plugins with Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
                             type: boolean
                           isManagementDisabled:
-                            description: 'IsManagementDisabled defines whether Oracle
-                              Cloud Agent can run all the available management plugins.
+                            description: |-
+                              IsManagementDisabled defines whether Oracle Cloud Agent can run all the available management plugins.
                               Default value is false (management plugins are enabled).
-                              These are the management plugins: OS Management Service
-                              Agent and Compute Instance Run Command. The management
-                              plugins are controlled by this parameter and by the
-                              per-plugin configuration in the `pluginsConfig` object.
-                              - If `isManagementDisabled` is true, all of the management
-                              plugins are disabled, regardless of the per-plugin configuration.
-                              - If `isManagementDisabled` is false, all of the management
-                              plugins are enabled. You can optionally disable individual
-                              management plugins by providing a value in the `pluginsConfig`
-                              object.'
+                              These are the management plugins: OS Management Service Agent and Compute Instance
+                              Run Command.
+                              The management plugins are controlled by this parameter and by the per-plugin
+                              configuration in the `pluginsConfig` object.
+                              - If `isManagementDisabled` is true, all of the management plugins are disabled, regardless of
+                              the per-plugin configuration.
+                              - If `isManagementDisabled` is false, all of the management plugins are enabled. You
+                              can optionally disable individual management plugins by providing a value in the `pluginsConfig`
+                              object.
                             type: boolean
                           isMonitoringDisabled:
-                            description: 'IsMonitoringDisabled defines whether Oracle
-                              Cloud Agent can gather performance metrics and monitor
-                              the instance using the monitoring plugins. Default value
-                              is false (monitoring plugins are enabled). These are
-                              the monitoring plugins: Compute Instance Monitoring
-                              and Custom Logs Monitoring. The monitoring plugins are
-                              controlled by this parameter and by the per-plugin configuration
-                              in the `pluginsConfig` object. - If `isMonitoringDisabled`
-                              is true, all of the monitoring plugins are disabled,
-                              regardless of the per-plugin configuration. - If `isMonitoringDisabled`
-                              is false, all of the monitoring plugins are enabled.
-                              You can optionally disable individual monitoring plugins
-                              by providing a value in the `pluginsConfig` object.'
+                            description: |-
+                              IsMonitoringDisabled defines whether Oracle Cloud Agent can gather performance metrics and monitor the instance using the
+                              monitoring plugins. Default value is false (monitoring plugins are enabled).
+                              These are the monitoring plugins: Compute Instance Monitoring
+                              and Custom Logs Monitoring.
+                              The monitoring plugins are controlled by this parameter and by the per-plugin
+                              configuration in the `pluginsConfig` object.
+                              - If `isMonitoringDisabled` is true, all of the monitoring plugins are disabled, regardless of
+                              the per-plugin configuration.
+                              - If `isMonitoringDisabled` is false, all of the monitoring plugins are enabled. You
+                              can optionally disable individual monitoring plugins by providing a value in the `pluginsConfig`
+                              object.
                             type: boolean
                           pluginsConfigs:
                             description: PluginsConfig defines the configuration of
@@ -1029,67 +1014,61 @@ spec:
                                 of plugins associated with this instance.
                               properties:
                                 desiredState:
-                                  description: 'DesiredState defines whether the plugin
-                                    should be enabled or disabled. To enable the monitoring
-                                    and management plugins, the `isMonitoringDisabled`
-                                    and `isManagementDisabled` attributes must also
-                                    be set to false. The following values are supported:
-                                    * `ENABLED` * `DISABLED`'
+                                  description: |-
+                                    DesiredState defines whether the plugin should be enabled or disabled.
+                                    To enable the monitoring and management plugins, the `isMonitoringDisabled` and
+                                    `isManagementDisabled` attributes must also be set to false.
+                                    The following values are supported:
+                                    * `ENABLED`
+                                    * `DISABLED`
                                   type: string
                                 name:
-                                  description: Name defines the name of the plugin.
-                                    To get a list of available plugins, use the ListInstanceagentAvailablePlugins
-                                    operation in the Oracle Cloud Agent API. For more
-                                    information about the available plugins, see Managing
-                                    Plugins with Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
+                                  description: |-
+                                    Name defines the name of the plugin. To get a list of available plugins, use the
+                                    ListInstanceagentAvailablePlugins
+                                    operation in the Oracle Cloud Agent API. For more information about the available plugins, see
+                                    Managing Plugins with Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
                                   type: string
                               type: object
                             type: array
                         type: object
                       availabilityConfig:
-                        description: LaunchInstanceAvailabilityConfig defines the
-                          options for VM migration during infrastructure maintenance
-                          events and for defining the availability of a VM instance
-                          after a maintenance event that impacts the underlying hardware.
+                        description: |-
+                          LaunchInstanceAvailabilityConfig defines the options for VM migration during infrastructure maintenance events and for defining
+                          the availability of a VM instance after a maintenance event that impacts the underlying hardware.
                         properties:
                           isLiveMigrationPreferred:
-                            description: IsLiveMigrationPreferred defines whether
-                              to live migrate supported VM instances to a healthy
-                              physical VM host without disrupting running instances
-                              during infrastructure maintenance events. If null, Oracle
-                              chooses the best option for migrating the VM during
-                              infrastructure maintenance events.
+                            description: |-
+                              IsLiveMigrationPreferred defines whether to live migrate supported VM instances to a healthy physical VM host without
+                              disrupting running instances during infrastructure maintenance events. If null, Oracle
+                              chooses the best option for migrating the VM during infrastructure maintenance events.
                             type: boolean
                           recoveryAction:
-                            description: RecoveryAction defines the lifecycle state
-                              for an instance when it is recovered after infrastructure
-                              maintenance. * `RESTORE_INSTANCE` - The instance is
-                              restored to the lifecycle state it was in before the
-                              maintenance event. If the instance was running, it is
-                              automatically rebooted. This is the default action when
-                              a value is not set. * `STOP_INSTANCE` - The instance
-                              is recovered in the stopped state.
+                            description: |-
+                              RecoveryAction defines the lifecycle state for an instance when it is recovered after infrastructure maintenance.
+                              * `RESTORE_INSTANCE` - The instance is restored to the lifecycle state it was in before the maintenance event.
+                              If the instance was running, it is automatically rebooted. This is the default action when a value is not set.
+                              * `STOP_INSTANCE` - The instance is recovered in the stopped state.
                             type: string
                         type: object
                       bootVolumeSizeInGBs:
-                        description: The size of boot volume. Please see https://docs.oracle.com/en-us/iaas/Content/Block/Tasks/extendingbootpartition.htm
+                        description: |-
+                          The size of boot volume. Please see https://docs.oracle.com/en-us/iaas/Content/Block/Tasks/extendingbootpartition.htm
                           to extend the boot volume size.
                         type: string
                       capacityReservationId:
-                        description: CapacityReservationId defines the OCID of the
-                          compute capacity reservation this instance is launched under.
-                          You can opt out of all default reservations by specifying
-                          an empty string as input for this field. For more information,
-                          see Capacity Reservations (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/reserve-capacity.htm#default).
+                        description: |-
+                          CapacityReservationId defines the OCID of the compute capacity reservation this instance is launched under.
+                          You can opt out of all default reservations by specifying an empty string as input for this field.
+                          For more information, see Capacity Reservations (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/reserve-capacity.htm#default).
                         type: string
                       compartmentId:
                         description: Compartment to launch the instance in.
                         type: string
                       computeClusterId:
-                        description: ComputeClusterId refers to OCID of the compute
-                          cluster that the instance will be created in. Please refer
-                          https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/compute-clusters.htm
-                          for more details
+                        description: |-
+                          ComputeClusterId refers to OCID of the compute cluster that the instance will be created in.
+                          Please refer https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/compute-clusters.htm for more details
                         type: string
                       dedicatedVmHostId:
                         description: DedicatedVmHostId defines the OCID of the dedicated
@@ -1100,10 +1079,10 @@ spec:
                           additionalProperties:
                             type: string
                           type: object
-                        description: 'Defined tags for this resource. Each key is
-                          predefined and scoped to a namespace. For more information,
-                          see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
-                          Example: `{"Operations": {"CostCenter": "42"}}`'
+                        description: |-
+                          Defined tags for this resource. Each key is predefined and scoped to a
+                          namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+                          Example: `{"Operations": {"CostCenter": "42"}}`
                         type: object
                       freeformTags:
                         additionalProperties:
@@ -1120,10 +1099,10 @@ spec:
                         description: InstanceOptions defines the instance options
                         properties:
                           areLegacyImdsEndpointsDisabled:
-                            description: Whether to disable the legacy (/v1) instance
-                              metadata service endpoints. Customers who have migrated
-                              to /v2 should set this to true for added security. Default
-                              is false.
+                            description: |-
+                              Whether to disable the legacy (/v1) instance metadata service endpoints.
+                              Customers who have migrated to /v2 should set this to true for added security.
+                              Default is false.
                             type: boolean
                         type: object
                       instanceSourceViaImageConfig:
@@ -1131,17 +1110,15 @@ spec:
                           for booting up instances via images
                         properties:
                           bootVolumeVpusPerGB:
-                            description: 'BootVolumeVpusPerGB defines the number of
-                              volume performance units (VPUs) that will be applied
-                              to this volume per GB, representing the Block Volume
-                              service''s elastic performance options. See Block Volume
-                              Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels)
-                              for more information. Allowed values: * `10`: Represents
-                              Balanced option. * `20`: Represents Higher Performance
-                              option. * `30`-`120`: Represents the Ultra High Performance
-                              option. For volumes with the auto-tuned performance
-                              feature enabled, this is set to the default (minimum)
-                              VPUs/GB.'
+                            description: |-
+                              BootVolumeVpusPerGB defines the number of volume performance units (VPUs) that will be applied to this volume per GB,
+                              representing the Block Volume service's elastic performance options.
+                              See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels) for more information.
+                              Allowed values:
+                                * `10`: Represents Balanced option.
+                                * `20`: Represents Higher Performance option.
+                                * `30`-`120`: Represents the Ultra High Performance option.
+                              For volumes with the auto-tuned performance feature enabled, this is set to the default (minimum) VPUs/GB.
                             format: int64
                             type: integer
                           kmsKeyId:
@@ -1162,24 +1139,23 @@ spec:
                           the compatibility and performance of VM shapes
                         properties:
                           bootVolumeType:
-                            description: BootVolumeType defines Emulation type for
-                              the boot volume. * `ISCSI` - ISCSI attached block storage
-                              device. * `SCSI` - Emulated SCSI disk. * `IDE` - Emulated
-                              IDE disk. * `VFIO` - Direct attached Virtual Function
-                              storage. This is the default option for local data volumes
-                              on platform images. * `PARAVIRTUALIZED` - Paravirtualized
-                              disk. This is the default for boot volumes and remote
-                              block storage volumes on platform images.
+                            description: |-
+                              BootVolumeType defines Emulation type for the boot volume.
+                              * `ISCSI` - ISCSI attached block storage device.
+                              * `SCSI` - Emulated SCSI disk.
+                              * `IDE` - Emulated IDE disk.
+                              * `VFIO` - Direct attached Virtual Function storage. This is the default option for local data
+                              volumes on platform images.
+                              * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+                              storage volumes on platform images.
                             type: string
                           firmware:
-                            description: Firmware defines the firmware used to boot
-                              VM. Select the option that matches your operating system.
-                              * `BIOS` - Boot VM using BIOS style firmware. This is
-                              compatible with both 32 bit and 64 bit operating systems
-                              that boot using MBR style bootloaders. * `UEFI_64` -
-                              Boot VM using UEFI style firmware compatible with 64
-                              bit operating systems. This is the default for platform
-                              images.
+                            description: |-
+                              Firmware defines the firmware used to boot VM. Select the option that matches your operating system.
+                              * `BIOS` - Boot VM using BIOS style firmware. This is compatible with both 32 bit and 64 bit operating
+                              systems that boot using MBR style bootloaders.
+                              * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems. This is the
+                              default for platform images.
                             type: string
                           isConsistentVolumeNamingEnabled:
                             description: IsConsistentVolumeNamingEnabled defines whether
@@ -1187,24 +1163,23 @@ spec:
                               to false.
                             type: boolean
                           networkType:
-                            description: NetworkType defines the emulation type for
-                              the physical network interface card (NIC). * `E1000`
-                              - Emulated Gigabit ethernet controller. Compatible with
-                              Linux e1000 network driver. * `VFIO` - Direct attached
-                              Virtual Function network controller. This is the networking
-                              type when you launch an instance using hardware-assisted
-                              (SR-IOV) networking. * `PARAVIRTUALIZED` - VM instances
-                              launch with paravirtualized devices using VirtIO drivers.
+                            description: |-
+                              NetworkType defines the emulation type for the physical network interface card (NIC).
+                              * `E1000` - Emulated Gigabit ethernet controller. Compatible with Linux e1000 network driver.
+                              * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
+                              when you launch an instance using hardware-assisted (SR-IOV) networking.
+                              * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
                             type: string
                           remoteDataVolumeType:
-                            description: RemoteDataVolumeType defines the emulation
-                              type for volume. * `ISCSI` - ISCSI attached block storage
-                              device. * `SCSI` - Emulated SCSI disk. * `IDE` - Emulated
-                              IDE disk. * `VFIO` - Direct attached Virtual Function
-                              storage. This is the default option for local data volumes
-                              on platform images. * `PARAVIRTUALIZED` - Paravirtualized
-                              disk. This is the default for boot volumes and remote
-                              block storage volumes on platform images.
+                            description: |-
+                              RemoteDataVolumeType defines the emulation type for volume.
+                              * `ISCSI` - ISCSI attached block storage device.
+                              * `SCSI` - Emulated SCSI disk.
+                              * `IDE` - Emulated IDE disk.
+                              * `VFIO` - Direct attached Virtual Function storage. This is the default option for local data
+                              volumes on platform images.
+                              * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+                              storage volumes on platform images.
                             type: string
                         type: object
                       launchVolumeAttachments:
@@ -1222,12 +1197,13 @@ spec:
                                     of devices for a given instance, see ListInstanceDevices.
                                   type: string
                                 displayName:
-                                  description: A user-friendly name. Does not have
-                                    to be unique, and it's changeable. Avoid entering
-                                    confidential information.
+                                  description: |-
+                                    A user-friendly name. Does not have to be unique, and it's changeable.
+                                    Avoid entering confidential information.
                                   type: string
                                 encryptionInTransitType:
-                                  description: Refer the top-level definition of encryptionInTransitType.
+                                  description: |-
+                                    Refer the top-level definition of encryptionInTransitType.
                                     The default value is NONE.
                                   type: string
                                 isAgentAutoIscsiLoginEnabled:
@@ -1241,13 +1217,11 @@ spec:
                                     in read-only mode.
                                   type: boolean
                                 isShareable:
-                                  description: Whether the attachment should be created
-                                    in shareable mode. If an attachment is created
-                                    in shareable mode, then other instances can attach
-                                    the same volume, provided that they also create
-                                    their attachments in shareable mode. Only certain
-                                    volume types can be attached in shareable mode.
-                                    Defaults to false if not specified.
+                                  description: |-
+                                    Whether the attachment should be created in shareable mode. If an attachment
+                                    is created in shareable mode, then other instances can attach the same volume, provided
+                                    that they also create their attachments in shareable mode. Only certain volume types can
+                                    be attached in shareable mode. Defaults to false if not specified.
                                   type: boolean
                                 launchCreateVolumeFromAttributes:
                                   description: LaunchCreateVolumeFromAttributes The
@@ -1255,35 +1229,34 @@ spec:
                                     operation.
                                   properties:
                                     compartmentId:
-                                      description: The OCID of the compartment that
-                                        contains the volume. If not provided, it will
-                                        be inherited from the instance.
+                                      description: |-
+                                        The OCID of the compartment that contains the volume. If not provided,
+                                        it will be inherited from the instance.
                                       type: string
                                     displayName:
-                                      description: A user-friendly name. Does not
-                                        have to be unique, and it's changeable. Avoid
-                                        entering confidential information.
+                                      description: |-
+                                        A user-friendly name. Does not have to be unique, and it's changeable.
+                                        Avoid entering confidential information.
                                       type: string
                                     kmsKeyId:
-                                      description: The OCID of the Vault service key
-                                        to assign as the master encryption key for
-                                        the volume.
+                                      description: |-
+                                        The OCID of the Vault service key to assign as the master encryption key
+                                        for the volume.
                                       type: string
                                     sizeInGBs:
                                       description: The size of the volume in GBs.
                                       format: int64
                                       type: integer
                                     vpusPerGB:
-                                      description: 'The number of volume performance
-                                        units (VPUs) that will be applied to this
-                                        volume per GB, representing the Block Volume
-                                        service''s elastic performance options. See
-                                        Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels)
-                                        for more information. Allowed values: * `0`:
-                                        Represents Lower Cost option. * `10`: Represents
-                                        Balanced option. * `20`: Represents Higher
-                                        Performance option. * `30`-`120`: Represents
-                                        the Ultra High Performance option.'
+                                      description: |-
+                                        The number of volume performance units (VPUs) that will be applied to this volume per GB,
+                                        representing the Block Volume service's elastic performance options.
+                                        See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels) for more information.
+                                        Allowed values:
+                                          * `0`: Represents Lower Cost option.
+                                          * `10`: Represents Balanced option.
+                                          * `20`: Represents Higher Performance option.
+                                          * `30`-`120`: Represents the Ultra High Performance option.
                                       format: int64
                                       type: integer
                                   type: object
@@ -1298,69 +1271,76 @@ spec:
                                   type: string
                               type: object
                             launchParavirtualizedVolumeAttachment:
-                              description: The details of paravirtualized volume attachment.
+                              description: LaunchParavirtualizedVolumeAttachment specifies
+                                the paravirtualized volume attachments to create as
+                                part of the launch instance operation.
                               properties:
                                 device:
-                                  description: The device name. To retrieve a list of devices
-                                    for a given instance, see ListInstanceDevices.
+                                  description: The device name. To retrieve a list
+                                    of devices for a given instance, see ListInstanceDevices.
                                   type: string
                                 displayName:
-                                  description: A user-friendly name. Does not have to be unique,
-                                    and it's changeable. Avoid entering confidential information.
+                                  description: |-
+                                    A user-friendly name. Does not have to be unique, and it's changeable.
+                                    Avoid entering confidential information.
                                   type: string
                                 isPvEncryptionInTransitEnabled:
-                                  description: Refer the top-level definition of isPvEncryptionInTransitEnabled.
+                                  description: |-
+                                    Refer the top-level definition of encryptionInTransitType.
                                     The default value is False.
                                   type: boolean
                                 isReadOnly:
-                                  description: Whether the attachment was created in read-only
-                                    mode.
+                                  description: Whether the attachment was created
+                                    in read-only mode.
                                   type: boolean
                                 isShareable:
-                                  description: Whether the attachment should be created in
-                                    shareable mode. If an attachment is created in shareable
-                                    mode, then other instances can attach the same volume,
-                                    provided that they also create their attachments in shareable
-                                    mode. Only certain volume types can be attached in shareable
-                                    mode. Defaults to false if not specified.
+                                  description: |-
+                                    Whether the attachment should be created in shareable mode. If an attachment
+                                    is created in shareable mode, then other instances can attach the same volume, provided
+                                    that they also create their attachments in shareable mode. Only certain volume types can
+                                    be attached in shareable mode. Defaults to false if not specified.
                                   type: boolean
                                 launchCreateVolumeFromAttributes:
-                                  description: LaunchCreateVolumeFromAttributes The details
-                                    of the volume to create for CreateVolume operation.
+                                  description: LaunchCreateVolumeFromAttributes The
+                                    details of the volume to create for CreateVolume
+                                    operation.
                                   properties:
                                     compartmentId:
-                                      description: The OCID of the compartment that contains
-                                        the volume. If not provided, it will be inherited
-                                        from the instance.
+                                      description: |-
+                                        The OCID of the compartment that contains the volume. If not provided,
+                                        it will be inherited from the instance.
                                       type: string
                                     displayName:
-                                      description: A user-friendly name. Does not have to
-                                        be unique, and it's changeable. Avoid entering confidential
-                                        information.
+                                      description: |-
+                                        A user-friendly name. Does not have to be unique, and it's changeable.
+                                        Avoid entering confidential information.
                                       type: string
                                     kmsKeyId:
-                                      description: The OCID of the Vault service key to assign
-                                        as the master encryption key for the volume.
+                                      description: |-
+                                        The OCID of the Vault service key to assign as the master encryption key
+                                        for the volume.
                                       type: string
                                     sizeInGBs:
                                       description: The size of the volume in GBs.
                                       format: int64
                                       type: integer
                                     vpusPerGB:
-                                      description: 'The number of volume performance units
-                                        (VPUs) that will be applied to this volume per GB,
-                                        representing the Block Volume service''s elastic performance
-                                        options. See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels)
-                                        for more information. Allowed values: * `0`: Represents
-                                        Lower Cost option. * `10`: Represents Balanced option.
-                                        * `20`: Represents Higher Performance option. * `30`-`120`:
-                                        Represents the Ultra High Performance option.'
+                                      description: |-
+                                        The number of volume performance units (VPUs) that will be applied to this volume per GB,
+                                        representing the Block Volume service's elastic performance options.
+                                        See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels) for more information.
+                                        Allowed values:
+                                          * `0`: Represents Lower Cost option.
+                                          * `10`: Represents Balanced option.
+                                          * `20`: Represents Higher Performance option.
+                                          * `30`-`120`: Represents the Ultra High Performance option.
                                       format: int64
                                       type: integer
                                   type: object
                                 volumeId:
                                   description: The OCID of the volume. If CreateVolumeDetails
-                                    is specified, this field must be omitted from the request.
+                                    is specified, this field must be omitted from
+                                    the request.
                                   type: string
                               type: object
                             volumeType:
@@ -1371,38 +1351,39 @@ spec:
                       metadata:
                         additionalProperties:
                           type: string
-                        description: Custom metadata key/value pairs that you provide,
-                          such as the SSH public key required to connect to the instance.
+                        description: |-
+                          Custom metadata key/value pairs that you provide, such as the SSH public key
+                          required to connect to the instance.
                         type: object
                       networkDetails:
                         description: NetworkDetails defines the configuration options
                           for the network
                         properties:
+                          assignIpv6Ip:
+                            description: AssignIPv6 determines whether to assign a
+                              IPv6 address to the instance.
+                            type: boolean
                           assignPrivateDnsRecord:
                             description: AssignPrivateDnsRecord defines whether the
                               VNIC should be assigned a DNS record.
-                            type: boolean
-                          assignIpv6Ip:
-                            description: assignIpv6Ip defines whether the VNIC should
-                              be assigned a IPv6.
                             type: boolean
                           assignPublicIp:
                             description: AssignPublicIp defines whether the instance
                               should have a public IP address
                             type: boolean
                           displayName:
-                            description: DisplayName defines a user-friendly name.
-                              Does not have to be unique, and it's changeable. Avoid
-                              entering confidential information.
+                            description: |-
+                              DisplayName defines a user-friendly name. Does not have to be unique, and it's changeable.
+                              Avoid entering confidential information.
                             type: string
                           hostnameLabel:
                             description: HostnameLabel defines the hostname for the
                               VNIC's primary private IP. Used for DNS.
                             type: string
                           nsgId:
-                            description: NSGId defines the ID of the NSG to use. This
-                              parameter takes priority over NsgNames. Deprecated,
-                              please use NetworkDetails.NSGIds
+                            description: |-
+                              NSGId defines the ID of the NSG to use. This parameter takes priority over NsgNames.
+                              Deprecated, please use NetworkDetails.NSGIds
                             type: string
                           nsgIds:
                             description: NSGIds defines the list of NSG IDs to use.
@@ -1438,15 +1419,14 @@ spec:
                               BM platform configuration
                             properties:
                               areVirtualInstructionsEnabled:
-                                description: Whether virtualization instructions are
-                                  available. For example, Secure Virtual Machine for
-                                  AMD shapes or VT-x for Intel shapes.
+                                description: |-
+                                  Whether virtualization instructions are available. For example, Secure Virtual Machine for AMD shapes
+                                  or VT-x for Intel shapes.
                                 type: boolean
                               isAccessControlServiceEnabled:
-                                description: Whether the Access Control Service is
-                                  enabled on the instance. When enabled, the platform
-                                  can enforce PCIe device isolation, required for
-                                  VFIO device pass-through.
+                                description: |-
+                                  Whether the Access Control Service is enabled on the instance. When enabled,
+                                  the platform can enforce PCIe device isolation, required for VFIO device pass-through.
                                 type: boolean
                               isInputOutputMemoryManagementUnitEnabled:
                                 description: Whether the input-output memory management
@@ -1467,39 +1447,35 @@ spec:
                                   instance.
                                 type: boolean
                               isSymmetricMultiThreadingEnabled:
-                                description: Whether symmetric multithreading is enabled
-                                  on the instance. Symmetric multithreading is also
-                                  called simultaneous multithreading (SMT) or Intel
-                                  Hyper-Threading. Intel and AMD processors have two
-                                  hardware execution threads per core (OCPU). SMT
-                                  permits multiple independent threads of execution,
-                                  to better use the resources and increase the efficiency
-                                  of the CPU. When multithreading is disabled, only
-                                  one thread is permitted to run on each core, which
-                                  can provide higher or more predictable performance
-                                  for some workloads.
+                                description: |-
+                                  Whether symmetric multithreading is enabled on the instance. Symmetric multithreading is also
+                                  called simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                                  Intel and AMD processors have two hardware execution threads per core (OCPU). SMT permits multiple
+                                  independent threads of execution, to better use the resources and increase the efficiency
+                                  of the CPU. When multithreading is disabled, only one thread is permitted to run on each core, which
+                                  can provide higher or more predictable performance for some workloads.
                                 type: boolean
                               isTrustedPlatformModuleEnabled:
                                 description: Whether the Trusted Platform Module (TPM)
                                   is enabled on the instance.
                                 type: boolean
                               numaNodesPerSocket:
-                                description: 'The number of NUMA nodes per socket
-                                  (NPS). The following values are supported: * `NPS0`
-                                  * `NPS1` * `NPS2` * `NPS4`'
+                                description: |-
+                                  The number of NUMA nodes per socket (NPS).
+                                  The following values are supported:
+                                  * `NPS0`
+                                  * `NPS1`
+                                  * `NPS2`
+                                  * `NPS4`
                                 type: string
                               percentageOfCoresEnabled:
-                                description: The percentage of cores enabled. Value
-                                  must be a multiple of 25%. If the requested percentage
-                                  results in a fractional number of cores, the system
-                                  rounds up the number of cores across processors
-                                  and provisions an instance with a whole number of
-                                  cores. If the applications that you run on the instance
-                                  use a core-based licensing model and need fewer
-                                  cores than the full size of the shape, you can disable
-                                  cores to reduce your licensing costs. The instance
-                                  itself is billed for the full shape, regardless
-                                  of whether all cores are enabled.
+                                description: |-
+                                  The percentage of cores enabled. Value must be a multiple of 25%. If the requested percentage
+                                  results in a fractional number of cores, the system rounds up the number of cores across processors
+                                  and provisions an instance with a whole number of cores.
+                                  If the applications that you run on the instance use a core-based licensing model and need fewer cores
+                                  than the full size of the shape, you can disable cores to reduce your licensing costs. The instance
+                                  itself is billed for the full shape, regardless of whether all cores are enabled.
                                 type: integer
                             type: object
                           amdRomeBmGpuPlatformConfig:
@@ -1507,15 +1483,14 @@ spec:
                               BM platform configuration
                             properties:
                               areVirtualInstructionsEnabled:
-                                description: Whether virtualization instructions are
-                                  available. For example, Secure Virtual Machine for
-                                  AMD shapes or VT-x for Intel shapes.
+                                description: |-
+                                  Whether virtualization instructions are available. For example, Secure Virtual Machine for AMD shapes
+                                  or VT-x for Intel shapes.
                                 type: boolean
                               isAccessControlServiceEnabled:
-                                description: Whether the Access Control Service is
-                                  enabled on the instance. When enabled, the platform
-                                  can enforce PCIe device isolation, required for
-                                  VFIO device pass-through.
+                                description: |-
+                                  Whether the Access Control Service is enabled on the instance. When enabled,
+                                  the platform can enforce PCIe device isolation, required for VFIO device pass-through.
                                 type: boolean
                               isInputOutputMemoryManagementUnitEnabled:
                                 description: Whether the input-output memory management
@@ -1536,26 +1511,26 @@ spec:
                                   instance.
                                 type: boolean
                               isSymmetricMultiThreadingEnabled:
-                                description: Whether symmetric multithreading is enabled
-                                  on the instance. Symmetric multithreading is also
-                                  called simultaneous multithreading (SMT) or Intel
-                                  Hyper-Threading. Intel and AMD processors have two
-                                  hardware execution threads per core (OCPU). SMT
-                                  permits multiple independent threads of execution,
-                                  to better use the resources and increase the efficiency
-                                  of the CPU. When multithreading is disabled, only
-                                  one thread is permitted to run on each core, which
-                                  can provide higher or more predictable performance
-                                  for some workloads.
+                                description: |-
+                                  Whether symmetric multithreading is enabled on the instance. Symmetric multithreading is also
+                                  called simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                                  Intel and AMD processors have two hardware execution threads per core (OCPU). SMT permits multiple
+                                  independent threads of execution, to better use the resources and increase the efficiency
+                                  of the CPU. When multithreading is disabled, only one thread is permitted to run on each core, which
+                                  can provide higher or more predictable performance for some workloads.
                                 type: boolean
                               isTrustedPlatformModuleEnabled:
                                 description: Whether the Trusted Platform Module (TPM)
                                   is enabled on the instance.
                                 type: boolean
                               numaNodesPerSocket:
-                                description: 'The number of NUMA nodes per socket
-                                  (NPS). The following values are supported: * `NPS0`
-                                  * `NPS1` * `NPS2` * `NPS4`'
+                                description: |-
+                                  The number of NUMA nodes per socket (NPS).
+                                  The following values are supported:
+                                  * `NPS0`
+                                  * `NPS1`
+                                  * `NPS2`
+                                  * `NPS4`
                                 type: string
                             type: object
                           amdRomeBmPlatformConfig:
@@ -1563,15 +1538,14 @@ spec:
                               BM platform configuration
                             properties:
                               areVirtualInstructionsEnabled:
-                                description: Whether virtualization instructions are
-                                  available. For example, Secure Virtual Machine for
-                                  AMD shapes or VT-x for Intel shapes.
+                                description: |-
+                                  Whether virtualization instructions are available. For example, Secure Virtual Machine for AMD shapes
+                                  or VT-x for Intel shapes.
                                 type: boolean
                               isAccessControlServiceEnabled:
-                                description: Whether the Access Control Service is
-                                  enabled on the instance. When enabled, the platform
-                                  can enforce PCIe device isolation, required for
-                                  VFIO device pass-through.
+                                description: |-
+                                  Whether the Access Control Service is enabled on the instance. When enabled,
+                                  the platform can enforce PCIe device isolation, required for VFIO device pass-through.
                                 type: boolean
                               isInputOutputMemoryManagementUnitEnabled:
                                 description: Whether the input-output memory management
@@ -1592,39 +1566,35 @@ spec:
                                   instance.
                                 type: boolean
                               isSymmetricMultiThreadingEnabled:
-                                description: Whether symmetric multithreading is enabled
-                                  on the instance. Symmetric multithreading is also
-                                  called simultaneous multithreading (SMT) or Intel
-                                  Hyper-Threading. Intel and AMD processors have two
-                                  hardware execution threads per core (OCPU). SMT
-                                  permits multiple independent threads of execution,
-                                  to better use the resources and increase the efficiency
-                                  of the CPU. When multithreading is disabled, only
-                                  one thread is permitted to run on each core, which
-                                  can provide higher or more predictable performance
-                                  for some workloads.
+                                description: |-
+                                  Whether symmetric multithreading is enabled on the instance. Symmetric multithreading is also
+                                  called simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                                  Intel and AMD processors have two hardware execution threads per core (OCPU). SMT permits multiple
+                                  independent threads of execution, to better use the resources and increase the efficiency
+                                  of the CPU. When multithreading is disabled, only one thread is permitted to run on each core, which
+                                  can provide higher or more predictable performance for some workloads.
                                 type: boolean
                               isTrustedPlatformModuleEnabled:
                                 description: Whether the Trusted Platform Module (TPM)
                                   is enabled on the instance.
                                 type: boolean
                               numaNodesPerSocket:
-                                description: 'The number of NUMA nodes per socket
-                                  (NPS). The following values are supported: * `NPS0`
-                                  * `NPS1` * `NPS2` * `NPS4`'
+                                description: |-
+                                  The number of NUMA nodes per socket (NPS).
+                                  The following values are supported:
+                                  * `NPS0`
+                                  * `NPS1`
+                                  * `NPS2`
+                                  * `NPS4`
                                 type: string
                               percentageOfCoresEnabled:
-                                description: The percentage of cores enabled. Value
-                                  must be a multiple of 25%. If the requested percentage
-                                  results in a fractional number of cores, the system
-                                  rounds up the number of cores across processors
-                                  and provisions an instance with a whole number of
-                                  cores. If the applications that you run on the instance
-                                  use a core-based licensing model and need fewer
-                                  cores than the full size of the shape, you can disable
-                                  cores to reduce your licensing costs. The instance
-                                  itself is billed for the full shape, regardless
-                                  of whether all cores are enabled.
+                                description: |-
+                                  The percentage of cores enabled. Value must be a multiple of 25%. If the requested percentage
+                                  results in a fractional number of cores, the system rounds up the number of cores across processors
+                                  and provisions an instance with a whole number of cores.
+                                  If the applications that you run on the instance use a core-based licensing model and need fewer cores
+                                  than the full size of the shape, you can disable cores to reduce your licensing costs. The instance
+                                  itself is billed for the full shape, regardless of whether all cores are enabled.
                                 type: integer
                             type: object
                           amdVmPlatformConfig:
@@ -1673,39 +1643,33 @@ spec:
                                   instance.
                                 type: boolean
                               isSymmetricMultiThreadingEnabled:
-                                description: Whether symmetric multithreading is enabled
-                                  on the instance. Symmetric multithreading is also
-                                  called simultaneous multithreading (SMT) or Intel
-                                  Hyper-Threading. Intel and AMD processors have two
-                                  hardware execution threads per core (OCPU). SMT
-                                  permits multiple independent threads of execution,
-                                  to better use the resources and increase the efficiency
-                                  of the CPU. When multithreading is disabled, only
-                                  one thread is permitted to run on each core, which
-                                  can provide higher or more predictable performance
-                                  for some workloads.
+                                description: |-
+                                  Whether symmetric multithreading is enabled on the instance. Symmetric multithreading is also
+                                  called simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                                  Intel and AMD processors have two hardware execution threads per core (OCPU). SMT permits multiple
+                                  independent threads of execution, to better use the resources and increase the efficiency
+                                  of the CPU. When multithreading is disabled, only one thread is permitted to run on each core, which
+                                  can provide higher or more predictable performance for some workloads.
                                 type: boolean
                               isTrustedPlatformModuleEnabled:
                                 description: Whether the Trusted Platform Module (TPM)
                                   is enabled on the instance.
                                 type: boolean
                               numaNodesPerSocket:
-                                description: 'The number of NUMA nodes per socket
-                                  (NPS). The following values are supported: * `NPS1`
-                                  * `NPS2`'
+                                description: |-
+                                  The number of NUMA nodes per socket (NPS).
+                                  The following values are supported:
+                                  * `NPS1`
+                                  * `NPS2`
                                 type: string
                               percentageOfCoresEnabled:
-                                description: The percentage of cores enabled. Value
-                                  must be a multiple of 25%. If the requested percentage
-                                  results in a fractional number of cores, the system
-                                  rounds up the number of cores across processors
-                                  and provisions an instance with a whole number of
-                                  cores. If the applications that you run on the instance
-                                  use a core-based licensing model and need fewer
-                                  cores than the full size of the shape, you can disable
-                                  cores to reduce your licensing costs. The instance
-                                  itself is billed for the full shape, regardless
-                                  of whether all cores are enabled.
+                                description: |-
+                                  The percentage of cores enabled. Value must be a multiple of 25%. If the requested percentage
+                                  results in a fractional number of cores, the system rounds up the number of cores across processors
+                                  and provisions an instance with a whole number of cores.
+                                  If the applications that you run on the instance use a core-based licensing model and need fewer cores
+                                  than the full size of the shape, you can disable cores to reduce your licensing costs. The instance
+                                  itself is billed for the full shape, regardless of whether all cores are enabled.
                                 type: integer
                             type: object
                           intelSkylakeBmPlatformConfig:
@@ -1755,11 +1719,16 @@ spec:
                                 type: boolean
                             type: object
                           platformConfigType:
-                            description: The type of platform configuration. Valid
-                              values are * `AMD_ROME_BM_GPU` * `AMD_ROME_BM` * `INTEL_ICELAKE_BM`
-                              * `AMD_VM` * `INTEL_VM` * `INTEL_SKYLAKE_BM` * `AMD_MILAN_BM`
-                              Based on the enum, exactly one of the specific configuration
-                              types must be set
+                            description: |-
+                              The type of platform configuration. Valid values are
+                              * `AMD_ROME_BM_GPU`
+                              * `AMD_ROME_BM`
+                              * `INTEL_ICELAKE_BM`
+                              * `AMD_VM`
+                              * `INTEL_VM`
+                              * `INTEL_SKYLAKE_BM`
+                              * `AMD_MILAN_BM`
+                              Based on the enum, exactly one of the specific configuration types must be set
                             type: string
                         type: object
                       preemptibleInstanceConfig:
@@ -1779,20 +1748,19 @@ spec:
                             type: object
                         type: object
                       preserveBootVolume:
-                        description: Specifies whether to delete or preserve the boot
-                          volume when terminating an instance. When set to true, the
-                          boot volume is preserved. The default value is false.
+                        description: |-
+                          Specifies whether to delete or preserve the boot volume when terminating an instance.
+                          When set to true, the boot volume is preserved. The default value is false.
                         type: boolean
                       preserveDataVolumesCreatedAtLaunch:
-                        description: Specifies whether to delete or preserve the data
-                          volumes created during launch when terminating an instance.
-                          When set to true, the data volumes are preserved. The default
-                          value is true.
+                        description: |-
+                          Specifies whether to delete or preserve the data volumes created during launch when
+                          terminating an instance. When set to true, the data volumes are preserved. The default value is true.
                         type: boolean
                       providerID:
-                        description: Provider ID of the instance, this will be set
-                          by Cluster API provider itself, users should not set this
-                          parameter.
+                        description: |-
+                          Provider ID of the instance, this will be set by Cluster API provider itself,
+                          users should not set this parameter.
                         type: string
                       shape:
                         description: Shape of the instance.
@@ -1802,14 +1770,13 @@ spec:
                           for flex instances.
                         properties:
                           baselineOcpuUtilization:
-                            description: 'The baseline OCPU utilization for a subcore
-                              burstable VM instance. Leave this attribute blank for
-                              a non-burstable instance, or explicitly specify non-burstable
-                              with `BASELINE_1_1`. The following values are supported:
+                            description: |-
+                              The baseline OCPU utilization for a subcore burstable VM instance. Leave this attribute blank for a
+                              non-burstable instance, or explicitly specify non-burstable with `BASELINE_1_1`.
+                              The following values are supported:
                               - `BASELINE_1_8` - baseline usage is 1/8 of an OCPU.
                               - `BASELINE_1_2` - baseline usage is 1/2 of an OCPU.
-                              - `BASELINE_1_1` - baseline usage is an entire OCPU.
-                              This represents a non-burstable instance.'
+                              - `BASELINE_1_1` - baseline usage is an entire OCPU. This represents a non-burstable instance.
                             type: string
                           memoryInGBs:
                             description: The total amount of memory available to the
@@ -1825,40 +1792,36 @@ spec:
                             type: string
                         type: object
                       subnetName:
-                        description: The name of the subnet to use. The name here
-                          refers to the subnets defined in the OCICluster Spec. Optional,
-                          only if multiple subnets of a type is defined, else the
-                          first element is used.
+                        description: |-
+                          The name of the subnet to use. The name here refers to the subnets
+                          defined in the OCICluster Spec. Optional, only if multiple subnets of a type
+                          is defined, else the first element is used.
                         type: string
                       vnicAttachments:
-                        description: VnicAttachments defines the configuration options
-                          for the vnic(s) attached to the machine The network bandwidth
-                          and number of VNICs scale proportionately with the number
-                          of OCPUs.
+                        description: |-
+                          VnicAttachments defines the configuration options for the vnic(s) attached to the machine
+                          The network bandwidth and number of VNICs scale proportionately with the number of OCPUs.
                         items:
                           properties:
-                            assignIpv6Ip:
-                              description: assignIpv6Ip defines whether the VNIC should
-                                be assigned a IPv6.
-                              type: boolean
                             assignPublicIp:
                               description: AssignPublicIp defines whether the vnic
                                 should have a public IP address
                               type: boolean
                             displayName:
-                              description: DisplayName defines a user-friendly name.
-                                Does not have to be unique. Avoid entering confidential
-                                information.
+                              description: |-
+                                DisplayName defines a user-friendly name. Does not have to be unique.
+                                Avoid entering confidential information.
                               type: string
                             nicIndex:
-                              description: NicIndex defines which physical Network
-                                Interface Card (NIC) to use You can determine which
-                                NICs are active for a shape by reviewing the https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm
+                              description: |-
+                                NicIndex defines which physical Network Interface Card (NIC) to use
+                                You can determine which NICs are active for a shape by reviewing the
+                                https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm
                               type: integer
                             subnetName:
-                              description: SubnetName defines the subnet name to use
-                                for the VNIC Defaults to the "worker" subnet if not
-                                provided
+                              description: |-
+                                SubnetName defines the subnet name to use for the VNIC
+                                Defaults to the "worker" subnet if not provided
                               type: string
                             vnicAttachmentId:
                               description: VnicAttachmentId defines the ID of the

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimanagedclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimanagedclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: ocimanagedclusters.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -20,14 +20,19 @@ spec:
         description: OCIManagedCluster is the Schema for the ocimanagedclusters API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -45,10 +50,11 @@ spec:
                   has been created and the cluster has an endpoint address
                 properties:
                   host:
-                    description: The hostname on which the API server is serving.
+                    description: host is the hostname on which the API server is serving.
+                    maxLength: 512
                     type: string
                   port:
-                    description: The port on which the API server is serving.
+                    description: port is the port on which the API server is serving.
                     format: int32
                     type: integer
                 required:
@@ -60,10 +66,10 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
-                description: 'Defined tags for this resource. Each key is predefined
-                  and scoped to a namespace. For more information, see Resource Tags
-                  (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
-                  Example: `{"Operations": {"CostCenter": "42"}}`'
+                description: |-
+                  Defined tags for this resource. Each key is predefined and scoped to a
+                  namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+                  Example: `{"Operations": {"CostCenter": "42"}}`
                 type: object
               freeformTags:
                 additionalProperties:
@@ -78,33 +84,39 @@ spec:
                     description: API version of the referent.
                     type: string
                   fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
                     type: string
                   kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                     type: string
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                     type: string
                   namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                     type: string
                   resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                     type: string
                   uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
@@ -133,15 +145,15 @@ spec:
                                   soon as current backend becomes unhealthy.
                                 properties:
                                   urlPath:
-                                    description: 'The path against which to run the
-                                      health check. Example: `/healthcheck` Default
-                                      value is `/healthz`'
+                                    description: |-
+                                      The path against which to run the health check.
+                                      Example: `/healthcheck`
+                                      Default value is `/healthz`
                                     type: string
                                 type: object
                               isFailOpen:
-                                description: If enabled, the network load balancer
-                                  will continue to distribute traffic in the configured
-                                  distribution in the event all backends are unhealthy.
+                                description: |-
+                                  If enabled, the network load balancer will continue to distribute traffic in the configured distribution in the event all backends are unhealthy.
                                   The value is false by default.
                                 type: boolean
                               isInstantFailoverEnabled:
@@ -150,27 +162,29 @@ spec:
                                   soon as current backend becomes unhealthy.
                                 type: boolean
                               isPreserveSource:
-                                description: If this parameter is enabled, then the
-                                  network load balancer preserves the source IP of
-                                  the packet when it is forwarded to backends. Backends
-                                  see the original source IP. If the isPreserveSourceDestination
-                                  parameter is enabled for the network load balancer
-                                  resource, then this parameter cannot be disabled.
+                                description: |-
+                                  If this parameter is enabled, then the network load balancer preserves the source IP of the packet when it is forwarded to backends.
+                                  Backends see the original source IP. If the isPreserveSourceDestination parameter is enabled for the network load balancer resource, then this parameter cannot be disabled.
                                   The value is false by default.
                                 type: boolean
                             type: object
                         type: object
                     type: object
+                  compartmentId:
+                    description: CompartmentId where to provision network resources
+                    type: string
                   skipNetworkManagement:
-                    description: SkipNetworkManagement defines if the networking spec(VCN
-                      related) specified by the user needs to be reconciled(actioned-upon)
+                    description: |-
+                      SkipNetworkManagement defines if the networking spec(VCN related) specified by the user needs to be reconciled(actioned-upon)
                       or used as it is. APIServerLB will still be reconciled.
                     type: boolean
                   vcn:
                     description: VCN configuration.
                     properties:
                       cidr:
-                        description: VCN CIDR. Deprecated, please use NetworkDetails.cidrs
+                        description: |-
+                          VCN CIDR.
+                          Deprecated, please use NetworkDetails.cidrs
                         type: string
                       cidrs:
                         description: VCN CIDRs.
@@ -178,20 +192,25 @@ spec:
                           type: string
                         type: array
                       dnsLabel:
-                        description: DnsLabel specifies a DNS label for the VCN, used
-                          in conjunction with the VNIC's hostname and subnet's DNS
-                          label to form a fully qualified domain name (FQDN) for each
-                          VNIC within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
+                        description: |-
+                          DnsLabel specifies a DNS label for the VCN, used in conjunction with the VNIC's hostname and
+                          subnet's DNS label to form a fully qualified domain name (FQDN) for each VNIC
+                          within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
                         type: string
                       id:
                         description: VCN OCID.
                         type: string
-                      skip:
-                        description: Skip specifies whether to skip creating vcn
-                        type: boolean
                       internetGatewayId:
                         description: ID of Internet Gateway.
                         type: string
+                      isIpv6Enabled:
+                        description: Configuration to enable IPv6.
+                        type: boolean
+                      isOracleGuaAllocationEnabled:
+                        description: Configuration to allow OCI to assign IPv6 Prefix.
+                          When true will use a /56 IPv6 global unicast address (GUA)
+                          prefix allocated by Oracle
+                        type: boolean
                       name:
                         description: VCN Name.
                         type: string
@@ -202,8 +221,9 @@ spec:
                         description: NetworkSecurityGroups is the configuration for
                           the Network Security Groups required in the VCN.
                         items:
-                          description: NSG defines configuration for a Network Security
-                            Group. https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/networksecuritygroups.htm
+                          description: |-
+                            NSG defines configuration for a Network Security Group.
+                            https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/networksecuritygroups.htm
                           properties:
                             egressRules:
                               description: EgressRules on the NSG.
@@ -220,47 +240,37 @@ spec:
                                           choice for the rule.
                                         type: string
                                       destination:
-                                        description: 'Conceptually, this is the range
-                                          of IP addresses that a packet originating
-                                          from the instance can go to. Allowed values:
-                                          * IP address range in CIDR notation. For
-                                          example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-                                          Note that IPv6 addressing is currently supported
-                                          only in certain regions. See IPv6 Addresses
-                                          (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                          * The `cidrBlock` value for a Service, if
-                                          you''re setting up a security list rule
-                                          for traffic destined for a particular `Service`
-                                          through a service gateway. For example:
-                                          `oci-phx-objectstorage`.'
+                                        description: |-
+                                          Conceptually, this is the range of IP addresses that a packet originating from the instance
+                                          can go to.
+                                          Allowed values:
+                                            * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
+                                              Note that IPv6 addressing is currently supported only in certain regions. See
+                                              IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                            * The `cidrBlock` value for a Service, if you're
+                                              setting up a security list rule for traffic destined for a particular `Service` through
+                                              a service gateway. For example: `oci-phx-objectstorage`.
                                         type: string
                                       destinationType:
-                                        description: 'Type of destination for the
-                                          rule. The default is `CIDR_BLOCK`. Allowed
-                                          values: * `CIDR_BLOCK`: If the rule''s `destination`
-                                          is an IP address range in CIDR notation.
-                                          * `SERVICE_CIDR_BLOCK`: If the rule''s `destination`
-                                          is the `cidrBlock` value for a Service (the
-                                          rule is for traffic destined for a particular
-                                          `Service` through a service gateway).'
+                                        description: |-
+                                          Type of destination for the rule. The default is `CIDR_BLOCK`.
+                                          Allowed values:
+                                            * `CIDR_BLOCK`: If the rule's `destination` is an IP address range in CIDR notation.
+                                            * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
+                                              Service (the rule is for traffic destined for a
+                                              particular `Service` through a service gateway).
                                         type: string
                                       icmpOptions:
-                                        description: 'IcmpOptions Optional and valid
-                                          only for ICMP and ICMPv6. Use to specify
-                                          a particular ICMP type and code as defined
-                                          in: - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                        description: |-
+                                          IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                          as defined in:
+                                          - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                           - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                          If you specify ICMP or ICMPv6 as the protocol
-                                          but omit this object, then all ICMP types
-                                          and codes are allowed. If you do provide
-                                          this object, the type is required and the
-                                          code is optional. To enable MTU negotiation
-                                          for ingress internet traffic via IPv4, make
-                                          sure to allow type 3 ("Destination Unreachable")
-                                          code 4 ("Fragmentation Needed and Don''t
-                                          Fragment was Set"). If you need to specify
-                                          multiple codes for a single type, create
-                                          a separate security list rule for each.'
+                                          If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                          codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                          To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                          Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                          multiple codes for a single type, create a separate security list rule for each.
                                         properties:
                                           code:
                                             description: The ICMP code (optional).
@@ -270,41 +280,33 @@ spec:
                                             type: integer
                                         type: object
                                       isStateless:
-                                        description: A stateless rule allows traffic
-                                          in one direction. Remember to add a corresponding
-                                          stateless rule in the other direction if
-                                          you need to support bidirectional traffic.
-                                          For example, if egress traffic allows TCP
-                                          destination port 80, there should be an
-                                          ingress rule to allow TCP source port 80.
-                                          Defaults to false, which means the rule
-                                          is stateful and a corresponding rule is
-                                          not necessary for bidirectional traffic.
+                                        description: |-
+                                          A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                          stateless rule in the other direction if you need to support bidirectional traffic. For
+                                          example, if egress traffic allows TCP destination port 80, there should be an ingress
+                                          rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                          and a corresponding rule is not necessary for bidirectional traffic.
                                         type: boolean
                                       protocol:
-                                        description: The transport protocol. Specify
-                                          either `all` or an IPv4 protocol number
-                                          as defined in Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                          Options are supported only for ICMP ("1"),
-                                          TCP ("6"), UDP ("17"), and ICMPv6 ("58").
+                                        description: |-
+                                          The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                          defined in
+                                          Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                          Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                         type: string
                                       tcpOptions:
-                                        description: TcpOptions Optional and valid
-                                          only for TCP. Use to specify particular
-                                          destination ports for TCP rules. If you
-                                          specify TCP as the protocol but omit this
-                                          object, then all destination ports are allowed.
+                                        description: |-
+                                          TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                          If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                         properties:
                                           destinationPortRange:
                                             description: PortRange The representation
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -317,11 +319,9 @@ spec:
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -331,22 +331,18 @@ spec:
                                             type: object
                                         type: object
                                       udpOptions:
-                                        description: UdpOptions Optional and valid
-                                          only for UDP. Use to specify particular
-                                          destination ports for UDP rules. If you
-                                          specify UDP as the protocol but omit this
-                                          object, then all destination ports are allowed.
+                                        description: |-
+                                          UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                          If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                         properties:
                                           destinationPortRange:
                                             description: PortRange The representation
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -359,11 +355,9 @@ spec:
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -374,9 +368,9 @@ spec:
                                         type: object
                                     type: object
                                   id:
-                                    description: 'EgressSecurityRule ID for NSG. Deprecated:
-                                      this field is not populated and used during
-                                      reconciliation'
+                                    description: |-
+                                      EgressSecurityRule ID for NSG.
+                                      Deprecated: this field is not populated and used during reconciliation
                                     type: string
                                 type: object
                               type: array
@@ -390,9 +384,9 @@ spec:
                                   for NSG
                                 properties:
                                   id:
-                                    description: 'IngressSecurityRule ID for NSG.
-                                      Deprecated: this field is not populated and
-                                      used during reconciliation'
+                                    description: |-
+                                      IngressSecurityRule ID for NSG.
+                                      Deprecated: this field is not populated and used during reconciliation
                                     type: string
                                   ingressRule:
                                     description: IngressSecurityRule A rule for allowing
@@ -403,22 +397,16 @@ spec:
                                           choice for the rule.
                                         type: string
                                       icmpOptions:
-                                        description: 'IcmpOptions Optional and valid
-                                          only for ICMP and ICMPv6. Use to specify
-                                          a particular ICMP type and code as defined
-                                          in: - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                        description: |-
+                                          IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                          as defined in:
+                                          - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                           - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                          If you specify ICMP or ICMPv6 as the protocol
-                                          but omit this object, then all ICMP types
-                                          and codes are allowed. If you do provide
-                                          this object, the type is required and the
-                                          code is optional. To enable MTU negotiation
-                                          for ingress internet traffic via IPv4, make
-                                          sure to allow type 3 ("Destination Unreachable")
-                                          code 4 ("Fragmentation Needed and Don''t
-                                          Fragment was Set"). If you need to specify
-                                          multiple codes for a single type, create
-                                          a separate security list rule for each.'
+                                          If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                          codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                          To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                          Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                          multiple codes for a single type, create a separate security list rule for each.
                                         properties:
                                           code:
                                             description: The ICMP code (optional).
@@ -428,66 +416,53 @@ spec:
                                             type: integer
                                         type: object
                                       isStateless:
-                                        description: A stateless rule allows traffic
-                                          in one direction. Remember to add a corresponding
-                                          stateless rule in the other direction if
-                                          you need to support bidirectional traffic.
-                                          For example, if ingress traffic allows TCP
-                                          destination port 80, there should be an
-                                          egress rule to allow TCP source port 80.
-                                          Defaults to false, which means the rule
-                                          is stateful and a corresponding rule is
-                                          not necessary for bidirectional traffic.
+                                        description: |-
+                                          A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                          stateless rule in the other direction if you need to support bidirectional traffic. For
+                                          example, if ingress traffic allows TCP destination port 80, there should be an egress
+                                          rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                          and a corresponding rule is not necessary for bidirectional traffic.
                                         type: boolean
                                       protocol:
-                                        description: The transport protocol. Specify
-                                          either `all` or an IPv4 protocol number
-                                          as defined in Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                          Options are supported only for ICMP ("1"),
-                                          TCP ("6"), UDP ("17"), and ICMPv6 ("58").
+                                        description: |-
+                                          The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                          defined in
+                                          Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                          Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                         type: string
                                       source:
-                                        description: 'Conceptually, this is the range
-                                          of IP addresses that a packet coming into
-                                          the instance can come from. Allowed values:
-                                          * IP address range in CIDR notation. For
-                                          example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
-                                          IPv6 addressing is supported for all commercial
-                                          and government regions. See IPv6 Addresses
-                                          (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                          * The `cidrBlock` value for a Service, if
-                                          you''re setting up a security list rule
-                                          for traffic coming from a particular `Service`
-                                          through a service gateway. For example:
-                                          `oci-phx-objectstorage`.'
+                                        description: |-
+                                          Conceptually, this is the range of IP addresses that a packet coming into the instance
+                                          can come from.
+                                          Allowed values:
+                                            * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
+                                              IPv6 addressing is supported for all commercial and government regions. See
+                                              IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                            * The `cidrBlock` value for a Service, if you're
+                                              setting up a security list rule for traffic coming from a particular `Service` through
+                                              a service gateway. For example: `oci-phx-objectstorage`.
                                         type: string
                                       sourceType:
-                                        description: 'Type of source for the rule.
-                                          The default is `CIDR_BLOCK`. * `CIDR_BLOCK`:
-                                          If the rule''s `source` is an IP address
-                                          range in CIDR notation. * `SERVICE_CIDR_BLOCK`:
-                                          If the rule''s `source` is the `cidrBlock`
-                                          value for a Service (the rule is for traffic
-                                          coming from a particular `Service` through
-                                          a service gateway).'
+                                        description: |-
+                                          Type of source for the rule. The default is `CIDR_BLOCK`.
+                                            * `CIDR_BLOCK`: If the rule's `source` is an IP address range in CIDR notation.
+                                            * `SERVICE_CIDR_BLOCK`: If the rule's `source` is the `cidrBlock` value for a
+                                              Service (the rule is for traffic coming from a
+                                              particular `Service` through a service gateway).
                                         type: string
                                       tcpOptions:
-                                        description: TcpOptions Optional and valid
-                                          only for TCP. Use to specify particular
-                                          destination ports for TCP rules. If you
-                                          specify TCP as the protocol but omit this
-                                          object, then all destination ports are allowed.
+                                        description: |-
+                                          TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                          If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                         properties:
                                           destinationPortRange:
                                             description: PortRange The representation
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -500,11 +475,9 @@ spec:
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -514,22 +487,18 @@ spec:
                                             type: object
                                         type: object
                                       udpOptions:
-                                        description: UdpOptions Optional and valid
-                                          only for UDP. Use to specify particular
-                                          destination ports for UDP rules. If you
-                                          specify UDP as the protocol but omit this
-                                          object, then all destination ports are allowed.
+                                        description: |-
+                                          UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                          If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                         properties:
                                           destinationPortRange:
                                             description: PortRange The representation
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -542,11 +511,9 @@ spec:
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -581,28 +548,39 @@ spec:
                       serviceGatewayId:
                         description: ID of Service Gateway.
                         type: string
+                      skip:
+                        description: |-
+                          Skip specifies whether to skip creating VCN.
+                          When is set to true, InternetGateway, NatGateway, ServiceGateway, RouteTable must have also Skip set to true
+                          If set to true(default: false) the ID must be specified by the user to a valid VCN ID.
+                        type: boolean
                       subnets:
                         description: Subnets is the configuration for subnets required
                           in the VCN.
                         items:
-                          description: Subnet defines the configuration for a network's
-                            subnet https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingVCNs_topic-Overview_of_VCNs_and_Subnets.htm#Overview
+                          description: |-
+                            Subnet defines the configuration for a network's subnet
+                            https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingVCNs_topic-Overview_of_VCNs_and_Subnets.htm#Overview
                           properties:
                             cidr:
                               description: Subnet CIDR.
                               type: string
                             dnsLabel:
-                              description: DnsLabel DNS label for the subnet, used
-                                in conjunction with the VNIC's hostname and VCN's
-                                DNS label to form a fully qualified domain name (FQDN)
-                                for each VNIC within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
+                              description: |-
+                                DnsLabel DNS label for the subnet, used in conjunction with the VNIC's hostname and
+                                VCN's DNS label to form a fully qualified domain name (FQDN) for each VNIC
+                                within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
                               type: string
                             id:
                               description: Subnet OCID.
                               type: string
-                            skip:
-                              description: Skip specifies whether to skip creating subnet
-                              type: boolean
+                            ipv6CidrBlockHextet:
+                              description: |-
+                                Use this to enable IPv6 hextet for this subnet. The VCN must be enabled for IPv6.
+                                You can't change this subnet characteristic later. All subnets are /64 in size. The subnet
+                                portion of the IPv6 address is the fourth hextet from the left (1111 in the following example).
+                                Example: `2001:0db8:0123:1111::/64`
+                              type: string
                             name:
                               description: Subnet Name.
                               type: string
@@ -624,47 +602,37 @@ spec:
                                           choice for the rule.
                                         type: string
                                       destination:
-                                        description: 'Conceptually, this is the range
-                                          of IP addresses that a packet originating
-                                          from the instance can go to. Allowed values:
-                                          * IP address range in CIDR notation. For
-                                          example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-                                          Note that IPv6 addressing is currently supported
-                                          only in certain regions. See IPv6 Addresses
-                                          (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                          * The `cidrBlock` value for a Service, if
-                                          you''re setting up a security list rule
-                                          for traffic destined for a particular `Service`
-                                          through a service gateway. For example:
-                                          `oci-phx-objectstorage`.'
+                                        description: |-
+                                          Conceptually, this is the range of IP addresses that a packet originating from the instance
+                                          can go to.
+                                          Allowed values:
+                                            * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
+                                              Note that IPv6 addressing is currently supported only in certain regions. See
+                                              IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                            * The `cidrBlock` value for a Service, if you're
+                                              setting up a security list rule for traffic destined for a particular `Service` through
+                                              a service gateway. For example: `oci-phx-objectstorage`.
                                         type: string
                                       destinationType:
-                                        description: 'Type of destination for the
-                                          rule. The default is `CIDR_BLOCK`. Allowed
-                                          values: * `CIDR_BLOCK`: If the rule''s `destination`
-                                          is an IP address range in CIDR notation.
-                                          * `SERVICE_CIDR_BLOCK`: If the rule''s `destination`
-                                          is the `cidrBlock` value for a Service (the
-                                          rule is for traffic destined for a particular
-                                          `Service` through a service gateway).'
+                                        description: |-
+                                          Type of destination for the rule. The default is `CIDR_BLOCK`.
+                                          Allowed values:
+                                            * `CIDR_BLOCK`: If the rule's `destination` is an IP address range in CIDR notation.
+                                            * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
+                                              Service (the rule is for traffic destined for a
+                                              particular `Service` through a service gateway).
                                         type: string
                                       icmpOptions:
-                                        description: 'IcmpOptions Optional and valid
-                                          only for ICMP and ICMPv6. Use to specify
-                                          a particular ICMP type and code as defined
-                                          in: - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                        description: |-
+                                          IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                          as defined in:
+                                          - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                           - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                          If you specify ICMP or ICMPv6 as the protocol
-                                          but omit this object, then all ICMP types
-                                          and codes are allowed. If you do provide
-                                          this object, the type is required and the
-                                          code is optional. To enable MTU negotiation
-                                          for ingress internet traffic via IPv4, make
-                                          sure to allow type 3 ("Destination Unreachable")
-                                          code 4 ("Fragmentation Needed and Don''t
-                                          Fragment was Set"). If you need to specify
-                                          multiple codes for a single type, create
-                                          a separate security list rule for each.'
+                                          If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                          codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                          To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                          Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                          multiple codes for a single type, create a separate security list rule for each.
                                         properties:
                                           code:
                                             description: The ICMP code (optional).
@@ -674,41 +642,33 @@ spec:
                                             type: integer
                                         type: object
                                       isStateless:
-                                        description: A stateless rule allows traffic
-                                          in one direction. Remember to add a corresponding
-                                          stateless rule in the other direction if
-                                          you need to support bidirectional traffic.
-                                          For example, if egress traffic allows TCP
-                                          destination port 80, there should be an
-                                          ingress rule to allow TCP source port 80.
-                                          Defaults to false, which means the rule
-                                          is stateful and a corresponding rule is
-                                          not necessary for bidirectional traffic.
+                                        description: |-
+                                          A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                          stateless rule in the other direction if you need to support bidirectional traffic. For
+                                          example, if egress traffic allows TCP destination port 80, there should be an ingress
+                                          rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                          and a corresponding rule is not necessary for bidirectional traffic.
                                         type: boolean
                                       protocol:
-                                        description: The transport protocol. Specify
-                                          either `all` or an IPv4 protocol number
-                                          as defined in Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                          Options are supported only for ICMP ("1"),
-                                          TCP ("6"), UDP ("17"), and ICMPv6 ("58").
+                                        description: |-
+                                          The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                          defined in
+                                          Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                          Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                         type: string
                                       tcpOptions:
-                                        description: TcpOptions Optional and valid
-                                          only for TCP. Use to specify particular
-                                          destination ports for TCP rules. If you
-                                          specify TCP as the protocol but omit this
-                                          object, then all destination ports are allowed.
+                                        description: |-
+                                          TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                          If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                         properties:
                                           destinationPortRange:
                                             description: PortRange The representation
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -721,11 +681,9 @@ spec:
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -735,22 +693,18 @@ spec:
                                             type: object
                                         type: object
                                       udpOptions:
-                                        description: UdpOptions Optional and valid
-                                          only for UDP. Use to specify particular
-                                          destination ports for UDP rules. If you
-                                          specify UDP as the protocol but omit this
-                                          object, then all destination ports are allowed.
+                                        description: |-
+                                          UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                          If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                         properties:
                                           destinationPortRange:
                                             description: PortRange The representation
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -763,11 +717,9 @@ spec:
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -792,22 +744,16 @@ spec:
                                           choice for the rule.
                                         type: string
                                       icmpOptions:
-                                        description: 'IcmpOptions Optional and valid
-                                          only for ICMP and ICMPv6. Use to specify
-                                          a particular ICMP type and code as defined
-                                          in: - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                        description: |-
+                                          IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                          as defined in:
+                                          - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                           - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                          If you specify ICMP or ICMPv6 as the protocol
-                                          but omit this object, then all ICMP types
-                                          and codes are allowed. If you do provide
-                                          this object, the type is required and the
-                                          code is optional. To enable MTU negotiation
-                                          for ingress internet traffic via IPv4, make
-                                          sure to allow type 3 ("Destination Unreachable")
-                                          code 4 ("Fragmentation Needed and Don''t
-                                          Fragment was Set"). If you need to specify
-                                          multiple codes for a single type, create
-                                          a separate security list rule for each.'
+                                          If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                          codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                          To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                          Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                          multiple codes for a single type, create a separate security list rule for each.
                                         properties:
                                           code:
                                             description: The ICMP code (optional).
@@ -817,66 +763,53 @@ spec:
                                             type: integer
                                         type: object
                                       isStateless:
-                                        description: A stateless rule allows traffic
-                                          in one direction. Remember to add a corresponding
-                                          stateless rule in the other direction if
-                                          you need to support bidirectional traffic.
-                                          For example, if ingress traffic allows TCP
-                                          destination port 80, there should be an
-                                          egress rule to allow TCP source port 80.
-                                          Defaults to false, which means the rule
-                                          is stateful and a corresponding rule is
-                                          not necessary for bidirectional traffic.
+                                        description: |-
+                                          A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                          stateless rule in the other direction if you need to support bidirectional traffic. For
+                                          example, if ingress traffic allows TCP destination port 80, there should be an egress
+                                          rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                          and a corresponding rule is not necessary for bidirectional traffic.
                                         type: boolean
                                       protocol:
-                                        description: The transport protocol. Specify
-                                          either `all` or an IPv4 protocol number
-                                          as defined in Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                          Options are supported only for ICMP ("1"),
-                                          TCP ("6"), UDP ("17"), and ICMPv6 ("58").
+                                        description: |-
+                                          The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                          defined in
+                                          Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                          Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                         type: string
                                       source:
-                                        description: 'Conceptually, this is the range
-                                          of IP addresses that a packet coming into
-                                          the instance can come from. Allowed values:
-                                          * IP address range in CIDR notation. For
-                                          example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
-                                          IPv6 addressing is supported for all commercial
-                                          and government regions. See IPv6 Addresses
-                                          (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                          * The `cidrBlock` value for a Service, if
-                                          you''re setting up a security list rule
-                                          for traffic coming from a particular `Service`
-                                          through a service gateway. For example:
-                                          `oci-phx-objectstorage`.'
+                                        description: |-
+                                          Conceptually, this is the range of IP addresses that a packet coming into the instance
+                                          can come from.
+                                          Allowed values:
+                                            * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
+                                              IPv6 addressing is supported for all commercial and government regions. See
+                                              IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                            * The `cidrBlock` value for a Service, if you're
+                                              setting up a security list rule for traffic coming from a particular `Service` through
+                                              a service gateway. For example: `oci-phx-objectstorage`.
                                         type: string
                                       sourceType:
-                                        description: 'Type of source for the rule.
-                                          The default is `CIDR_BLOCK`. * `CIDR_BLOCK`:
-                                          If the rule''s `source` is an IP address
-                                          range in CIDR notation. * `SERVICE_CIDR_BLOCK`:
-                                          If the rule''s `source` is the `cidrBlock`
-                                          value for a Service (the rule is for traffic
-                                          coming from a particular `Service` through
-                                          a service gateway).'
+                                        description: |-
+                                          Type of source for the rule. The default is `CIDR_BLOCK`.
+                                            * `CIDR_BLOCK`: If the rule's `source` is an IP address range in CIDR notation.
+                                            * `SERVICE_CIDR_BLOCK`: If the rule's `source` is the `cidrBlock` value for a
+                                              Service (the rule is for traffic coming from a
+                                              particular `Service` through a service gateway).
                                         type: string
                                       tcpOptions:
-                                        description: TcpOptions Optional and valid
-                                          only for TCP. Use to specify particular
-                                          destination ports for TCP rules. If you
-                                          specify TCP as the protocol but omit this
-                                          object, then all destination ports are allowed.
+                                        description: |-
+                                          TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                          If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                         properties:
                                           destinationPortRange:
                                             description: PortRange The representation
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -889,11 +822,9 @@ spec:
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -903,22 +834,18 @@ spec:
                                             type: object
                                         type: object
                                       udpOptions:
-                                        description: UdpOptions Optional and valid
-                                          only for UDP. Use to specify particular
-                                          destination ports for UDP rules. If you
-                                          specify UDP as the protocol but omit this
-                                          object, then all destination ports are allowed.
+                                        description: |-
+                                          UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                          If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                         properties:
                                           destinationPortRange:
                                             description: PortRange The representation
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -931,11 +858,9 @@ spec:
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -950,6 +875,11 @@ spec:
                                   description: SecurityList Name.
                                   type: string
                               type: object
+                            skip:
+                              description: |-
+                                Skip specifies whether to skip creating subnets. If set to true (default: false) the ID
+                                must be specified by the user to a valid Subnet ID.
+                              type: boolean
                             type:
                               description: Type defines the subnet type (e.g. public,
                                 private).
@@ -967,76 +897,72 @@ spec:
                     description: VCNPeering configuration.
                     properties:
                       drg:
-                        description: DRG configuration refers to the DRG which has
-                          to be created if required. If management cluster and workload
-                          cluster shares the same DRG, this fields is not required
-                          to be specified.
+                        description: |-
+                          DRG configuration refers to the DRG which has to be created if required. If management cluster
+                          and workload cluster shares the same DRG, this fields is not required to be specified.
                         properties:
                           id:
                             description: ID is the OCID for the created DRG.
                             type: string
                           manage:
-                            description: Manage defines whether the DRG has to be
-                              managed(including create). If set to false(the default)
-                              the ID has to be specified by the user to a valid DRG
-                              ID to which the VCN has to be attached.
+                            description: |-
+                              Manage defines whether the DRG has to be managed(including create). If set to false(the default) the ID
+                              has to be specified by the user to a valid DRG ID to which the VCN has to be attached.
                             type: boolean
                           name:
                             description: Name is the name of the created DRG.
                             type: string
                           vcnAttachmentId:
-                            description: VcnAttachmentId is the ID of the VCN attachment
-                              of the DRG. The workload cluster VCN can be attached
-                              to either the management cluster VCN if they are sharing
-                              the same DRG or to the workload cluster DRG.
+                            description: |-
+                              VcnAttachmentId is the ID of the VCN attachment of the DRG.
+                              The workload cluster VCN can be attached to either the management cluster VCN if they are sharing the same DRG
+                              or to the workload cluster DRG.
                             type: string
                         type: object
                       peerRouteRules:
-                        description: PeerRouteRules defines the routing rules which
-                          will be added to the private route tables of the workload
-                          cluster VCN. The routes defined here will be directed to
-                          DRG.
+                        description: |-
+                          PeerRouteRules defines the routing rules which will be added to the private route tables
+                          of the workload cluster VCN. The routes defined here will be directed to DRG.
                         items:
                           description: PeerRouteRule defines a Route Rule to be routed
                             via a DRG.
                           properties:
                             vcnCIDRRange:
-                              description: VCNCIDRRange is the CIDR Range of peer
-                                VCN to which the workload cluster VCN will be peered.
-                                The CIDR range is required to add the route rule in
-                                the workload cluster VCN, the route rule will forward
-                                any traffic to the CIDR to the DRG.
+                              description: |-
+                                VCNCIDRRange is the CIDR Range of peer VCN to which the
+                                workload cluster VCN will be peered. The CIDR range is required to add the route rule
+                                in the workload cluster VCN, the route rule will forward any traffic to the CIDR to the DRG.
                               type: string
                           type: object
                         type: array
                       remotePeeringConnections:
-                        description: RemotePeeringConnections defines the RPC connections
-                          which be established with the workload cluster DRG.
+                        description: |-
+                          RemotePeeringConnections defines the RPC connections which be established with the
+                          workload cluster DRG.
                         items:
-                          description: RemotePeeringConnection is used to peer VCNs
-                            residing in different regions(typically). Remote VCN Peering
-                            is explained here - https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/remoteVCNpeering.htm
+                          description: |-
+                            RemotePeeringConnection is used to peer VCNs residing in different regions(typically).
+                            Remote VCN Peering is explained here - https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/remoteVCNpeering.htm
                           properties:
                             managePeerRPC:
-                              description: ManagePeerRPC will define if the Peer VCN
-                                needs to be managed. If set to true a Remote Peering
-                                Connection will be created in the Peer DRG and the
-                                connection will be created between local and peer
-                                RPC.
+                              description: |-
+                                ManagePeerRPC will define if the Peer VCN needs to be managed. If set to true
+                                a Remote Peering Connection will be created in the Peer DRG and the connection
+                                will be created between local and peer RPC.
                               type: boolean
                             name:
-                              description: A unique name identifying the RPC, please
-                                note this is to identify the RPC from other RPC elements,
-                                and will not be used in any OCI API call.
+                              description: |-
+                                A unique name identifying the RPC, please note this is to identify the RPC
+                                from other RPC elements, and will not be used in any OCI API call.
                               type: string
                             peerDRGId:
                               description: PeerDRGId defines the DRG ID of the peer.
                               type: string
                             peerRPCConnectionId:
-                              description: PeerRPCConnectionId defines the RPC ID
-                                of peer. If ManagePeerRPC is set to true this will
-                                be created by Cluster API Provider for OCI, otherwise
-                                this has be defined by the user.
+                              description: |-
+                                PeerRPCConnectionId defines the RPC ID of peer. If ManagePeerRPC is set to true
+                                this will be created by Cluster API Provider for OCI, otherwise this has be defined by the
+                                user.
                               type: string
                             peerRegionName:
                               description: PeerRegionName defined the region name
@@ -1051,14 +977,15 @@ spec:
                     type: object
                 type: object
               ociResourceIdentifier:
-                description: The unique ID which will be used to tag all the resources
-                  created by this Cluster. The tag will be used to identify resources
-                  belonging to this cluster. this will be auto-generated and should
-                  not be set by the user.
+                description: |-
+                  The unique ID which will be used to tag all the resources created by this Cluster.
+                  The tag will be used to identify resources belonging to this cluster.
+                  this will be auto-generated and should not be set by the user.
                 type: string
               region:
-                description: Region the cluster operates in. It must be one of available
-                  regions in Region Identifier format. See https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm
+                description: |-
+                  Region the cluster operates in. It must be one of available regions in Region Identifier format.
+                  See https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm
                 type: string
             type: object
           status:
@@ -1079,9 +1006,9 @@ spec:
                       description: 'Name is the AD''s full name. Example: Uocm:PHX-AD-1'
                       type: string
                   type: object
-                description: AvailabilityDomains encapsulates the clusters Availability
-                  Domain (AD) information in a map where the map key is the AD name
-                  and the struct is details about the AD.
+                description: |-
+                  AvailabilityDomains encapsulates the clusters Availability Domain (AD) information in a map
+                  where the map key is the AD name and the struct is details about the AD.
                 type: object
               conditions:
                 description: NetworkSpec encapsulates all things related to OCI network.
@@ -1090,37 +1017,44 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
+                      description: status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -1130,18 +1064,18 @@ spec:
                 type: array
               failureDomains:
                 additionalProperties:
-                  description: FailureDomainSpec is the Schema for Cluster API failure
-                    domains. It allows controllers to understand how many failure
-                    domains a cluster can optionally span across.
+                  description: |-
+                    FailureDomainSpec is the Schema for Cluster API failure domains.
+                    It allows controllers to understand how many failure domains a cluster can optionally span across.
                   properties:
                     attributes:
                       additionalProperties:
                         type: string
-                      description: Attributes is a free form map of attributes an
+                      description: attributes is a free form map of attributes an
                         infrastructure provider might use or require.
                       type: object
                     controlPlane:
-                      description: ControlPlane determines if this failure domain
+                      description: controlPlane determines if this failure domain
                         is suitable for use by control plane machines.
                       type: boolean
                   type: object
@@ -1161,14 +1095,19 @@ spec:
         description: OCIManagedCluster is the Schema for the ocimanagedclusters API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -1191,9 +1130,9 @@ spec:
                       description: 'Name is the AD''s full name. Example: Uocm:PHX-AD-1'
                       type: string
                   type: object
-                description: AvailabilityDomains encapsulates the clusters Availability
-                  Domain (AD) information in a map where the map key is the AD name
-                  and the struct is details about the AD.
+                description: |-
+                  AvailabilityDomains encapsulates the clusters Availability Domain (AD) information in a map
+                  where the map key is the AD name and the struct is details about the AD.
                 type: object
               compartmentId:
                 description: Compartment to create the cluster network.
@@ -1205,10 +1144,11 @@ spec:
                   has been created and the cluster has an endpoint address
                 properties:
                   host:
-                    description: The hostname on which the API server is serving.
+                    description: host is the hostname on which the API server is serving.
+                    maxLength: 512
                     type: string
                   port:
-                    description: The port on which the API server is serving.
+                    description: port is the port on which the API server is serving.
                     format: int32
                     type: integer
                 required:
@@ -1220,10 +1160,10 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
-                description: 'Defined tags for this resource. Each key is predefined
-                  and scoped to a namespace. For more information, see Resource Tags
-                  (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
-                  Example: `{"Operations": {"CostCenter": "42"}}`'
+                description: |-
+                  Defined tags for this resource. Each key is predefined and scoped to a
+                  namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+                  Example: `{"Operations": {"CostCenter": "42"}}`
                 type: object
               freeformTags:
                 additionalProperties:
@@ -1236,9 +1176,9 @@ spec:
                 nullable: true
                 properties:
                   certOverride:
-                    description: CertOverride is a secret that contains information
-                      about a cert override used by all the OCI SDK clients. The secret
-                      must contain data with a `cert`property.
+                    description: |-
+                      CertOverride is a secret that contains information about a cert override used by all the OCI SDK clients.
+                      The secret must contain data with a `cert`property.
                     nullable: true
                     properties:
                       name:
@@ -1300,33 +1240,39 @@ spec:
                     description: API version of the referent.
                     type: string
                   fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
                     type: string
                   kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                     type: string
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                     type: string
                   namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                     type: string
                   resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                     type: string
                   uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
@@ -1358,15 +1304,15 @@ spec:
                                   soon as current backend becomes unhealthy.
                                 properties:
                                   urlPath:
-                                    description: 'The path against which to run the
-                                      health check. Example: `/healthcheck` Default
-                                      value is `/healthz`'
+                                    description: |-
+                                      The path against which to run the health check.
+                                      Example: `/healthcheck`
+                                      Default value is `/healthz`
                                     type: string
                                 type: object
                               isFailOpen:
-                                description: If enabled, the network load balancer
-                                  will continue to distribute traffic in the configured
-                                  distribution in the event all backends are unhealthy.
+                                description: |-
+                                  If enabled, the network load balancer will continue to distribute traffic in the configured distribution in the event all backends are unhealthy.
                                   The value is false by default.
                                 type: boolean
                               isInstantFailoverEnabled:
@@ -1375,27 +1321,29 @@ spec:
                                   soon as current backend becomes unhealthy.
                                 type: boolean
                               isPreserveSource:
-                                description: If this parameter is enabled, then the
-                                  network load balancer preserves the source IP of
-                                  the packet when it is forwarded to backends. Backends
-                                  see the original source IP. If the isPreserveSourceDestination
-                                  parameter is enabled for the network load balancer
-                                  resource, then this parameter cannot be disabled.
+                                description: |-
+                                  If this parameter is enabled, then the network load balancer preserves the source IP of the packet when it is forwarded to backends.
+                                  Backends see the original source IP. If the isPreserveSourceDestination parameter is enabled for the network load balancer resource, then this parameter cannot be disabled.
                                   The value is false by default.
                                 type: boolean
                             type: object
                         type: object
                     type: object
+                  compartmentId:
+                    description: CompartmentId where to provision network resources
+                    type: string
                   skipNetworkManagement:
-                    description: SkipNetworkManagement defines if the networking spec(VCN
-                      related) specified by the user needs to be reconciled(actioned-upon)
+                    description: |-
+                      SkipNetworkManagement defines if the networking spec(VCN related) specified by the user needs to be reconciled(actioned-upon)
                       or used as it is. APIServerLB will still be reconciled.
                     type: boolean
                   vcn:
                     description: VCN configuration.
                     properties:
                       cidr:
-                        description: VCN CIDR. Deprecated, please use NetworkDetails.cidrs
+                        description: |-
+                          VCN CIDR.
+                          Deprecated, please use NetworkDetails.cidrs
                         type: string
                       cidrs:
                         description: VCN CIDRs.
@@ -1403,17 +1351,14 @@ spec:
                           type: string
                         type: array
                       dnsLabel:
-                        description: DnsLabel specifies a DNS label for the VCN, used
-                          in conjunction with the VNIC's hostname and subnet's DNS
-                          label to form a fully qualified domain name (FQDN) for each
-                          VNIC within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
+                        description: |-
+                          DnsLabel specifies a DNS label for the VCN, used in conjunction with the VNIC's hostname and
+                          subnet's DNS label to form a fully qualified domain name (FQDN) for each VNIC
+                          within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
                         type: string
                       id:
                         description: VCN OCID.
                         type: string
-                      skip:
-                        description: Skip specifies whether to skip creating vcn
-                        type: boolean
                       internetGateway:
                         description: Configuration for Internet Gateway.
                         properties:
@@ -1421,10 +1366,19 @@ spec:
                             description: ID of Internet Gateway.
                             type: string
                           skip:
-                            description: Skip specifies whether to skip creating internet
-                              gateway even if any one Subnet is public.
+                            description: |-
+                              Skip specifies whether to skip creating internet gateway even if any one Subnet is public.
+                              In case of VCN being Skipped (Skip field of VCN set to true), this field must be true also
                             type: boolean
                         type: object
+                      isIpv6Enabled:
+                        description: Configuration to enable IPv6.
+                        type: boolean
+                      isOracleGuaAllocationEnabled:
+                        description: Configuration to allow OCI to assign IPv6 Prefix.
+                          When true will use a /56 IPv6 global unicast address (GUA)
+                          prefix allocated by Oracle
+                        type: boolean
                       name:
                         description: VCN Name.
                         type: string
@@ -1435,8 +1389,9 @@ spec:
                             description: ID of Nat Gateway.
                             type: string
                           skip:
-                            description: Skip specifies whether to skip creating NAT
-                              gateway even if any one Subnet is private.
+                            description: |-
+                              Skip specifies whether to skip creating NAT gateway even if any one Subnet is private.
+                              In case of VCN being Skipped (Skip field of VCN set to true), this field must be true also
                             type: boolean
                         type: object
                       networkSecurityGroup:
@@ -1446,8 +1401,9 @@ spec:
                             description: NetworkSecurityGroup is the configuration
                               for the Network Security Groups required in the VCN.
                             items:
-                              description: NSG defines configuration for a Network
-                                Security Group. https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/networksecuritygroups.htm
+                              description: |-
+                                NSG defines configuration for a Network Security Group.
+                                https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/networksecuritygroups.htm
                               properties:
                                 egressRules:
                                   description: EgressRules on the NSG.
@@ -1464,54 +1420,39 @@ spec:
                                               your choice for the rule.
                                             type: string
                                           destination:
-                                            description: 'Conceptually, this is the
-                                              range of IP addresses that a packet
-                                              originating from the instance can go
-                                              to. Allowed values: * IP address range
-                                              in CIDR notation. For example: `192.168.1.0/24`
-                                              or `2001:0db8:0123:45::/56` Note that
-                                              IPv6 addressing is currently supported
-                                              only in certain regions. See IPv6 Addresses
-                                              (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                              * The `cidrBlock` value for a Service,
-                                              if you''re setting up a security list
-                                              rule for traffic destined for a particular
-                                              `Service` through a service gateway.
-                                              For example: `oci-phx-objectstorage`.'
+                                            description: |-
+                                              Conceptually, this is the range of IP addresses that a packet originating from the instance
+                                              can go to.
+                                              Allowed values:
+                                                * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
+                                                  Note that IPv6 addressing is currently supported only in certain regions. See
+                                                  IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                                * The `cidrBlock` value for a Service, if you're
+                                                  setting up a security list rule for traffic destined for a particular `Service` through
+                                                  a service gateway. For example: `oci-phx-objectstorage`.
                                             type: string
                                           destinationType:
-                                            description: 'Type of destination for
-                                              the rule. The default is `CIDR_BLOCK`.
-                                              Allowed values: * `CIDR_BLOCK`: If the
-                                              rule''s `destination` is an IP address
-                                              range in CIDR notation. * `SERVICE_CIDR_BLOCK`:
-                                              If the rule''s `destination` is the
-                                              `cidrBlock` value for a Service (the
-                                              rule is for traffic destined for a particular
-                                              `Service` through a service gateway).
-                                              * `NETWORK_SECURITY_GROUP`: If the rule''s
-                                              `destination` is the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)
-                                              of a NetworkSecurityGroup.'
+                                            description: |-
+                                              Type of destination for the rule. The default is `CIDR_BLOCK`.
+                                              Allowed values:
+                                                * `CIDR_BLOCK`: If the rule's `destination` is an IP address range in CIDR notation.
+                                                * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
+                                                  Service (the rule is for traffic destined for a
+                                                  particular `Service` through a service gateway).
+                                                * `NETWORK_SECURITY_GROUP`: If the rule's `destination` is the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a
+                                                  NetworkSecurityGroup.
                                             type: string
                                           icmpOptions:
-                                            description: 'IcmpOptions Optional and
-                                              valid only for ICMP and ICMPv6. Use
-                                              to specify a particular ICMP type and
-                                              code as defined in: - ICMP Parameters
-                                              (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                            description: |-
+                                              IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                              as defined in:
+                                              - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                               - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                              If you specify ICMP or ICMPv6 as the
-                                              protocol but omit this object, then
-                                              all ICMP types and codes are allowed.
-                                              If you do provide this object, the type
-                                              is required and the code is optional.
-                                              To enable MTU negotiation for ingress
-                                              internet traffic via IPv4, make sure
-                                              to allow type 3 ("Destination Unreachable")
-                                              code 4 ("Fragmentation Needed and Don''t
-                                              Fragment was Set"). If you need to specify
-                                              multiple codes for a single type, create
-                                              a separate security list rule for each.'
+                                              If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                              codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                              To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                              Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                              multiple codes for a single type, create a separate security list rule for each.
                                             properties:
                                               code:
                                                 description: The ICMP code (optional).
@@ -1521,45 +1462,33 @@ spec:
                                                 type: integer
                                             type: object
                                           isStateless:
-                                            description: A stateless rule allows traffic
-                                              in one direction. Remember to add a
-                                              corresponding stateless rule in the
-                                              other direction if you need to support
-                                              bidirectional traffic. For example,
-                                              if egress traffic allows TCP destination
-                                              port 80, there should be an ingress
-                                              rule to allow TCP source port 80. Defaults
-                                              to false, which means the rule is stateful
-                                              and a corresponding rule is not necessary
-                                              for bidirectional traffic.
+                                            description: |-
+                                              A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                              stateless rule in the other direction if you need to support bidirectional traffic. For
+                                              example, if egress traffic allows TCP destination port 80, there should be an ingress
+                                              rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                              and a corresponding rule is not necessary for bidirectional traffic.
                                             type: boolean
                                           protocol:
-                                            description: The transport protocol. Specify
-                                              either `all` or an IPv4 protocol number
-                                              as defined in Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                              Options are supported only for ICMP
-                                              ("1"), TCP ("6"), UDP ("17"), and ICMPv6
-                                              ("58").
+                                            description: |-
+                                              The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                              defined in
+                                              Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                              Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                             type: string
                                           tcpOptions:
-                                            description: TcpOptions Optional and valid
-                                              only for TCP. Use to specify particular
-                                              destination ports for TCP rules. If
-                                              you specify TCP as the protocol but
-                                              omit this object, then all destination
-                                              ports are allowed.
+                                            description: |-
+                                              TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                              If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                             properties:
                                               destinationPortRange:
                                                 description: PortRange The representation
                                                   of PortRange.
                                                 properties:
                                                   max:
-                                                    description: The maximum port
-                                                      number, which must not be less
-                                                      than the minimum port number.
-                                                      To specify a single port number,
-                                                      set both the min and max to
-                                                      the same value.
+                                                    description: |-
+                                                      The maximum port number, which must not be less than the minimum port number. To specify
+                                                      a single port number, set both the min and max to the same value.
                                                     type: integer
                                                   min:
                                                     description: The minimum port
@@ -1572,12 +1501,9 @@ spec:
                                                   of PortRange.
                                                 properties:
                                                   max:
-                                                    description: The maximum port
-                                                      number, which must not be less
-                                                      than the minimum port number.
-                                                      To specify a single port number,
-                                                      set both the min and max to
-                                                      the same value.
+                                                    description: |-
+                                                      The maximum port number, which must not be less than the minimum port number. To specify
+                                                      a single port number, set both the min and max to the same value.
                                                     type: integer
                                                   min:
                                                     description: The minimum port
@@ -1587,24 +1513,18 @@ spec:
                                                 type: object
                                             type: object
                                           udpOptions:
-                                            description: UdpOptions Optional and valid
-                                              only for UDP. Use to specify particular
-                                              destination ports for UDP rules. If
-                                              you specify UDP as the protocol but
-                                              omit this object, then all destination
-                                              ports are allowed.
+                                            description: |-
+                                              UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                              If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                             properties:
                                               destinationPortRange:
                                                 description: PortRange The representation
                                                   of PortRange.
                                                 properties:
                                                   max:
-                                                    description: The maximum port
-                                                      number, which must not be less
-                                                      than the minimum port number.
-                                                      To specify a single port number,
-                                                      set both the min and max to
-                                                      the same value.
+                                                    description: |-
+                                                      The maximum port number, which must not be less than the minimum port number. To specify
+                                                      a single port number, set both the min and max to the same value.
                                                     type: integer
                                                   min:
                                                     description: The minimum port
@@ -1617,12 +1537,9 @@ spec:
                                                   of PortRange.
                                                 properties:
                                                   max:
-                                                    description: The maximum port
-                                                      number, which must not be less
-                                                      than the minimum port number.
-                                                      To specify a single port number,
-                                                      set both the min and max to
-                                                      the same value.
+                                                    description: |-
+                                                      The maximum port number, which must not be less than the minimum port number. To specify
+                                                      a single port number, set both the min and max to the same value.
                                                     type: integer
                                                   min:
                                                     description: The minimum port
@@ -1652,24 +1569,16 @@ spec:
                                               your choice for the rule.
                                             type: string
                                           icmpOptions:
-                                            description: 'IcmpOptions Optional and
-                                              valid only for ICMP and ICMPv6. Use
-                                              to specify a particular ICMP type and
-                                              code as defined in: - ICMP Parameters
-                                              (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                            description: |-
+                                              IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                              as defined in:
+                                              - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                               - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                              If you specify ICMP or ICMPv6 as the
-                                              protocol but omit this object, then
-                                              all ICMP types and codes are allowed.
-                                              If you do provide this object, the type
-                                              is required and the code is optional.
-                                              To enable MTU negotiation for ingress
-                                              internet traffic via IPv4, make sure
-                                              to allow type 3 ("Destination Unreachable")
-                                              code 4 ("Fragmentation Needed and Don''t
-                                              Fragment was Set"). If you need to specify
-                                              multiple codes for a single type, create
-                                              a separate security list rule for each.'
+                                              If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                              codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                              To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                              Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                              multiple codes for a single type, create a separate security list rule for each.
                                             properties:
                                               code:
                                                 description: The ICMP code (optional).
@@ -1679,74 +1588,55 @@ spec:
                                                 type: integer
                                             type: object
                                           isStateless:
-                                            description: A stateless rule allows traffic
-                                              in one direction. Remember to add a
-                                              corresponding stateless rule in the
-                                              other direction if you need to support
-                                              bidirectional traffic. For example,
-                                              if ingress traffic allows TCP destination
-                                              port 80, there should be an egress rule
-                                              to allow TCP source port 80. Defaults
-                                              to false, which means the rule is stateful
-                                              and a corresponding rule is not necessary
-                                              for bidirectional traffic.
+                                            description: |-
+                                              A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                              stateless rule in the other direction if you need to support bidirectional traffic. For
+                                              example, if ingress traffic allows TCP destination port 80, there should be an egress
+                                              rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                              and a corresponding rule is not necessary for bidirectional traffic.
                                             type: boolean
                                           protocol:
-                                            description: The transport protocol. Specify
-                                              either `all` or an IPv4 protocol number
-                                              as defined in Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                              Options are supported only for ICMP
-                                              ("1"), TCP ("6"), UDP ("17"), and ICMPv6
-                                              ("58").
+                                            description: |-
+                                              The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                              defined in
+                                              Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                              Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                             type: string
                                           source:
-                                            description: 'Conceptually, this is the
-                                              range of IP addresses that a packet
-                                              coming into the instance can come from.
-                                              Allowed values: * IP address range in
-                                              CIDR notation. For example: `192.168.1.0/24`
-                                              or `2001:0db8:0123:45::/56`. IPv6 addressing
-                                              is supported for all commercial and
-                                              government regions. See IPv6 Addresses
-                                              (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                              * The `cidrBlock` value for a Service,
-                                              if you''re setting up a security list
-                                              rule for traffic coming from a particular
-                                              `Service` through a service gateway.
-                                              For example: `oci-phx-objectstorage`.'
+                                            description: |-
+                                              Conceptually, this is the range of IP addresses that a packet coming into the instance
+                                              can come from.
+                                              Allowed values:
+                                                * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
+                                                  IPv6 addressing is supported for all commercial and government regions. See
+                                                  IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                                * The `cidrBlock` value for a Service, if you're
+                                                  setting up a security list rule for traffic coming from a particular `Service` through
+                                                  a service gateway. For example: `oci-phx-objectstorage`.
                                             type: string
                                           sourceType:
-                                            description: 'Type of source for the rule.
-                                              The default is `CIDR_BLOCK`. * `CIDR_BLOCK`:
-                                              If the rule''s `source` is an IP address
-                                              range in CIDR notation. * `SERVICE_CIDR_BLOCK`:
-                                              If the rule''s `source` is the `cidrBlock`
-                                              value for a Service (the rule is for
-                                              traffic coming from a particular `Service`
-                                              through a service gateway). * `NETWORK_SECURITY_GROUP`:
-                                              If the rule''s `destination` is the
-                                              OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)
-                                              of a NetworkSecurityGroup.'
+                                            description: |-
+                                              Type of source for the rule. The default is `CIDR_BLOCK`.
+                                                * `CIDR_BLOCK`: If the rule's `source` is an IP address range in CIDR notation.
+                                                * `SERVICE_CIDR_BLOCK`: If the rule's `source` is the `cidrBlock` value for a
+                                                  Service (the rule is for traffic coming from a
+                                                  particular `Service` through a service gateway).
+                                                * `NETWORK_SECURITY_GROUP`: If the rule's `destination` is the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a
+                                                  NetworkSecurityGroup.
                                             type: string
                                           tcpOptions:
-                                            description: TcpOptions Optional and valid
-                                              only for TCP. Use to specify particular
-                                              destination ports for TCP rules. If
-                                              you specify TCP as the protocol but
-                                              omit this object, then all destination
-                                              ports are allowed.
+                                            description: |-
+                                              TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                              If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                             properties:
                                               destinationPortRange:
                                                 description: PortRange The representation
                                                   of PortRange.
                                                 properties:
                                                   max:
-                                                    description: The maximum port
-                                                      number, which must not be less
-                                                      than the minimum port number.
-                                                      To specify a single port number,
-                                                      set both the min and max to
-                                                      the same value.
+                                                    description: |-
+                                                      The maximum port number, which must not be less than the minimum port number. To specify
+                                                      a single port number, set both the min and max to the same value.
                                                     type: integer
                                                   min:
                                                     description: The minimum port
@@ -1759,12 +1649,9 @@ spec:
                                                   of PortRange.
                                                 properties:
                                                   max:
-                                                    description: The maximum port
-                                                      number, which must not be less
-                                                      than the minimum port number.
-                                                      To specify a single port number,
-                                                      set both the min and max to
-                                                      the same value.
+                                                    description: |-
+                                                      The maximum port number, which must not be less than the minimum port number. To specify
+                                                      a single port number, set both the min and max to the same value.
                                                     type: integer
                                                   min:
                                                     description: The minimum port
@@ -1774,24 +1661,18 @@ spec:
                                                 type: object
                                             type: object
                                           udpOptions:
-                                            description: UdpOptions Optional and valid
-                                              only for UDP. Use to specify particular
-                                              destination ports for UDP rules. If
-                                              you specify UDP as the protocol but
-                                              omit this object, then all destination
-                                              ports are allowed.
+                                            description: |-
+                                              UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                              If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                             properties:
                                               destinationPortRange:
                                                 description: PortRange The representation
                                                   of PortRange.
                                                 properties:
                                                   max:
-                                                    description: The maximum port
-                                                      number, which must not be less
-                                                      than the minimum port number.
-                                                      To specify a single port number,
-                                                      set both the min and max to
-                                                      the same value.
+                                                    description: |-
+                                                      The maximum port number, which must not be less than the minimum port number. To specify
+                                                      a single port number, set both the min and max to the same value.
                                                     type: integer
                                                   min:
                                                     description: The minimum port
@@ -1804,12 +1685,9 @@ spec:
                                                   of PortRange.
                                                 properties:
                                                   max:
-                                                    description: The maximum port
-                                                      number, which must not be less
-                                                      than the minimum port number.
-                                                      To specify a single port number,
-                                                      set both the min and max to
-                                                      the same value.
+                                                    description: |-
+                                                      The maximum port number, which must not be less than the minimum port number. To specify
+                                                      a single port number, set both the min and max to the same value.
                                                     type: integer
                                                   min:
                                                     description: The minimum port
@@ -1850,8 +1728,9 @@ spec:
                             description: ID of Public Route Table.
                             type: string
                           skip:
-                            description: Skip specifies whether to skip creating Route
-                              table.
+                            description: |-
+                              Skip specifies whether to skip creating Route table.
+                              In case of VCN being Skipped (Skip field of VCN set to true), this field must be true also
                             type: boolean
                         type: object
                       serviceGateway:
@@ -1861,32 +1740,44 @@ spec:
                             description: ID of Service Gateway.
                             type: string
                           skip:
-                            description: Skip specifies whether to skip creating Service
-                              gateway.
+                            description: |-
+                              Skip specifies whether to skip creating Service gateway.
+                              In case of VCN being Skipped (Skip field of VCN set to true), this field must be true also
                             type: boolean
                         type: object
+                      skip:
+                        description: |-
+                          Skip specifies whether to skip creating VCN.
+                          When is set to true, InternetGateway, NatGateway, ServiceGateway, RouteTable must have also Skip set to true
+                          If set to true(default: false) the ID must be specified by the user to a valid VCN ID.
+                        type: boolean
                       subnets:
                         description: Subnets is the configuration for subnets required
                           in the VCN.
                         items:
-                          description: Subnet defines the configuration for a network's
-                            subnet https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingVCNs_topic-Overview_of_VCNs_and_Subnets.htm#Overview
+                          description: |-
+                            Subnet defines the configuration for a network's subnet
+                            https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingVCNs_topic-Overview_of_VCNs_and_Subnets.htm#Overview
                           properties:
                             cidr:
                               description: Subnet CIDR.
                               type: string
                             dnsLabel:
-                              description: DnsLabel DNS label for the subnet, used
-                                in conjunction with the VNIC's hostname and VCN's
-                                DNS label to form a fully qualified domain name (FQDN)
-                                for each VNIC within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
+                              description: |-
+                                DnsLabel DNS label for the subnet, used in conjunction with the VNIC's hostname and
+                                VCN's DNS label to form a fully qualified domain name (FQDN) for each VNIC
+                                within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
                               type: string
                             id:
                               description: Subnet OCID.
                               type: string
-                            skip:
-                              description: Skip specifies whether to skip creating subnet
-                              type: boolean
+                            ipv6CidrBlockHextet:
+                              description: |-
+                                Use this to enable IPv6 hextet for this subnet. The VCN must be enabled for IPv6.
+                                You can't change this subnet characteristic later. All subnets are /64 in size. The subnet
+                                portion of the IPv6 address is the fourth hextet from the left (1111 in the following example).
+                                Example: `2001:0db8:0123:1111::/64`
+                              type: string
                             name:
                               description: Subnet Name.
                               type: string
@@ -1908,50 +1799,39 @@ spec:
                                           choice for the rule.
                                         type: string
                                       destination:
-                                        description: 'Conceptually, this is the range
-                                          of IP addresses that a packet originating
-                                          from the instance can go to. Allowed values:
-                                          * IP address range in CIDR notation. For
-                                          example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-                                          Note that IPv6 addressing is currently supported
-                                          only in certain regions. See IPv6 Addresses
-                                          (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                          * The `cidrBlock` value for a Service, if
-                                          you''re setting up a security list rule
-                                          for traffic destined for a particular `Service`
-                                          through a service gateway. For example:
-                                          `oci-phx-objectstorage`.'
+                                        description: |-
+                                          Conceptually, this is the range of IP addresses that a packet originating from the instance
+                                          can go to.
+                                          Allowed values:
+                                            * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
+                                              Note that IPv6 addressing is currently supported only in certain regions. See
+                                              IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                            * The `cidrBlock` value for a Service, if you're
+                                              setting up a security list rule for traffic destined for a particular `Service` through
+                                              a service gateway. For example: `oci-phx-objectstorage`.
                                         type: string
                                       destinationType:
-                                        description: 'Type of destination for the
-                                          rule. The default is `CIDR_BLOCK`. Allowed
-                                          values: * `CIDR_BLOCK`: If the rule''s `destination`
-                                          is an IP address range in CIDR notation.
-                                          * `SERVICE_CIDR_BLOCK`: If the rule''s `destination`
-                                          is the `cidrBlock` value for a Service (the
-                                          rule is for traffic destined for a particular
-                                          `Service` through a service gateway). *
-                                          `NETWORK_SECURITY_GROUP`: If the rule''s
-                                          `destination` is the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)
-                                          of a NetworkSecurityGroup.'
+                                        description: |-
+                                          Type of destination for the rule. The default is `CIDR_BLOCK`.
+                                          Allowed values:
+                                            * `CIDR_BLOCK`: If the rule's `destination` is an IP address range in CIDR notation.
+                                            * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
+                                              Service (the rule is for traffic destined for a
+                                              particular `Service` through a service gateway).
+                                            * `NETWORK_SECURITY_GROUP`: If the rule's `destination` is the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a
+                                              NetworkSecurityGroup.
                                         type: string
                                       icmpOptions:
-                                        description: 'IcmpOptions Optional and valid
-                                          only for ICMP and ICMPv6. Use to specify
-                                          a particular ICMP type and code as defined
-                                          in: - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                        description: |-
+                                          IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                          as defined in:
+                                          - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                           - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                          If you specify ICMP or ICMPv6 as the protocol
-                                          but omit this object, then all ICMP types
-                                          and codes are allowed. If you do provide
-                                          this object, the type is required and the
-                                          code is optional. To enable MTU negotiation
-                                          for ingress internet traffic via IPv4, make
-                                          sure to allow type 3 ("Destination Unreachable")
-                                          code 4 ("Fragmentation Needed and Don''t
-                                          Fragment was Set"). If you need to specify
-                                          multiple codes for a single type, create
-                                          a separate security list rule for each.'
+                                          If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                          codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                          To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                          Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                          multiple codes for a single type, create a separate security list rule for each.
                                         properties:
                                           code:
                                             description: The ICMP code (optional).
@@ -1961,41 +1841,33 @@ spec:
                                             type: integer
                                         type: object
                                       isStateless:
-                                        description: A stateless rule allows traffic
-                                          in one direction. Remember to add a corresponding
-                                          stateless rule in the other direction if
-                                          you need to support bidirectional traffic.
-                                          For example, if egress traffic allows TCP
-                                          destination port 80, there should be an
-                                          ingress rule to allow TCP source port 80.
-                                          Defaults to false, which means the rule
-                                          is stateful and a corresponding rule is
-                                          not necessary for bidirectional traffic.
+                                        description: |-
+                                          A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                          stateless rule in the other direction if you need to support bidirectional traffic. For
+                                          example, if egress traffic allows TCP destination port 80, there should be an ingress
+                                          rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                          and a corresponding rule is not necessary for bidirectional traffic.
                                         type: boolean
                                       protocol:
-                                        description: The transport protocol. Specify
-                                          either `all` or an IPv4 protocol number
-                                          as defined in Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                          Options are supported only for ICMP ("1"),
-                                          TCP ("6"), UDP ("17"), and ICMPv6 ("58").
+                                        description: |-
+                                          The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                          defined in
+                                          Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                          Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                         type: string
                                       tcpOptions:
-                                        description: TcpOptions Optional and valid
-                                          only for TCP. Use to specify particular
-                                          destination ports for TCP rules. If you
-                                          specify TCP as the protocol but omit this
-                                          object, then all destination ports are allowed.
+                                        description: |-
+                                          TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                          If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                         properties:
                                           destinationPortRange:
                                             description: PortRange The representation
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -2008,11 +1880,9 @@ spec:
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -2022,22 +1892,18 @@ spec:
                                             type: object
                                         type: object
                                       udpOptions:
-                                        description: UdpOptions Optional and valid
-                                          only for UDP. Use to specify particular
-                                          destination ports for UDP rules. If you
-                                          specify UDP as the protocol but omit this
-                                          object, then all destination ports are allowed.
+                                        description: |-
+                                          UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                          If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                         properties:
                                           destinationPortRange:
                                             description: PortRange The representation
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -2050,11 +1916,9 @@ spec:
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -2079,22 +1943,16 @@ spec:
                                           choice for the rule.
                                         type: string
                                       icmpOptions:
-                                        description: 'IcmpOptions Optional and valid
-                                          only for ICMP and ICMPv6. Use to specify
-                                          a particular ICMP type and code as defined
-                                          in: - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                        description: |-
+                                          IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                          as defined in:
+                                          - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                           - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                          If you specify ICMP or ICMPv6 as the protocol
-                                          but omit this object, then all ICMP types
-                                          and codes are allowed. If you do provide
-                                          this object, the type is required and the
-                                          code is optional. To enable MTU negotiation
-                                          for ingress internet traffic via IPv4, make
-                                          sure to allow type 3 ("Destination Unreachable")
-                                          code 4 ("Fragmentation Needed and Don''t
-                                          Fragment was Set"). If you need to specify
-                                          multiple codes for a single type, create
-                                          a separate security list rule for each.'
+                                          If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                          codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                          To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                          Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                          multiple codes for a single type, create a separate security list rule for each.
                                         properties:
                                           code:
                                             description: The ICMP code (optional).
@@ -2104,69 +1962,55 @@ spec:
                                             type: integer
                                         type: object
                                       isStateless:
-                                        description: A stateless rule allows traffic
-                                          in one direction. Remember to add a corresponding
-                                          stateless rule in the other direction if
-                                          you need to support bidirectional traffic.
-                                          For example, if ingress traffic allows TCP
-                                          destination port 80, there should be an
-                                          egress rule to allow TCP source port 80.
-                                          Defaults to false, which means the rule
-                                          is stateful and a corresponding rule is
-                                          not necessary for bidirectional traffic.
+                                        description: |-
+                                          A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                          stateless rule in the other direction if you need to support bidirectional traffic. For
+                                          example, if ingress traffic allows TCP destination port 80, there should be an egress
+                                          rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                          and a corresponding rule is not necessary for bidirectional traffic.
                                         type: boolean
                                       protocol:
-                                        description: The transport protocol. Specify
-                                          either `all` or an IPv4 protocol number
-                                          as defined in Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                          Options are supported only for ICMP ("1"),
-                                          TCP ("6"), UDP ("17"), and ICMPv6 ("58").
+                                        description: |-
+                                          The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                          defined in
+                                          Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                          Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                         type: string
                                       source:
-                                        description: 'Conceptually, this is the range
-                                          of IP addresses that a packet coming into
-                                          the instance can come from. Allowed values:
-                                          * IP address range in CIDR notation. For
-                                          example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
-                                          IPv6 addressing is supported for all commercial
-                                          and government regions. See IPv6 Addresses
-                                          (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                          * The `cidrBlock` value for a Service, if
-                                          you''re setting up a security list rule
-                                          for traffic coming from a particular `Service`
-                                          through a service gateway. For example:
-                                          `oci-phx-objectstorage`.'
+                                        description: |-
+                                          Conceptually, this is the range of IP addresses that a packet coming into the instance
+                                          can come from.
+                                          Allowed values:
+                                            * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
+                                              IPv6 addressing is supported for all commercial and government regions. See
+                                              IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                            * The `cidrBlock` value for a Service, if you're
+                                              setting up a security list rule for traffic coming from a particular `Service` through
+                                              a service gateway. For example: `oci-phx-objectstorage`.
                                         type: string
                                       sourceType:
-                                        description: 'Type of source for the rule.
-                                          The default is `CIDR_BLOCK`. * `CIDR_BLOCK`:
-                                          If the rule''s `source` is an IP address
-                                          range in CIDR notation. * `SERVICE_CIDR_BLOCK`:
-                                          If the rule''s `source` is the `cidrBlock`
-                                          value for a Service (the rule is for traffic
-                                          coming from a particular `Service` through
-                                          a service gateway). * `NETWORK_SECURITY_GROUP`:
-                                          If the rule''s `destination` is the OCID
-                                          (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)
-                                          of a NetworkSecurityGroup.'
+                                        description: |-
+                                          Type of source for the rule. The default is `CIDR_BLOCK`.
+                                            * `CIDR_BLOCK`: If the rule's `source` is an IP address range in CIDR notation.
+                                            * `SERVICE_CIDR_BLOCK`: If the rule's `source` is the `cidrBlock` value for a
+                                              Service (the rule is for traffic coming from a
+                                              particular `Service` through a service gateway).
+                                            * `NETWORK_SECURITY_GROUP`: If the rule's `destination` is the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a
+                                              NetworkSecurityGroup.
                                         type: string
                                       tcpOptions:
-                                        description: TcpOptions Optional and valid
-                                          only for TCP. Use to specify particular
-                                          destination ports for TCP rules. If you
-                                          specify TCP as the protocol but omit this
-                                          object, then all destination ports are allowed.
+                                        description: |-
+                                          TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                          If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                         properties:
                                           destinationPortRange:
                                             description: PortRange The representation
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -2179,11 +2023,9 @@ spec:
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -2193,22 +2035,18 @@ spec:
                                             type: object
                                         type: object
                                       udpOptions:
-                                        description: UdpOptions Optional and valid
-                                          only for UDP. Use to specify particular
-                                          destination ports for UDP rules. If you
-                                          specify UDP as the protocol but omit this
-                                          object, then all destination ports are allowed.
+                                        description: |-
+                                          UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                          If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                         properties:
                                           destinationPortRange:
                                             description: PortRange The representation
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -2221,11 +2059,9 @@ spec:
                                               of PortRange.
                                             properties:
                                               max:
-                                                description: The maximum port number,
-                                                  which must not be less than the
-                                                  minimum port number. To specify
-                                                  a single port number, set both the
-                                                  min and max to the same value.
+                                                description: |-
+                                                  The maximum port number, which must not be less than the minimum port number. To specify
+                                                  a single port number, set both the min and max to the same value.
                                                 type: integer
                                               min:
                                                 description: The minimum port number,
@@ -2240,6 +2076,11 @@ spec:
                                   description: SecurityList Name.
                                   type: string
                               type: object
+                            skip:
+                              description: |-
+                                Skip specifies whether to skip creating subnets. If set to true(default: false) the ID
+                                must be specified by the user to a valid Subnet ID.
+                              type: boolean
                             type:
                               description: Type defines the subnet type (e.g. public,
                                 private).
@@ -2257,76 +2098,72 @@ spec:
                     description: VCNPeering configuration.
                     properties:
                       drg:
-                        description: DRG configuration refers to the DRG which has
-                          to be created if required. If management cluster and workload
-                          cluster shares the same DRG, this fields is not required
-                          to be specified.
+                        description: |-
+                          DRG configuration refers to the DRG which has to be created if required. If management cluster
+                          and workload cluster shares the same DRG, this fields is not required to be specified.
                         properties:
                           id:
                             description: ID is the OCID for the created DRG.
                             type: string
                           manage:
-                            description: Manage defines whether the DRG has to be
-                              managed(including create). If set to false(the default)
-                              the ID has to be specified by the user to a valid DRG
-                              ID to which the VCN has to be attached.
+                            description: |-
+                              Manage defines whether the DRG has to be managed(including create). If set to false(the default) the ID
+                              has to be specified by the user to a valid DRG ID to which the VCN has to be attached.
                             type: boolean
                           name:
                             description: Name is the name of the created DRG.
                             type: string
                           vcnAttachmentId:
-                            description: VcnAttachmentId is the ID of the VCN attachment
-                              of the DRG. The workload cluster VCN can be attached
-                              to either the management cluster VCN if they are sharing
-                              the same DRG or to the workload cluster DRG.
+                            description: |-
+                              VcnAttachmentId is the ID of the VCN attachment of the DRG.
+                              The workload cluster VCN can be attached to either the management cluster VCN if they are sharing the same DRG
+                              or to the workload cluster DRG.
                             type: string
                         type: object
                       peerRouteRules:
-                        description: PeerRouteRules defines the routing rules which
-                          will be added to the private route tables of the workload
-                          cluster VCN. The routes defined here will be directed to
-                          DRG.
+                        description: |-
+                          PeerRouteRules defines the routing rules which will be added to the private route tables
+                          of the workload cluster VCN. The routes defined here will be directed to DRG.
                         items:
                           description: PeerRouteRule defines a Route Rule to be routed
                             via a DRG.
                           properties:
                             vcnCIDRRange:
-                              description: VCNCIDRRange is the CIDR Range of peer
-                                VCN to which the workload cluster VCN will be peered.
-                                The CIDR range is required to add the route rule in
-                                the workload cluster VCN, the route rule will forward
-                                any traffic to the CIDR to the DRG.
+                              description: |-
+                                VCNCIDRRange is the CIDR Range of peer VCN to which the
+                                workload cluster VCN will be peered. The CIDR range is required to add the route rule
+                                in the workload cluster VCN, the route rule will forward any traffic to the CIDR to the DRG.
                               type: string
                           type: object
                         type: array
                       remotePeeringConnections:
-                        description: RemotePeeringConnections defines the RPC connections
-                          which be established with the workload cluster DRG.
+                        description: |-
+                          RemotePeeringConnections defines the RPC connections which be established with the
+                          workload cluster DRG.
                         items:
-                          description: RemotePeeringConnection is used to peer VCNs
-                            residing in different regions(typically). Remote VCN Peering
-                            is explained here - https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/remoteVCNpeering.htm
+                          description: |-
+                            RemotePeeringConnection is used to peer VCNs residing in different regions(typically).
+                            Remote VCN Peering is explained here - https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/remoteVCNpeering.htm
                           properties:
                             managePeerRPC:
-                              description: ManagePeerRPC will define if the Peer VCN
-                                needs to be managed. If set to true a Remote Peering
-                                Connection will be created in the Peer DRG and the
-                                connection will be created between local and peer
-                                RPC.
+                              description: |-
+                                ManagePeerRPC will define if the Peer VCN needs to be managed. If set to true
+                                a Remote Peering Connection will be created in the Peer DRG and the connection
+                                will be created between local and peer RPC.
                               type: boolean
                             name:
-                              description: A unique name identifying the RPC, please
-                                note this is to identify the RPC from other RPC elements,
-                                and will not be used in any OCI API call.
+                              description: |-
+                                A unique name identifying the RPC, please note this is to identify the RPC
+                                from other RPC elements, and will not be used in any OCI API call.
                               type: string
                             peerDRGId:
                               description: PeerDRGId defines the DRG ID of the peer.
                               type: string
                             peerRPCConnectionId:
-                              description: PeerRPCConnectionId defines the RPC ID
-                                of peer. If ManagePeerRPC is set to true this will
-                                be created by Cluster API Provider for OCI, otherwise
-                                this has be defined by the user.
+                              description: |-
+                                PeerRPCConnectionId defines the RPC ID of peer. If ManagePeerRPC is set to true
+                                this will be created by Cluster API Provider for OCI, otherwise this has be defined by the
+                                user.
                               type: string
                             peerRegionName:
                               description: PeerRegionName defined the region name
@@ -2341,14 +2178,15 @@ spec:
                     type: object
                 type: object
               ociResourceIdentifier:
-                description: The unique ID which will be used to tag all the resources
-                  created by this Cluster. The tag will be used to identify resources
-                  belonging to this cluster. this will be auto-generated and should
-                  not be set by the user.
+                description: |-
+                  The unique ID which will be used to tag all the resources created by this Cluster.
+                  The tag will be used to identify resources belonging to this cluster.
+                  this will be auto-generated and should not be set by the user.
                 type: string
               region:
-                description: Region the cluster operates in. It must be one of available
-                  regions in Region Identifier format. See https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm
+                description: |-
+                  Region the cluster operates in. It must be one of available regions in Region Identifier format.
+                  See https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm
                 type: string
             type: object
           status:
@@ -2361,37 +2199,44 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
+                      description: status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -2401,18 +2246,18 @@ spec:
                 type: array
               failureDomains:
                 additionalProperties:
-                  description: FailureDomainSpec is the Schema for Cluster API failure
-                    domains. It allows controllers to understand how many failure
-                    domains a cluster can optionally span across.
+                  description: |-
+                    FailureDomainSpec is the Schema for Cluster API failure domains.
+                    It allows controllers to understand how many failure domains a cluster can optionally span across.
                   properties:
                     attributes:
                       additionalProperties:
                         type: string
-                      description: Attributes is a free form map of attributes an
+                      description: attributes is a free form map of attributes an
                         infrastructure provider might use or require.
                       type: object
                     controlPlane:
-                      description: ControlPlane determines if this failure domain
+                      description: controlPlane determines if this failure domain
                         is suitable for use by control plane machines.
                       type: boolean
                   type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimanagedclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimanagedclustertemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: ocimanagedclustertemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -23,14 +23,19 @@ spec:
           API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -57,10 +62,13 @@ spec:
                           has an endpoint address
                         properties:
                           host:
-                            description: The hostname on which the API server is serving.
+                            description: host is the hostname on which the API server
+                              is serving.
+                            maxLength: 512
                             type: string
                           port:
-                            description: The port on which the API server is serving.
+                            description: port is the port on which the API server
+                              is serving.
                             format: int32
                             type: integer
                         required:
@@ -72,10 +80,10 @@ spec:
                           additionalProperties:
                             type: string
                           type: object
-                        description: 'Defined tags for this resource. Each key is
-                          predefined and scoped to a namespace. For more information,
-                          see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
-                          Example: `{"Operations": {"CostCenter": "42"}}`'
+                        description: |-
+                          Defined tags for this resource. Each key is predefined and scoped to a
+                          namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+                          Example: `{"Operations": {"CostCenter": "42"}}`
                         type: object
                       freeformTags:
                         additionalProperties:
@@ -90,34 +98,39 @@ spec:
                             description: API version of the referent.
                             type: string
                           fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
                             type: string
                           kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                             type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                             type: string
                           namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                             type: string
                           resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                             type: string
                           uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
@@ -148,17 +161,16 @@ spec:
                                           unhealthy.
                                         properties:
                                           urlPath:
-                                            description: 'The path against which to
-                                              run the health check. Example: `/healthcheck`
-                                              Default value is `/healthz`'
+                                            description: |-
+                                              The path against which to run the health check.
+                                              Example: `/healthcheck`
+                                              Default value is `/healthz`
                                             type: string
                                         type: object
                                       isFailOpen:
-                                        description: If enabled, the network load
-                                          balancer will continue to distribute traffic
-                                          in the configured distribution in the event
-                                          all backends are unhealthy. The value is
-                                          false by default.
+                                        description: |-
+                                          If enabled, the network load balancer will continue to distribute traffic in the configured distribution in the event all backends are unhealthy.
+                                          The value is false by default.
                                         type: boolean
                                       isInstantFailoverEnabled:
                                         description: If enabled existing connections
@@ -167,29 +179,30 @@ spec:
                                           unhealthy.
                                         type: boolean
                                       isPreserveSource:
-                                        description: If this parameter is enabled,
-                                          then the network load balancer preserves
-                                          the source IP of the packet when it is forwarded
-                                          to backends. Backends see the original source
-                                          IP. If the isPreserveSourceDestination parameter
-                                          is enabled for the network load balancer
-                                          resource, then this parameter cannot be
-                                          disabled. The value is false by default.
+                                        description: |-
+                                          If this parameter is enabled, then the network load balancer preserves the source IP of the packet when it is forwarded to backends.
+                                          Backends see the original source IP. If the isPreserveSourceDestination parameter is enabled for the network load balancer resource, then this parameter cannot be disabled.
+                                          The value is false by default.
                                         type: boolean
                                     type: object
                                 type: object
                             type: object
+                          compartmentId:
+                            description: CompartmentId where to provision network
+                              resources
+                            type: string
                           skipNetworkManagement:
-                            description: SkipNetworkManagement defines if the networking
-                              spec(VCN related) specified by the user needs to be
-                              reconciled(actioned-upon) or used as it is. APIServerLB
-                              will still be reconciled.
+                            description: |-
+                              SkipNetworkManagement defines if the networking spec(VCN related) specified by the user needs to be reconciled(actioned-upon)
+                              or used as it is. APIServerLB will still be reconciled.
                             type: boolean
                           vcn:
                             description: VCN configuration.
                             properties:
                               cidr:
-                                description: VCN CIDR. Deprecated, please use NetworkDetails.cidrs
+                                description: |-
+                                  VCN CIDR.
+                                  Deprecated, please use NetworkDetails.cidrs
                                 type: string
                               cidrs:
                                 description: VCN CIDRs.
@@ -197,21 +210,25 @@ spec:
                                   type: string
                                 type: array
                               dnsLabel:
-                                description: DnsLabel specifies a DNS label for the
-                                  VCN, used in conjunction with the VNIC's hostname
-                                  and subnet's DNS label to form a fully qualified
-                                  domain name (FQDN) for each VNIC within this subnet
-                                  (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
+                                description: |-
+                                  DnsLabel specifies a DNS label for the VCN, used in conjunction with the VNIC's hostname and
+                                  subnet's DNS label to form a fully qualified domain name (FQDN) for each VNIC
+                                  within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
                                 type: string
                               id:
                                 description: VCN OCID.
                                 type: string
-                              skip:
-                                description: Skip specifies whether to skip creating vcn
-                                type: boolean
                               internetGatewayId:
                                 description: ID of Internet Gateway.
                                 type: string
+                              isIpv6Enabled:
+                                description: Configuration to enable IPv6.
+                                type: boolean
+                              isOracleGuaAllocationEnabled:
+                                description: Configuration to allow OCI to assign
+                                  IPv6 Prefix. When true will use a /56 IPv6 global
+                                  unicast address (GUA) prefix allocated by Oracle
+                                type: boolean
                               name:
                                 description: VCN Name.
                                 type: string
@@ -223,8 +240,9 @@ spec:
                                   for the Network Security Groups required in the
                                   VCN.
                                 items:
-                                  description: NSG defines configuration for a Network
-                                    Security Group. https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/networksecuritygroups.htm
+                                  description: |-
+                                    NSG defines configuration for a Network Security Group.
+                                    https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/networksecuritygroups.htm
                                   properties:
                                     egressRules:
                                       description: EgressRules on the NSG.
@@ -241,55 +259,37 @@ spec:
                                                   of your choice for the rule.
                                                 type: string
                                               destination:
-                                                description: 'Conceptually, this is
-                                                  the range of IP addresses that a
-                                                  packet originating from the instance
-                                                  can go to. Allowed values: * IP
-                                                  address range in CIDR notation.
-                                                  For example: `192.168.1.0/24` or
-                                                  `2001:0db8:0123:45::/56` Note that
-                                                  IPv6 addressing is currently supported
-                                                  only in certain regions. See IPv6
-                                                  Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                                  * The `cidrBlock` value for a Service,
-                                                  if you''re setting up a security
-                                                  list rule for traffic destined for
-                                                  a particular `Service` through a
-                                                  service gateway. For example: `oci-phx-objectstorage`.'
+                                                description: |-
+                                                  Conceptually, this is the range of IP addresses that a packet originating from the instance
+                                                  can go to.
+                                                  Allowed values:
+                                                    * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
+                                                      Note that IPv6 addressing is currently supported only in certain regions. See
+                                                      IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                                    * The `cidrBlock` value for a Service, if you're
+                                                      setting up a security list rule for traffic destined for a particular `Service` through
+                                                      a service gateway. For example: `oci-phx-objectstorage`.
                                                 type: string
                                               destinationType:
-                                                description: 'Type of destination
-                                                  for the rule. The default is `CIDR_BLOCK`.
-                                                  Allowed values: * `CIDR_BLOCK`:
-                                                  If the rule''s `destination` is
-                                                  an IP address range in CIDR notation.
-                                                  * `SERVICE_CIDR_BLOCK`: If the rule''s
-                                                  `destination` is the `cidrBlock`
-                                                  value for a Service (the rule is
-                                                  for traffic destined for a particular
-                                                  `Service` through a service gateway).'
+                                                description: |-
+                                                  Type of destination for the rule. The default is `CIDR_BLOCK`.
+                                                  Allowed values:
+                                                    * `CIDR_BLOCK`: If the rule's `destination` is an IP address range in CIDR notation.
+                                                    * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
+                                                      Service (the rule is for traffic destined for a
+                                                      particular `Service` through a service gateway).
                                                 type: string
                                               icmpOptions:
-                                                description: 'IcmpOptions Optional
-                                                  and valid only for ICMP and ICMPv6.
-                                                  Use to specify a particular ICMP
-                                                  type and code as defined in: - ICMP
-                                                  Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                                description: |-
+                                                  IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                                  as defined in:
+                                                  - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                                   - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                                  If you specify ICMP or ICMPv6 as
-                                                  the protocol but omit this object,
-                                                  then all ICMP types and codes are
-                                                  allowed. If you do provide this
-                                                  object, the type is required and
-                                                  the code is optional. To enable
-                                                  MTU negotiation for ingress internet
-                                                  traffic via IPv4, make sure to allow
-                                                  type 3 ("Destination Unreachable")
-                                                  code 4 ("Fragmentation Needed and
-                                                  Don''t Fragment was Set"). If you
-                                                  need to specify multiple codes for
-                                                  a single type, create a separate
-                                                  security list rule for each.'
+                                                  If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                                  codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                                  To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                                  Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                                  multiple codes for a single type, create a separate security list rule for each.
                                                 properties:
                                                   code:
                                                     description: The ICMP code (optional).
@@ -299,48 +299,33 @@ spec:
                                                     type: integer
                                                 type: object
                                               isStateless:
-                                                description: A stateless rule allows
-                                                  traffic in one direction. Remember
-                                                  to add a corresponding stateless
-                                                  rule in the other direction if you
-                                                  need to support bidirectional traffic.
-                                                  For example, if egress traffic allows
-                                                  TCP destination port 80, there should
-                                                  be an ingress rule to allow TCP
-                                                  source port 80. Defaults to false,
-                                                  which means the rule is stateful
-                                                  and a corresponding rule is not
-                                                  necessary for bidirectional traffic.
+                                                description: |-
+                                                  A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                                  stateless rule in the other direction if you need to support bidirectional traffic. For
+                                                  example, if egress traffic allows TCP destination port 80, there should be an ingress
+                                                  rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                                  and a corresponding rule is not necessary for bidirectional traffic.
                                                 type: boolean
                                               protocol:
-                                                description: The transport protocol.
-                                                  Specify either `all` or an IPv4
-                                                  protocol number as defined in Protocol
-                                                  Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                                  Options are supported only for ICMP
-                                                  ("1"), TCP ("6"), UDP ("17"), and
-                                                  ICMPv6 ("58").
+                                                description: |-
+                                                  The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                                  defined in
+                                                  Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                                  Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                                 type: string
                                               tcpOptions:
-                                                description: TcpOptions Optional and
-                                                  valid only for TCP. Use to specify
-                                                  particular destination ports for
-                                                  TCP rules. If you specify TCP as
-                                                  the protocol but omit this object,
-                                                  then all destination ports are allowed.
+                                                description: |-
+                                                  TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                                  If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                                 properties:
                                                   destinationPortRange:
                                                     description: PortRange The representation
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -354,13 +339,9 @@ spec:
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -371,25 +352,18 @@ spec:
                                                     type: object
                                                 type: object
                                               udpOptions:
-                                                description: UdpOptions Optional and
-                                                  valid only for UDP. Use to specify
-                                                  particular destination ports for
-                                                  UDP rules. If you specify UDP as
-                                                  the protocol but omit this object,
-                                                  then all destination ports are allowed.
+                                                description: |-
+                                                  UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                                  If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                                 properties:
                                                   destinationPortRange:
                                                     description: PortRange The representation
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -403,13 +377,9 @@ spec:
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -421,9 +391,9 @@ spec:
                                                 type: object
                                             type: object
                                           id:
-                                            description: 'EgressSecurityRule ID for
-                                              NSG. Deprecated: this field is not populated
-                                              and used during reconciliation'
+                                            description: |-
+                                              EgressSecurityRule ID for NSG.
+                                              Deprecated: this field is not populated and used during reconciliation
                                             type: string
                                         type: object
                                       type: array
@@ -437,9 +407,9 @@ spec:
                                           IngressSecurityRule for NSG
                                         properties:
                                           id:
-                                            description: 'IngressSecurityRule ID for
-                                              NSG. Deprecated: this field is not populated
-                                              and used during reconciliation'
+                                            description: |-
+                                              IngressSecurityRule ID for NSG.
+                                              Deprecated: this field is not populated and used during reconciliation
                                             type: string
                                           ingressRule:
                                             description: IngressSecurityRule A rule
@@ -450,26 +420,16 @@ spec:
                                                   of your choice for the rule.
                                                 type: string
                                               icmpOptions:
-                                                description: 'IcmpOptions Optional
-                                                  and valid only for ICMP and ICMPv6.
-                                                  Use to specify a particular ICMP
-                                                  type and code as defined in: - ICMP
-                                                  Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                                description: |-
+                                                  IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                                  as defined in:
+                                                  - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                                   - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                                  If you specify ICMP or ICMPv6 as
-                                                  the protocol but omit this object,
-                                                  then all ICMP types and codes are
-                                                  allowed. If you do provide this
-                                                  object, the type is required and
-                                                  the code is optional. To enable
-                                                  MTU negotiation for ingress internet
-                                                  traffic via IPv4, make sure to allow
-                                                  type 3 ("Destination Unreachable")
-                                                  code 4 ("Fragmentation Needed and
-                                                  Don''t Fragment was Set"). If you
-                                                  need to specify multiple codes for
-                                                  a single type, create a separate
-                                                  security list rule for each.'
+                                                  If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                                  codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                                  To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                                  Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                                  multiple codes for a single type, create a separate security list rule for each.
                                                 properties:
                                                   code:
                                                     description: The ICMP code (optional).
@@ -479,77 +439,53 @@ spec:
                                                     type: integer
                                                 type: object
                                               isStateless:
-                                                description: A stateless rule allows
-                                                  traffic in one direction. Remember
-                                                  to add a corresponding stateless
-                                                  rule in the other direction if you
-                                                  need to support bidirectional traffic.
-                                                  For example, if ingress traffic
-                                                  allows TCP destination port 80,
-                                                  there should be an egress rule to
-                                                  allow TCP source port 80. Defaults
-                                                  to false, which means the rule is
-                                                  stateful and a corresponding rule
-                                                  is not necessary for bidirectional
-                                                  traffic.
+                                                description: |-
+                                                  A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                                  stateless rule in the other direction if you need to support bidirectional traffic. For
+                                                  example, if ingress traffic allows TCP destination port 80, there should be an egress
+                                                  rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                                  and a corresponding rule is not necessary for bidirectional traffic.
                                                 type: boolean
                                               protocol:
-                                                description: The transport protocol.
-                                                  Specify either `all` or an IPv4
-                                                  protocol number as defined in Protocol
-                                                  Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                                  Options are supported only for ICMP
-                                                  ("1"), TCP ("6"), UDP ("17"), and
-                                                  ICMPv6 ("58").
+                                                description: |-
+                                                  The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                                  defined in
+                                                  Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                                  Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                                 type: string
                                               source:
-                                                description: 'Conceptually, this is
-                                                  the range of IP addresses that a
-                                                  packet coming into the instance
-                                                  can come from. Allowed values: *
-                                                  IP address range in CIDR notation.
-                                                  For example: `192.168.1.0/24` or
-                                                  `2001:0db8:0123:45::/56`. IPv6 addressing
-                                                  is supported for all commercial
-                                                  and government regions. See IPv6
-                                                  Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                                  * The `cidrBlock` value for a Service,
-                                                  if you''re setting up a security
-                                                  list rule for traffic coming from
-                                                  a particular `Service` through a
-                                                  service gateway. For example: `oci-phx-objectstorage`.'
+                                                description: |-
+                                                  Conceptually, this is the range of IP addresses that a packet coming into the instance
+                                                  can come from.
+                                                  Allowed values:
+                                                    * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
+                                                      IPv6 addressing is supported for all commercial and government regions. See
+                                                      IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                                    * The `cidrBlock` value for a Service, if you're
+                                                      setting up a security list rule for traffic coming from a particular `Service` through
+                                                      a service gateway. For example: `oci-phx-objectstorage`.
                                                 type: string
                                               sourceType:
-                                                description: 'Type of source for the
-                                                  rule. The default is `CIDR_BLOCK`.
-                                                  * `CIDR_BLOCK`: If the rule''s `source`
-                                                  is an IP address range in CIDR notation.
-                                                  * `SERVICE_CIDR_BLOCK`: If the rule''s
-                                                  `source` is the `cidrBlock` value
-                                                  for a Service (the rule is for traffic
-                                                  coming from a particular `Service`
-                                                  through a service gateway).'
+                                                description: |-
+                                                  Type of source for the rule. The default is `CIDR_BLOCK`.
+                                                    * `CIDR_BLOCK`: If the rule's `source` is an IP address range in CIDR notation.
+                                                    * `SERVICE_CIDR_BLOCK`: If the rule's `source` is the `cidrBlock` value for a
+                                                      Service (the rule is for traffic coming from a
+                                                      particular `Service` through a service gateway).
                                                 type: string
                                               tcpOptions:
-                                                description: TcpOptions Optional and
-                                                  valid only for TCP. Use to specify
-                                                  particular destination ports for
-                                                  TCP rules. If you specify TCP as
-                                                  the protocol but omit this object,
-                                                  then all destination ports are allowed.
+                                                description: |-
+                                                  TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                                  If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                                 properties:
                                                   destinationPortRange:
                                                     description: PortRange The representation
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -563,13 +499,9 @@ spec:
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -580,25 +512,18 @@ spec:
                                                     type: object
                                                 type: object
                                               udpOptions:
-                                                description: UdpOptions Optional and
-                                                  valid only for UDP. Use to specify
-                                                  particular destination ports for
-                                                  UDP rules. If you specify UDP as
-                                                  the protocol but omit this object,
-                                                  then all destination ports are allowed.
+                                                description: |-
+                                                  UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                                  If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                                 properties:
                                                   destinationPortRange:
                                                     description: PortRange The representation
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -612,13 +537,9 @@ spec:
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -655,29 +576,39 @@ spec:
                               serviceGatewayId:
                                 description: ID of Service Gateway.
                                 type: string
+                              skip:
+                                description: |-
+                                  Skip specifies whether to skip creating VCN.
+                                  When is set to true, InternetGateway, NatGateway, ServiceGateway, RouteTable must have also Skip set to true
+                                  If set to true(default: false) the ID must be specified by the user to a valid VCN ID.
+                                type: boolean
                               subnets:
                                 description: Subnets is the configuration for subnets
                                   required in the VCN.
                                 items:
-                                  description: Subnet defines the configuration for
-                                    a network's subnet https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingVCNs_topic-Overview_of_VCNs_and_Subnets.htm#Overview
+                                  description: |-
+                                    Subnet defines the configuration for a network's subnet
+                                    https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingVCNs_topic-Overview_of_VCNs_and_Subnets.htm#Overview
                                   properties:
                                     cidr:
                                       description: Subnet CIDR.
                                       type: string
                                     dnsLabel:
-                                      description: DnsLabel DNS label for the subnet,
-                                        used in conjunction with the VNIC's hostname
-                                        and VCN's DNS label to form a fully qualified
-                                        domain name (FQDN) for each VNIC within this
-                                        subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
+                                      description: |-
+                                        DnsLabel DNS label for the subnet, used in conjunction with the VNIC's hostname and
+                                        VCN's DNS label to form a fully qualified domain name (FQDN) for each VNIC
+                                        within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
                                       type: string
                                     id:
                                       description: Subnet OCID.
                                       type: string
-                                    skip:
-                                      description: Skip specifies whether to skip creating subnet
-                                      type: boolean
+                                    ipv6CidrBlockHextet:
+                                      description: |-
+                                        Use this to enable IPv6 hextet for this subnet. The VCN must be enabled for IPv6.
+                                        You can't change this subnet characteristic later. All subnets are /64 in size. The subnet
+                                        portion of the IPv6 address is the fourth hextet from the left (1111 in the following example).
+                                        Example: `2001:0db8:0123:1111::/64`
+                                      type: string
                                     name:
                                       description: Subnet Name.
                                       type: string
@@ -701,55 +632,37 @@ spec:
                                                   of your choice for the rule.
                                                 type: string
                                               destination:
-                                                description: 'Conceptually, this is
-                                                  the range of IP addresses that a
-                                                  packet originating from the instance
-                                                  can go to. Allowed values: * IP
-                                                  address range in CIDR notation.
-                                                  For example: `192.168.1.0/24` or
-                                                  `2001:0db8:0123:45::/56` Note that
-                                                  IPv6 addressing is currently supported
-                                                  only in certain regions. See IPv6
-                                                  Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                                  * The `cidrBlock` value for a Service,
-                                                  if you''re setting up a security
-                                                  list rule for traffic destined for
-                                                  a particular `Service` through a
-                                                  service gateway. For example: `oci-phx-objectstorage`.'
+                                                description: |-
+                                                  Conceptually, this is the range of IP addresses that a packet originating from the instance
+                                                  can go to.
+                                                  Allowed values:
+                                                    * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
+                                                      Note that IPv6 addressing is currently supported only in certain regions. See
+                                                      IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                                    * The `cidrBlock` value for a Service, if you're
+                                                      setting up a security list rule for traffic destined for a particular `Service` through
+                                                      a service gateway. For example: `oci-phx-objectstorage`.
                                                 type: string
                                               destinationType:
-                                                description: 'Type of destination
-                                                  for the rule. The default is `CIDR_BLOCK`.
-                                                  Allowed values: * `CIDR_BLOCK`:
-                                                  If the rule''s `destination` is
-                                                  an IP address range in CIDR notation.
-                                                  * `SERVICE_CIDR_BLOCK`: If the rule''s
-                                                  `destination` is the `cidrBlock`
-                                                  value for a Service (the rule is
-                                                  for traffic destined for a particular
-                                                  `Service` through a service gateway).'
+                                                description: |-
+                                                  Type of destination for the rule. The default is `CIDR_BLOCK`.
+                                                  Allowed values:
+                                                    * `CIDR_BLOCK`: If the rule's `destination` is an IP address range in CIDR notation.
+                                                    * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
+                                                      Service (the rule is for traffic destined for a
+                                                      particular `Service` through a service gateway).
                                                 type: string
                                               icmpOptions:
-                                                description: 'IcmpOptions Optional
-                                                  and valid only for ICMP and ICMPv6.
-                                                  Use to specify a particular ICMP
-                                                  type and code as defined in: - ICMP
-                                                  Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                                description: |-
+                                                  IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                                  as defined in:
+                                                  - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                                   - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                                  If you specify ICMP or ICMPv6 as
-                                                  the protocol but omit this object,
-                                                  then all ICMP types and codes are
-                                                  allowed. If you do provide this
-                                                  object, the type is required and
-                                                  the code is optional. To enable
-                                                  MTU negotiation for ingress internet
-                                                  traffic via IPv4, make sure to allow
-                                                  type 3 ("Destination Unreachable")
-                                                  code 4 ("Fragmentation Needed and
-                                                  Don''t Fragment was Set"). If you
-                                                  need to specify multiple codes for
-                                                  a single type, create a separate
-                                                  security list rule for each.'
+                                                  If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                                  codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                                  To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                                  Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                                  multiple codes for a single type, create a separate security list rule for each.
                                                 properties:
                                                   code:
                                                     description: The ICMP code (optional).
@@ -759,48 +672,33 @@ spec:
                                                     type: integer
                                                 type: object
                                               isStateless:
-                                                description: A stateless rule allows
-                                                  traffic in one direction. Remember
-                                                  to add a corresponding stateless
-                                                  rule in the other direction if you
-                                                  need to support bidirectional traffic.
-                                                  For example, if egress traffic allows
-                                                  TCP destination port 80, there should
-                                                  be an ingress rule to allow TCP
-                                                  source port 80. Defaults to false,
-                                                  which means the rule is stateful
-                                                  and a corresponding rule is not
-                                                  necessary for bidirectional traffic.
+                                                description: |-
+                                                  A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                                  stateless rule in the other direction if you need to support bidirectional traffic. For
+                                                  example, if egress traffic allows TCP destination port 80, there should be an ingress
+                                                  rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                                  and a corresponding rule is not necessary for bidirectional traffic.
                                                 type: boolean
                                               protocol:
-                                                description: The transport protocol.
-                                                  Specify either `all` or an IPv4
-                                                  protocol number as defined in Protocol
-                                                  Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                                  Options are supported only for ICMP
-                                                  ("1"), TCP ("6"), UDP ("17"), and
-                                                  ICMPv6 ("58").
+                                                description: |-
+                                                  The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                                  defined in
+                                                  Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                                  Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                                 type: string
                                               tcpOptions:
-                                                description: TcpOptions Optional and
-                                                  valid only for TCP. Use to specify
-                                                  particular destination ports for
-                                                  TCP rules. If you specify TCP as
-                                                  the protocol but omit this object,
-                                                  then all destination ports are allowed.
+                                                description: |-
+                                                  TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                                  If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                                 properties:
                                                   destinationPortRange:
                                                     description: PortRange The representation
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -814,13 +712,9 @@ spec:
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -831,25 +725,18 @@ spec:
                                                     type: object
                                                 type: object
                                               udpOptions:
-                                                description: UdpOptions Optional and
-                                                  valid only for UDP. Use to specify
-                                                  particular destination ports for
-                                                  UDP rules. If you specify UDP as
-                                                  the protocol but omit this object,
-                                                  then all destination ports are allowed.
+                                                description: |-
+                                                  UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                                  If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                                 properties:
                                                   destinationPortRange:
                                                     description: PortRange The representation
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -863,13 +750,9 @@ spec:
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -895,26 +778,16 @@ spec:
                                                   of your choice for the rule.
                                                 type: string
                                               icmpOptions:
-                                                description: 'IcmpOptions Optional
-                                                  and valid only for ICMP and ICMPv6.
-                                                  Use to specify a particular ICMP
-                                                  type and code as defined in: - ICMP
-                                                  Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                                description: |-
+                                                  IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                                  as defined in:
+                                                  - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                                   - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                                  If you specify ICMP or ICMPv6 as
-                                                  the protocol but omit this object,
-                                                  then all ICMP types and codes are
-                                                  allowed. If you do provide this
-                                                  object, the type is required and
-                                                  the code is optional. To enable
-                                                  MTU negotiation for ingress internet
-                                                  traffic via IPv4, make sure to allow
-                                                  type 3 ("Destination Unreachable")
-                                                  code 4 ("Fragmentation Needed and
-                                                  Don''t Fragment was Set"). If you
-                                                  need to specify multiple codes for
-                                                  a single type, create a separate
-                                                  security list rule for each.'
+                                                  If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                                  codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                                  To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                                  Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                                  multiple codes for a single type, create a separate security list rule for each.
                                                 properties:
                                                   code:
                                                     description: The ICMP code (optional).
@@ -924,77 +797,53 @@ spec:
                                                     type: integer
                                                 type: object
                                               isStateless:
-                                                description: A stateless rule allows
-                                                  traffic in one direction. Remember
-                                                  to add a corresponding stateless
-                                                  rule in the other direction if you
-                                                  need to support bidirectional traffic.
-                                                  For example, if ingress traffic
-                                                  allows TCP destination port 80,
-                                                  there should be an egress rule to
-                                                  allow TCP source port 80. Defaults
-                                                  to false, which means the rule is
-                                                  stateful and a corresponding rule
-                                                  is not necessary for bidirectional
-                                                  traffic.
+                                                description: |-
+                                                  A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                                  stateless rule in the other direction if you need to support bidirectional traffic. For
+                                                  example, if ingress traffic allows TCP destination port 80, there should be an egress
+                                                  rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                                  and a corresponding rule is not necessary for bidirectional traffic.
                                                 type: boolean
                                               protocol:
-                                                description: The transport protocol.
-                                                  Specify either `all` or an IPv4
-                                                  protocol number as defined in Protocol
-                                                  Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                                  Options are supported only for ICMP
-                                                  ("1"), TCP ("6"), UDP ("17"), and
-                                                  ICMPv6 ("58").
+                                                description: |-
+                                                  The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                                  defined in
+                                                  Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                                  Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                                 type: string
                                               source:
-                                                description: 'Conceptually, this is
-                                                  the range of IP addresses that a
-                                                  packet coming into the instance
-                                                  can come from. Allowed values: *
-                                                  IP address range in CIDR notation.
-                                                  For example: `192.168.1.0/24` or
-                                                  `2001:0db8:0123:45::/56`. IPv6 addressing
-                                                  is supported for all commercial
-                                                  and government regions. See IPv6
-                                                  Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                                  * The `cidrBlock` value for a Service,
-                                                  if you''re setting up a security
-                                                  list rule for traffic coming from
-                                                  a particular `Service` through a
-                                                  service gateway. For example: `oci-phx-objectstorage`.'
+                                                description: |-
+                                                  Conceptually, this is the range of IP addresses that a packet coming into the instance
+                                                  can come from.
+                                                  Allowed values:
+                                                    * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
+                                                      IPv6 addressing is supported for all commercial and government regions. See
+                                                      IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                                    * The `cidrBlock` value for a Service, if you're
+                                                      setting up a security list rule for traffic coming from a particular `Service` through
+                                                      a service gateway. For example: `oci-phx-objectstorage`.
                                                 type: string
                                               sourceType:
-                                                description: 'Type of source for the
-                                                  rule. The default is `CIDR_BLOCK`.
-                                                  * `CIDR_BLOCK`: If the rule''s `source`
-                                                  is an IP address range in CIDR notation.
-                                                  * `SERVICE_CIDR_BLOCK`: If the rule''s
-                                                  `source` is the `cidrBlock` value
-                                                  for a Service (the rule is for traffic
-                                                  coming from a particular `Service`
-                                                  through a service gateway).'
+                                                description: |-
+                                                  Type of source for the rule. The default is `CIDR_BLOCK`.
+                                                    * `CIDR_BLOCK`: If the rule's `source` is an IP address range in CIDR notation.
+                                                    * `SERVICE_CIDR_BLOCK`: If the rule's `source` is the `cidrBlock` value for a
+                                                      Service (the rule is for traffic coming from a
+                                                      particular `Service` through a service gateway).
                                                 type: string
                                               tcpOptions:
-                                                description: TcpOptions Optional and
-                                                  valid only for TCP. Use to specify
-                                                  particular destination ports for
-                                                  TCP rules. If you specify TCP as
-                                                  the protocol but omit this object,
-                                                  then all destination ports are allowed.
+                                                description: |-
+                                                  TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                                  If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                                 properties:
                                                   destinationPortRange:
                                                     description: PortRange The representation
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -1008,13 +857,9 @@ spec:
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -1025,25 +870,18 @@ spec:
                                                     type: object
                                                 type: object
                                               udpOptions:
-                                                description: UdpOptions Optional and
-                                                  valid only for UDP. Use to specify
-                                                  particular destination ports for
-                                                  UDP rules. If you specify UDP as
-                                                  the protocol but omit this object,
-                                                  then all destination ports are allowed.
+                                                description: |-
+                                                  UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                                  If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                                 properties:
                                                   destinationPortRange:
                                                     description: PortRange The representation
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -1057,13 +895,9 @@ spec:
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -1079,6 +913,11 @@ spec:
                                           description: SecurityList Name.
                                           type: string
                                       type: object
+                                    skip:
+                                      description: |-
+                                        Skip specifies whether to skip creating subnets. If set to true (default: false) the ID
+                                        must be specified by the user to a valid Subnet ID.
+                                      type: boolean
                                     type:
                                       description: Type defines the subnet type (e.g.
                                         public, private).
@@ -1096,83 +935,73 @@ spec:
                             description: VCNPeering configuration.
                             properties:
                               drg:
-                                description: DRG configuration refers to the DRG which
-                                  has to be created if required. If management cluster
-                                  and workload cluster shares the same DRG, this fields
-                                  is not required to be specified.
+                                description: |-
+                                  DRG configuration refers to the DRG which has to be created if required. If management cluster
+                                  and workload cluster shares the same DRG, this fields is not required to be specified.
                                 properties:
                                   id:
                                     description: ID is the OCID for the created DRG.
                                     type: string
                                   manage:
-                                    description: Manage defines whether the DRG has
-                                      to be managed(including create). If set to false(the
-                                      default) the ID has to be specified by the user
-                                      to a valid DRG ID to which the VCN has to be
-                                      attached.
+                                    description: |-
+                                      Manage defines whether the DRG has to be managed(including create). If set to false(the default) the ID
+                                      has to be specified by the user to a valid DRG ID to which the VCN has to be attached.
                                     type: boolean
                                   name:
                                     description: Name is the name of the created DRG.
                                     type: string
                                   vcnAttachmentId:
-                                    description: VcnAttachmentId is the ID of the
-                                      VCN attachment of the DRG. The workload cluster
-                                      VCN can be attached to either the management
-                                      cluster VCN if they are sharing the same DRG
+                                    description: |-
+                                      VcnAttachmentId is the ID of the VCN attachment of the DRG.
+                                      The workload cluster VCN can be attached to either the management cluster VCN if they are sharing the same DRG
                                       or to the workload cluster DRG.
                                     type: string
                                 type: object
                               peerRouteRules:
-                                description: PeerRouteRules defines the routing rules
-                                  which will be added to the private route tables
-                                  of the workload cluster VCN. The routes defined
-                                  here will be directed to DRG.
+                                description: |-
+                                  PeerRouteRules defines the routing rules which will be added to the private route tables
+                                  of the workload cluster VCN. The routes defined here will be directed to DRG.
                                 items:
                                   description: PeerRouteRule defines a Route Rule
                                     to be routed via a DRG.
                                   properties:
                                     vcnCIDRRange:
-                                      description: VCNCIDRRange is the CIDR Range
-                                        of peer VCN to which the workload cluster
-                                        VCN will be peered. The CIDR range is required
-                                        to add the route rule in the workload cluster
-                                        VCN, the route rule will forward any traffic
-                                        to the CIDR to the DRG.
+                                      description: |-
+                                        VCNCIDRRange is the CIDR Range of peer VCN to which the
+                                        workload cluster VCN will be peered. The CIDR range is required to add the route rule
+                                        in the workload cluster VCN, the route rule will forward any traffic to the CIDR to the DRG.
                                       type: string
                                   type: object
                                 type: array
                               remotePeeringConnections:
-                                description: RemotePeeringConnections defines the
-                                  RPC connections which be established with the workload
-                                  cluster DRG.
+                                description: |-
+                                  RemotePeeringConnections defines the RPC connections which be established with the
+                                  workload cluster DRG.
                                 items:
-                                  description: RemotePeeringConnection is used to
-                                    peer VCNs residing in different regions(typically).
+                                  description: |-
+                                    RemotePeeringConnection is used to peer VCNs residing in different regions(typically).
                                     Remote VCN Peering is explained here - https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/remoteVCNpeering.htm
                                   properties:
                                     managePeerRPC:
-                                      description: ManagePeerRPC will define if the
-                                        Peer VCN needs to be managed. If set to true
-                                        a Remote Peering Connection will be created
-                                        in the Peer DRG and the connection will be
-                                        created between local and peer RPC.
+                                      description: |-
+                                        ManagePeerRPC will define if the Peer VCN needs to be managed. If set to true
+                                        a Remote Peering Connection will be created in the Peer DRG and the connection
+                                        will be created between local and peer RPC.
                                       type: boolean
                                     name:
-                                      description: A unique name identifying the RPC,
-                                        please note this is to identify the RPC from
-                                        other RPC elements, and will not be used in
-                                        any OCI API call.
+                                      description: |-
+                                        A unique name identifying the RPC, please note this is to identify the RPC
+                                        from other RPC elements, and will not be used in any OCI API call.
                                       type: string
                                     peerDRGId:
                                       description: PeerDRGId defines the DRG ID of
                                         the peer.
                                       type: string
                                     peerRPCConnectionId:
-                                      description: PeerRPCConnectionId defines the
-                                        RPC ID of peer. If ManagePeerRPC is set to
-                                        true this will be created by Cluster API Provider
-                                        for OCI, otherwise this has be defined by
-                                        the user.
+                                      description: |-
+                                        PeerRPCConnectionId defines the RPC ID of peer. If ManagePeerRPC is set to true
+                                        this will be created by Cluster API Provider for OCI, otherwise this has be defined by the
+                                        user.
                                       type: string
                                     peerRegionName:
                                       description: PeerRegionName defined the region
@@ -1188,14 +1017,15 @@ spec:
                             type: object
                         type: object
                       ociResourceIdentifier:
-                        description: The unique ID which will be used to tag all the
-                          resources created by this Cluster. The tag will be used
-                          to identify resources belonging to this cluster. this will
-                          be auto-generated and should not be set by the user.
+                        description: |-
+                          The unique ID which will be used to tag all the resources created by this Cluster.
+                          The tag will be used to identify resources belonging to this cluster.
+                          this will be auto-generated and should not be set by the user.
                         type: string
                       region:
-                        description: Region the cluster operates in. It must be one
-                          of available regions in Region Identifier format. See https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm
+                        description: |-
+                          Region the cluster operates in. It must be one of available regions in Region Identifier format.
+                          See https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm
                         type: string
                     type: object
                 required:
@@ -1214,14 +1044,19 @@ spec:
           API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -1253,10 +1088,9 @@ spec:
                                 Uocm:PHX-AD-1'
                               type: string
                           type: object
-                        description: AvailabilityDomains encapsulates the clusters
-                          Availability Domain (AD) information in a map where the
-                          map key is the AD name and the struct is details about the
-                          AD.
+                        description: |-
+                          AvailabilityDomains encapsulates the clusters Availability Domain (AD) information in a map
+                          where the map key is the AD name and the struct is details about the AD.
                         type: object
                       compartmentId:
                         description: Compartment to create the cluster network.
@@ -1269,10 +1103,13 @@ spec:
                           has an endpoint address
                         properties:
                           host:
-                            description: The hostname on which the API server is serving.
+                            description: host is the hostname on which the API server
+                              is serving.
+                            maxLength: 512
                             type: string
                           port:
-                            description: The port on which the API server is serving.
+                            description: port is the port on which the API server
+                              is serving.
                             format: int32
                             type: integer
                         required:
@@ -1284,10 +1121,10 @@ spec:
                           additionalProperties:
                             type: string
                           type: object
-                        description: 'Defined tags for this resource. Each key is
-                          predefined and scoped to a namespace. For more information,
-                          see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
-                          Example: `{"Operations": {"CostCenter": "42"}}`'
+                        description: |-
+                          Defined tags for this resource. Each key is predefined and scoped to a
+                          namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+                          Example: `{"Operations": {"CostCenter": "42"}}`
                         type: object
                       freeformTags:
                         additionalProperties:
@@ -1300,8 +1137,8 @@ spec:
                         nullable: true
                         properties:
                           certOverride:
-                            description: CertOverride is a secret that contains information
-                              about a cert override used by all the OCI SDK clients.
+                            description: |-
+                              CertOverride is a secret that contains information about a cert override used by all the OCI SDK clients.
                               The secret must contain data with a `cert`property.
                             nullable: true
                             properties:
@@ -1364,34 +1201,39 @@ spec:
                             description: API version of the referent.
                             type: string
                           fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
                             type: string
                           kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                             type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                             type: string
                           namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                             type: string
                           resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                             type: string
                           uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
@@ -1426,17 +1268,16 @@ spec:
                                           unhealthy.
                                         properties:
                                           urlPath:
-                                            description: 'The path against which to
-                                              run the health check. Example: `/healthcheck`
-                                              Default value is `/healthz`'
+                                            description: |-
+                                              The path against which to run the health check.
+                                              Example: `/healthcheck`
+                                              Default value is `/healthz`
                                             type: string
                                         type: object
                                       isFailOpen:
-                                        description: If enabled, the network load
-                                          balancer will continue to distribute traffic
-                                          in the configured distribution in the event
-                                          all backends are unhealthy. The value is
-                                          false by default.
+                                        description: |-
+                                          If enabled, the network load balancer will continue to distribute traffic in the configured distribution in the event all backends are unhealthy.
+                                          The value is false by default.
                                         type: boolean
                                       isInstantFailoverEnabled:
                                         description: If enabled existing connections
@@ -1445,29 +1286,30 @@ spec:
                                           unhealthy.
                                         type: boolean
                                       isPreserveSource:
-                                        description: If this parameter is enabled,
-                                          then the network load balancer preserves
-                                          the source IP of the packet when it is forwarded
-                                          to backends. Backends see the original source
-                                          IP. If the isPreserveSourceDestination parameter
-                                          is enabled for the network load balancer
-                                          resource, then this parameter cannot be
-                                          disabled. The value is false by default.
+                                        description: |-
+                                          If this parameter is enabled, then the network load balancer preserves the source IP of the packet when it is forwarded to backends.
+                                          Backends see the original source IP. If the isPreserveSourceDestination parameter is enabled for the network load balancer resource, then this parameter cannot be disabled.
+                                          The value is false by default.
                                         type: boolean
                                     type: object
                                 type: object
                             type: object
+                          compartmentId:
+                            description: CompartmentId where to provision network
+                              resources
+                            type: string
                           skipNetworkManagement:
-                            description: SkipNetworkManagement defines if the networking
-                              spec(VCN related) specified by the user needs to be
-                              reconciled(actioned-upon) or used as it is. APIServerLB
-                              will still be reconciled.
+                            description: |-
+                              SkipNetworkManagement defines if the networking spec(VCN related) specified by the user needs to be reconciled(actioned-upon)
+                              or used as it is. APIServerLB will still be reconciled.
                             type: boolean
                           vcn:
                             description: VCN configuration.
                             properties:
                               cidr:
-                                description: VCN CIDR. Deprecated, please use NetworkDetails.cidrs
+                                description: |-
+                                  VCN CIDR.
+                                  Deprecated, please use NetworkDetails.cidrs
                                 type: string
                               cidrs:
                                 description: VCN CIDRs.
@@ -1475,18 +1317,14 @@ spec:
                                   type: string
                                 type: array
                               dnsLabel:
-                                description: DnsLabel specifies a DNS label for the
-                                  VCN, used in conjunction with the VNIC's hostname
-                                  and subnet's DNS label to form a fully qualified
-                                  domain name (FQDN) for each VNIC within this subnet
-                                  (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
+                                description: |-
+                                  DnsLabel specifies a DNS label for the VCN, used in conjunction with the VNIC's hostname and
+                                  subnet's DNS label to form a fully qualified domain name (FQDN) for each VNIC
+                                  within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
                                 type: string
                               id:
                                 description: VCN OCID.
                                 type: string
-                              skip:
-                                description: Skip specifies whether to skip creating vcn
-                                type: boolean
                               internetGateway:
                                 description: Configuration for Internet Gateway.
                                 properties:
@@ -1494,10 +1332,19 @@ spec:
                                     description: ID of Internet Gateway.
                                     type: string
                                   skip:
-                                    description: Skip specifies whether to skip creating
-                                      internet gateway even if any one Subnet is public.
+                                    description: |-
+                                      Skip specifies whether to skip creating internet gateway even if any one Subnet is public.
+                                      In case of VCN being Skipped (Skip field of VCN set to true), this field must be true also
                                     type: boolean
                                 type: object
+                              isIpv6Enabled:
+                                description: Configuration to enable IPv6.
+                                type: boolean
+                              isOracleGuaAllocationEnabled:
+                                description: Configuration to allow OCI to assign
+                                  IPv6 Prefix. When true will use a /56 IPv6 global
+                                  unicast address (GUA) prefix allocated by Oracle
+                                type: boolean
                               name:
                                 description: VCN Name.
                                 type: string
@@ -1508,8 +1355,9 @@ spec:
                                     description: ID of Nat Gateway.
                                     type: string
                                   skip:
-                                    description: Skip specifies whether to skip creating
-                                      NAT gateway even if any one Subnet is private.
+                                    description: |-
+                                      Skip specifies whether to skip creating NAT gateway even if any one Subnet is private.
+                                      In case of VCN being Skipped (Skip field of VCN set to true), this field must be true also
                                     type: boolean
                                 type: object
                               networkSecurityGroup:
@@ -1520,8 +1368,9 @@ spec:
                                       for the Network Security Groups required in
                                       the VCN.
                                     items:
-                                      description: NSG defines configuration for a
-                                        Network Security Group. https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/networksecuritygroups.htm
+                                      description: |-
+                                        NSG defines configuration for a Network Security Group.
+                                        https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/networksecuritygroups.htm
                                       properties:
                                         egressRules:
                                           description: EgressRules on the NSG.
@@ -1538,64 +1387,39 @@ spec:
                                                       of your choice for the rule.
                                                     type: string
                                                   destination:
-                                                    description: 'Conceptually, this
-                                                      is the range of IP addresses
-                                                      that a packet originating from
-                                                      the instance can go to. Allowed
-                                                      values: * IP address range in
-                                                      CIDR notation. For example:
-                                                      `192.168.1.0/24` or `2001:0db8:0123:45::/56`
-                                                      Note that IPv6 addressing is
-                                                      currently supported only in
-                                                      certain regions. See IPv6 Addresses
-                                                      (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                                      * The `cidrBlock` value for
-                                                      a Service, if you''re setting
-                                                      up a security list rule for
-                                                      traffic destined for a particular
-                                                      `Service` through a service
-                                                      gateway. For example: `oci-phx-objectstorage`.'
+                                                    description: |-
+                                                      Conceptually, this is the range of IP addresses that a packet originating from the instance
+                                                      can go to.
+                                                      Allowed values:
+                                                        * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
+                                                          Note that IPv6 addressing is currently supported only in certain regions. See
+                                                          IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                                        * The `cidrBlock` value for a Service, if you're
+                                                          setting up a security list rule for traffic destined for a particular `Service` through
+                                                          a service gateway. For example: `oci-phx-objectstorage`.
                                                     type: string
                                                   destinationType:
-                                                    description: 'Type of destination
-                                                      for the rule. The default is
-                                                      `CIDR_BLOCK`. Allowed values:
-                                                      * `CIDR_BLOCK`: If the rule''s
-                                                      `destination` is an IP address
-                                                      range in CIDR notation. * `SERVICE_CIDR_BLOCK`:
-                                                      If the rule''s `destination`
-                                                      is the `cidrBlock` value for
-                                                      a Service (the rule is for traffic
-                                                      destined for a particular `Service`
-                                                      through a service gateway).
-                                                      * `NETWORK_SECURITY_GROUP`:
-                                                      If the rule''s `destination`
-                                                      is the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)
-                                                      of a NetworkSecurityGroup.'
+                                                    description: |-
+                                                      Type of destination for the rule. The default is `CIDR_BLOCK`.
+                                                      Allowed values:
+                                                        * `CIDR_BLOCK`: If the rule's `destination` is an IP address range in CIDR notation.
+                                                        * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
+                                                          Service (the rule is for traffic destined for a
+                                                          particular `Service` through a service gateway).
+                                                        * `NETWORK_SECURITY_GROUP`: If the rule's `destination` is the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a
+                                                          NetworkSecurityGroup.
                                                     type: string
                                                   icmpOptions:
-                                                    description: 'IcmpOptions Optional
-                                                      and valid only for ICMP and
-                                                      ICMPv6. Use to specify a particular
-                                                      ICMP type and code as defined
-                                                      in: - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                                    description: |-
+                                                      IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                                      as defined in:
+                                                      - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                                       - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                                      If you specify ICMP or ICMPv6
-                                                      as the protocol but omit this
-                                                      object, then all ICMP types
-                                                      and codes are allowed. If you
-                                                      do provide this object, the
-                                                      type is required and the code
-                                                      is optional. To enable MTU negotiation
-                                                      for ingress internet traffic
-                                                      via IPv4, make sure to allow
-                                                      type 3 ("Destination Unreachable")
-                                                      code 4 ("Fragmentation Needed
-                                                      and Don''t Fragment was Set").
-                                                      If you need to specify multiple
-                                                      codes for a single type, create
-                                                      a separate security list rule
-                                                      for each.'
+                                                      If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                                      codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                                      To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                                      Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                                      multiple codes for a single type, create a separate security list rule for each.
                                                     properties:
                                                       code:
                                                         description: The ICMP code
@@ -1606,52 +1430,33 @@ spec:
                                                         type: integer
                                                     type: object
                                                   isStateless:
-                                                    description: A stateless rule
-                                                      allows traffic in one direction.
-                                                      Remember to add a corresponding
-                                                      stateless rule in the other
-                                                      direction if you need to support
-                                                      bidirectional traffic. For example,
-                                                      if egress traffic allows TCP
-                                                      destination port 80, there should
-                                                      be an ingress rule to allow
-                                                      TCP source port 80. Defaults
-                                                      to false, which means the rule
-                                                      is stateful and a corresponding
-                                                      rule is not necessary for bidirectional
-                                                      traffic.
+                                                    description: |-
+                                                      A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                                      stateless rule in the other direction if you need to support bidirectional traffic. For
+                                                      example, if egress traffic allows TCP destination port 80, there should be an ingress
+                                                      rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                                      and a corresponding rule is not necessary for bidirectional traffic.
                                                     type: boolean
                                                   protocol:
-                                                    description: The transport protocol.
-                                                      Specify either `all` or an IPv4
-                                                      protocol number as defined in
+                                                    description: |-
+                                                      The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                                      defined in
                                                       Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                                      Options are supported only for
-                                                      ICMP ("1"), TCP ("6"), UDP ("17"),
-                                                      and ICMPv6 ("58").
+                                                      Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                                     type: string
                                                   tcpOptions:
-                                                    description: TcpOptions Optional
-                                                      and valid only for TCP. Use
-                                                      to specify particular destination
-                                                      ports for TCP rules. If you
-                                                      specify TCP as the protocol
-                                                      but omit this object, then all
-                                                      destination ports are allowed.
+                                                    description: |-
+                                                      TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                                      If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                                     properties:
                                                       destinationPortRange:
                                                         description: PortRange The
                                                           representation of PortRange.
                                                         properties:
                                                           max:
-                                                            description: The maximum
-                                                              port number, which must
-                                                              not be less than the
-                                                              minimum port number.
-                                                              To specify a single
-                                                              port number, set both
-                                                              the min and max to the
-                                                              same value.
+                                                            description: |-
+                                                              The maximum port number, which must not be less than the minimum port number. To specify
+                                                              a single port number, set both the min and max to the same value.
                                                             type: integer
                                                           min:
                                                             description: The minimum
@@ -1665,14 +1470,9 @@ spec:
                                                           representation of PortRange.
                                                         properties:
                                                           max:
-                                                            description: The maximum
-                                                              port number, which must
-                                                              not be less than the
-                                                              minimum port number.
-                                                              To specify a single
-                                                              port number, set both
-                                                              the min and max to the
-                                                              same value.
+                                                            description: |-
+                                                              The maximum port number, which must not be less than the minimum port number. To specify
+                                                              a single port number, set both the min and max to the same value.
                                                             type: integer
                                                           min:
                                                             description: The minimum
@@ -1683,27 +1483,18 @@ spec:
                                                         type: object
                                                     type: object
                                                   udpOptions:
-                                                    description: UdpOptions Optional
-                                                      and valid only for UDP. Use
-                                                      to specify particular destination
-                                                      ports for UDP rules. If you
-                                                      specify UDP as the protocol
-                                                      but omit this object, then all
-                                                      destination ports are allowed.
+                                                    description: |-
+                                                      UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                                      If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                                     properties:
                                                       destinationPortRange:
                                                         description: PortRange The
                                                           representation of PortRange.
                                                         properties:
                                                           max:
-                                                            description: The maximum
-                                                              port number, which must
-                                                              not be less than the
-                                                              minimum port number.
-                                                              To specify a single
-                                                              port number, set both
-                                                              the min and max to the
-                                                              same value.
+                                                            description: |-
+                                                              The maximum port number, which must not be less than the minimum port number. To specify
+                                                              a single port number, set both the min and max to the same value.
                                                             type: integer
                                                           min:
                                                             description: The minimum
@@ -1717,14 +1508,9 @@ spec:
                                                           representation of PortRange.
                                                         properties:
                                                           max:
-                                                            description: The maximum
-                                                              port number, which must
-                                                              not be less than the
-                                                              minimum port number.
-                                                              To specify a single
-                                                              port number, set both
-                                                              the min and max to the
-                                                              same value.
+                                                            description: |-
+                                                              The maximum port number, which must not be less than the minimum port number. To specify
+                                                              a single port number, set both the min and max to the same value.
                                                             type: integer
                                                           min:
                                                             description: The minimum
@@ -1755,28 +1541,16 @@ spec:
                                                       of your choice for the rule.
                                                     type: string
                                                   icmpOptions:
-                                                    description: 'IcmpOptions Optional
-                                                      and valid only for ICMP and
-                                                      ICMPv6. Use to specify a particular
-                                                      ICMP type and code as defined
-                                                      in: - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                                    description: |-
+                                                      IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                                      as defined in:
+                                                      - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                                       - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                                      If you specify ICMP or ICMPv6
-                                                      as the protocol but omit this
-                                                      object, then all ICMP types
-                                                      and codes are allowed. If you
-                                                      do provide this object, the
-                                                      type is required and the code
-                                                      is optional. To enable MTU negotiation
-                                                      for ingress internet traffic
-                                                      via IPv4, make sure to allow
-                                                      type 3 ("Destination Unreachable")
-                                                      code 4 ("Fragmentation Needed
-                                                      and Don''t Fragment was Set").
-                                                      If you need to specify multiple
-                                                      codes for a single type, create
-                                                      a separate security list rule
-                                                      for each.'
+                                                      If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                                      codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                                      To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                                      Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                                      multiple codes for a single type, create a separate security list rule for each.
                                                     properties:
                                                       code:
                                                         description: The ICMP code
@@ -1787,87 +1561,55 @@ spec:
                                                         type: integer
                                                     type: object
                                                   isStateless:
-                                                    description: A stateless rule
-                                                      allows traffic in one direction.
-                                                      Remember to add a corresponding
-                                                      stateless rule in the other
-                                                      direction if you need to support
-                                                      bidirectional traffic. For example,
-                                                      if ingress traffic allows TCP
-                                                      destination port 80, there should
-                                                      be an egress rule to allow TCP
-                                                      source port 80. Defaults to
-                                                      false, which means the rule
-                                                      is stateful and a corresponding
-                                                      rule is not necessary for bidirectional
-                                                      traffic.
+                                                    description: |-
+                                                      A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                                      stateless rule in the other direction if you need to support bidirectional traffic. For
+                                                      example, if ingress traffic allows TCP destination port 80, there should be an egress
+                                                      rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                                      and a corresponding rule is not necessary for bidirectional traffic.
                                                     type: boolean
                                                   protocol:
-                                                    description: The transport protocol.
-                                                      Specify either `all` or an IPv4
-                                                      protocol number as defined in
+                                                    description: |-
+                                                      The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                                      defined in
                                                       Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                                      Options are supported only for
-                                                      ICMP ("1"), TCP ("6"), UDP ("17"),
-                                                      and ICMPv6 ("58").
+                                                      Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                                     type: string
                                                   source:
-                                                    description: 'Conceptually, this
-                                                      is the range of IP addresses
-                                                      that a packet coming into the
-                                                      instance can come from. Allowed
-                                                      values: * IP address range in
-                                                      CIDR notation. For example:
-                                                      `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
-                                                      IPv6 addressing is supported
-                                                      for all commercial and government
-                                                      regions. See IPv6 Addresses
-                                                      (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                                      * The `cidrBlock` value for
-                                                      a Service, if you''re setting
-                                                      up a security list rule for
-                                                      traffic coming from a particular
-                                                      `Service` through a service
-                                                      gateway. For example: `oci-phx-objectstorage`.'
+                                                    description: |-
+                                                      Conceptually, this is the range of IP addresses that a packet coming into the instance
+                                                      can come from.
+                                                      Allowed values:
+                                                        * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
+                                                          IPv6 addressing is supported for all commercial and government regions. See
+                                                          IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                                        * The `cidrBlock` value for a Service, if you're
+                                                          setting up a security list rule for traffic coming from a particular `Service` through
+                                                          a service gateway. For example: `oci-phx-objectstorage`.
                                                     type: string
                                                   sourceType:
-                                                    description: 'Type of source for
-                                                      the rule. The default is `CIDR_BLOCK`.
-                                                      * `CIDR_BLOCK`: If the rule''s
-                                                      `source` is an IP address range
-                                                      in CIDR notation. * `SERVICE_CIDR_BLOCK`:
-                                                      If the rule''s `source` is the
-                                                      `cidrBlock` value for a Service
-                                                      (the rule is for traffic coming
-                                                      from a particular `Service`
-                                                      through a service gateway).
-                                                      * `NETWORK_SECURITY_GROUP`:
-                                                      If the rule''s `destination`
-                                                      is the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)
-                                                      of a NetworkSecurityGroup.'
+                                                    description: |-
+                                                      Type of source for the rule. The default is `CIDR_BLOCK`.
+                                                        * `CIDR_BLOCK`: If the rule's `source` is an IP address range in CIDR notation.
+                                                        * `SERVICE_CIDR_BLOCK`: If the rule's `source` is the `cidrBlock` value for a
+                                                          Service (the rule is for traffic coming from a
+                                                          particular `Service` through a service gateway).
+                                                        * `NETWORK_SECURITY_GROUP`: If the rule's `destination` is the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a
+                                                          NetworkSecurityGroup.
                                                     type: string
                                                   tcpOptions:
-                                                    description: TcpOptions Optional
-                                                      and valid only for TCP. Use
-                                                      to specify particular destination
-                                                      ports for TCP rules. If you
-                                                      specify TCP as the protocol
-                                                      but omit this object, then all
-                                                      destination ports are allowed.
+                                                    description: |-
+                                                      TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                                      If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                                     properties:
                                                       destinationPortRange:
                                                         description: PortRange The
                                                           representation of PortRange.
                                                         properties:
                                                           max:
-                                                            description: The maximum
-                                                              port number, which must
-                                                              not be less than the
-                                                              minimum port number.
-                                                              To specify a single
-                                                              port number, set both
-                                                              the min and max to the
-                                                              same value.
+                                                            description: |-
+                                                              The maximum port number, which must not be less than the minimum port number. To specify
+                                                              a single port number, set both the min and max to the same value.
                                                             type: integer
                                                           min:
                                                             description: The minimum
@@ -1881,14 +1623,9 @@ spec:
                                                           representation of PortRange.
                                                         properties:
                                                           max:
-                                                            description: The maximum
-                                                              port number, which must
-                                                              not be less than the
-                                                              minimum port number.
-                                                              To specify a single
-                                                              port number, set both
-                                                              the min and max to the
-                                                              same value.
+                                                            description: |-
+                                                              The maximum port number, which must not be less than the minimum port number. To specify
+                                                              a single port number, set both the min and max to the same value.
                                                             type: integer
                                                           min:
                                                             description: The minimum
@@ -1899,27 +1636,18 @@ spec:
                                                         type: object
                                                     type: object
                                                   udpOptions:
-                                                    description: UdpOptions Optional
-                                                      and valid only for UDP. Use
-                                                      to specify particular destination
-                                                      ports for UDP rules. If you
-                                                      specify UDP as the protocol
-                                                      but omit this object, then all
-                                                      destination ports are allowed.
+                                                    description: |-
+                                                      UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                                      If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                                     properties:
                                                       destinationPortRange:
                                                         description: PortRange The
                                                           representation of PortRange.
                                                         properties:
                                                           max:
-                                                            description: The maximum
-                                                              port number, which must
-                                                              not be less than the
-                                                              minimum port number.
-                                                              To specify a single
-                                                              port number, set both
-                                                              the min and max to the
-                                                              same value.
+                                                            description: |-
+                                                              The maximum port number, which must not be less than the minimum port number. To specify
+                                                              a single port number, set both the min and max to the same value.
                                                             type: integer
                                                           min:
                                                             description: The minimum
@@ -1933,14 +1661,9 @@ spec:
                                                           representation of PortRange.
                                                         properties:
                                                           max:
-                                                            description: The maximum
-                                                              port number, which must
-                                                              not be less than the
-                                                              minimum port number.
-                                                              To specify a single
-                                                              port number, set both
-                                                              the min and max to the
-                                                              same value.
+                                                            description: |-
+                                                              The maximum port number, which must not be less than the minimum port number. To specify
+                                                              a single port number, set both the min and max to the same value.
                                                             type: integer
                                                           min:
                                                             description: The minimum
@@ -1983,8 +1706,9 @@ spec:
                                     description: ID of Public Route Table.
                                     type: string
                                   skip:
-                                    description: Skip specifies whether to skip creating
-                                      Route table.
+                                    description: |-
+                                      Skip specifies whether to skip creating Route table.
+                                      In case of VCN being Skipped (Skip field of VCN set to true), this field must be true also
                                     type: boolean
                                 type: object
                               serviceGateway:
@@ -1994,33 +1718,44 @@ spec:
                                     description: ID of Service Gateway.
                                     type: string
                                   skip:
-                                    description: Skip specifies whether to skip creating
-                                      Service gateway.
+                                    description: |-
+                                      Skip specifies whether to skip creating Service gateway.
+                                      In case of VCN being Skipped (Skip field of VCN set to true), this field must be true also
                                     type: boolean
                                 type: object
+                              skip:
+                                description: |-
+                                  Skip specifies whether to skip creating VCN.
+                                  When is set to true, InternetGateway, NatGateway, ServiceGateway, RouteTable must have also Skip set to true
+                                  If set to true(default: false) the ID must be specified by the user to a valid VCN ID.
+                                type: boolean
                               subnets:
                                 description: Subnets is the configuration for subnets
                                   required in the VCN.
                                 items:
-                                  description: Subnet defines the configuration for
-                                    a network's subnet https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingVCNs_topic-Overview_of_VCNs_and_Subnets.htm#Overview
+                                  description: |-
+                                    Subnet defines the configuration for a network's subnet
+                                    https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingVCNs_topic-Overview_of_VCNs_and_Subnets.htm#Overview
                                   properties:
                                     cidr:
                                       description: Subnet CIDR.
                                       type: string
                                     dnsLabel:
-                                      description: DnsLabel DNS label for the subnet,
-                                        used in conjunction with the VNIC's hostname
-                                        and VCN's DNS label to form a fully qualified
-                                        domain name (FQDN) for each VNIC within this
-                                        subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
+                                      description: |-
+                                        DnsLabel DNS label for the subnet, used in conjunction with the VNIC's hostname and
+                                        VCN's DNS label to form a fully qualified domain name (FQDN) for each VNIC
+                                        within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
                                       type: string
                                     id:
                                       description: Subnet OCID.
                                       type: string
-                                    skip:
-                                      description: Skip specifies whether to skip creating subnet
-                                      type: boolean
+                                    ipv6CidrBlockHextet:
+                                      description: |-
+                                        Use this to enable IPv6 hextet for this subnet. The VCN must be enabled for IPv6.
+                                        You can't change this subnet characteristic later. All subnets are /64 in size. The subnet
+                                        portion of the IPv6 address is the fourth hextet from the left (1111 in the following example).
+                                        Example: `2001:0db8:0123:1111::/64`
+                                      type: string
                                     name:
                                       description: Subnet Name.
                                       type: string
@@ -2044,59 +1779,39 @@ spec:
                                                   of your choice for the rule.
                                                 type: string
                                               destination:
-                                                description: 'Conceptually, this is
-                                                  the range of IP addresses that a
-                                                  packet originating from the instance
-                                                  can go to. Allowed values: * IP
-                                                  address range in CIDR notation.
-                                                  For example: `192.168.1.0/24` or
-                                                  `2001:0db8:0123:45::/56` Note that
-                                                  IPv6 addressing is currently supported
-                                                  only in certain regions. See IPv6
-                                                  Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                                  * The `cidrBlock` value for a Service,
-                                                  if you''re setting up a security
-                                                  list rule for traffic destined for
-                                                  a particular `Service` through a
-                                                  service gateway. For example: `oci-phx-objectstorage`.'
+                                                description: |-
+                                                  Conceptually, this is the range of IP addresses that a packet originating from the instance
+                                                  can go to.
+                                                  Allowed values:
+                                                    * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
+                                                      Note that IPv6 addressing is currently supported only in certain regions. See
+                                                      IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                                    * The `cidrBlock` value for a Service, if you're
+                                                      setting up a security list rule for traffic destined for a particular `Service` through
+                                                      a service gateway. For example: `oci-phx-objectstorage`.
                                                 type: string
                                               destinationType:
-                                                description: 'Type of destination
-                                                  for the rule. The default is `CIDR_BLOCK`.
-                                                  Allowed values: * `CIDR_BLOCK`:
-                                                  If the rule''s `destination` is
-                                                  an IP address range in CIDR notation.
-                                                  * `SERVICE_CIDR_BLOCK`: If the rule''s
-                                                  `destination` is the `cidrBlock`
-                                                  value for a Service (the rule is
-                                                  for traffic destined for a particular
-                                                  `Service` through a service gateway).
-                                                  * `NETWORK_SECURITY_GROUP`: If the
-                                                  rule''s `destination` is the OCID
-                                                  (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)
-                                                  of a NetworkSecurityGroup.'
+                                                description: |-
+                                                  Type of destination for the rule. The default is `CIDR_BLOCK`.
+                                                  Allowed values:
+                                                    * `CIDR_BLOCK`: If the rule's `destination` is an IP address range in CIDR notation.
+                                                    * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
+                                                      Service (the rule is for traffic destined for a
+                                                      particular `Service` through a service gateway).
+                                                    * `NETWORK_SECURITY_GROUP`: If the rule's `destination` is the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a
+                                                      NetworkSecurityGroup.
                                                 type: string
                                               icmpOptions:
-                                                description: 'IcmpOptions Optional
-                                                  and valid only for ICMP and ICMPv6.
-                                                  Use to specify a particular ICMP
-                                                  type and code as defined in: - ICMP
-                                                  Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                                description: |-
+                                                  IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                                  as defined in:
+                                                  - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                                   - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                                  If you specify ICMP or ICMPv6 as
-                                                  the protocol but omit this object,
-                                                  then all ICMP types and codes are
-                                                  allowed. If you do provide this
-                                                  object, the type is required and
-                                                  the code is optional. To enable
-                                                  MTU negotiation for ingress internet
-                                                  traffic via IPv4, make sure to allow
-                                                  type 3 ("Destination Unreachable")
-                                                  code 4 ("Fragmentation Needed and
-                                                  Don''t Fragment was Set"). If you
-                                                  need to specify multiple codes for
-                                                  a single type, create a separate
-                                                  security list rule for each.'
+                                                  If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                                  codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                                  To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                                  Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                                  multiple codes for a single type, create a separate security list rule for each.
                                                 properties:
                                                   code:
                                                     description: The ICMP code (optional).
@@ -2106,48 +1821,33 @@ spec:
                                                     type: integer
                                                 type: object
                                               isStateless:
-                                                description: A stateless rule allows
-                                                  traffic in one direction. Remember
-                                                  to add a corresponding stateless
-                                                  rule in the other direction if you
-                                                  need to support bidirectional traffic.
-                                                  For example, if egress traffic allows
-                                                  TCP destination port 80, there should
-                                                  be an ingress rule to allow TCP
-                                                  source port 80. Defaults to false,
-                                                  which means the rule is stateful
-                                                  and a corresponding rule is not
-                                                  necessary for bidirectional traffic.
+                                                description: |-
+                                                  A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                                  stateless rule in the other direction if you need to support bidirectional traffic. For
+                                                  example, if egress traffic allows TCP destination port 80, there should be an ingress
+                                                  rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                                  and a corresponding rule is not necessary for bidirectional traffic.
                                                 type: boolean
                                               protocol:
-                                                description: The transport protocol.
-                                                  Specify either `all` or an IPv4
-                                                  protocol number as defined in Protocol
-                                                  Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                                  Options are supported only for ICMP
-                                                  ("1"), TCP ("6"), UDP ("17"), and
-                                                  ICMPv6 ("58").
+                                                description: |-
+                                                  The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                                  defined in
+                                                  Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                                  Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                                 type: string
                                               tcpOptions:
-                                                description: TcpOptions Optional and
-                                                  valid only for TCP. Use to specify
-                                                  particular destination ports for
-                                                  TCP rules. If you specify TCP as
-                                                  the protocol but omit this object,
-                                                  then all destination ports are allowed.
+                                                description: |-
+                                                  TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                                  If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                                 properties:
                                                   destinationPortRange:
                                                     description: PortRange The representation
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -2161,13 +1861,9 @@ spec:
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -2178,25 +1874,18 @@ spec:
                                                     type: object
                                                 type: object
                                               udpOptions:
-                                                description: UdpOptions Optional and
-                                                  valid only for UDP. Use to specify
-                                                  particular destination ports for
-                                                  UDP rules. If you specify UDP as
-                                                  the protocol but omit this object,
-                                                  then all destination ports are allowed.
+                                                description: |-
+                                                  UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                                  If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                                 properties:
                                                   destinationPortRange:
                                                     description: PortRange The representation
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -2210,13 +1899,9 @@ spec:
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -2242,26 +1927,16 @@ spec:
                                                   of your choice for the rule.
                                                 type: string
                                               icmpOptions:
-                                                description: 'IcmpOptions Optional
-                                                  and valid only for ICMP and ICMPv6.
-                                                  Use to specify a particular ICMP
-                                                  type and code as defined in: - ICMP
-                                                  Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                                description: |-
+                                                  IcmpOptions Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                                                  as defined in:
+                                                  - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
                                                   - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
-                                                  If you specify ICMP or ICMPv6 as
-                                                  the protocol but omit this object,
-                                                  then all ICMP types and codes are
-                                                  allowed. If you do provide this
-                                                  object, the type is required and
-                                                  the code is optional. To enable
-                                                  MTU negotiation for ingress internet
-                                                  traffic via IPv4, make sure to allow
-                                                  type 3 ("Destination Unreachable")
-                                                  code 4 ("Fragmentation Needed and
-                                                  Don''t Fragment was Set"). If you
-                                                  need to specify multiple codes for
-                                                  a single type, create a separate
-                                                  security list rule for each.'
+                                                  If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                                                  codes are allowed. If you do provide this object, the type is required and the code is optional.
+                                                  To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 ("Destination
+                                                  Unreachable") code 4 ("Fragmentation Needed and Don't Fragment was Set"). If you need to specify
+                                                  multiple codes for a single type, create a separate security list rule for each.
                                                 properties:
                                                   code:
                                                     description: The ICMP code (optional).
@@ -2271,80 +1946,55 @@ spec:
                                                     type: integer
                                                 type: object
                                               isStateless:
-                                                description: A stateless rule allows
-                                                  traffic in one direction. Remember
-                                                  to add a corresponding stateless
-                                                  rule in the other direction if you
-                                                  need to support bidirectional traffic.
-                                                  For example, if ingress traffic
-                                                  allows TCP destination port 80,
-                                                  there should be an egress rule to
-                                                  allow TCP source port 80. Defaults
-                                                  to false, which means the rule is
-                                                  stateful and a corresponding rule
-                                                  is not necessary for bidirectional
-                                                  traffic.
+                                                description: |-
+                                                  A stateless rule allows traffic in one direction. Remember to add a corresponding
+                                                  stateless rule in the other direction if you need to support bidirectional traffic. For
+                                                  example, if ingress traffic allows TCP destination port 80, there should be an egress
+                                                  rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                                                  and a corresponding rule is not necessary for bidirectional traffic.
                                                 type: boolean
                                               protocol:
-                                                description: The transport protocol.
-                                                  Specify either `all` or an IPv4
-                                                  protocol number as defined in Protocol
-                                                  Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
-                                                  Options are supported only for ICMP
-                                                  ("1"), TCP ("6"), UDP ("17"), and
-                                                  ICMPv6 ("58").
+                                                description: |-
+                                                  The transport protocol. Specify either `all` or an IPv4 protocol number as
+                                                  defined in
+                                                  Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                                  Options are supported only for ICMP ("1"), TCP ("6"), UDP ("17"), and ICMPv6 ("58").
                                                 type: string
                                               source:
-                                                description: 'Conceptually, this is
-                                                  the range of IP addresses that a
-                                                  packet coming into the instance
-                                                  can come from. Allowed values: *
-                                                  IP address range in CIDR notation.
-                                                  For example: `192.168.1.0/24` or
-                                                  `2001:0db8:0123:45::/56`. IPv6 addressing
-                                                  is supported for all commercial
-                                                  and government regions. See IPv6
-                                                  Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
-                                                  * The `cidrBlock` value for a Service,
-                                                  if you''re setting up a security
-                                                  list rule for traffic coming from
-                                                  a particular `Service` through a
-                                                  service gateway. For example: `oci-phx-objectstorage`.'
+                                                description: |-
+                                                  Conceptually, this is the range of IP addresses that a packet coming into the instance
+                                                  can come from.
+                                                  Allowed values:
+                                                    * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
+                                                      IPv6 addressing is supported for all commercial and government regions. See
+                                                      IPv6 Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                                    * The `cidrBlock` value for a Service, if you're
+                                                      setting up a security list rule for traffic coming from a particular `Service` through
+                                                      a service gateway. For example: `oci-phx-objectstorage`.
                                                 type: string
                                               sourceType:
-                                                description: 'Type of source for the
-                                                  rule. The default is `CIDR_BLOCK`.
-                                                  * `CIDR_BLOCK`: If the rule''s `source`
-                                                  is an IP address range in CIDR notation.
-                                                  * `SERVICE_CIDR_BLOCK`: If the rule''s
-                                                  `source` is the `cidrBlock` value
-                                                  for a Service (the rule is for traffic
-                                                  coming from a particular `Service`
-                                                  through a service gateway). * `NETWORK_SECURITY_GROUP`:
-                                                  If the rule''s `destination` is
-                                                  the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)
-                                                  of a NetworkSecurityGroup.'
+                                                description: |-
+                                                  Type of source for the rule. The default is `CIDR_BLOCK`.
+                                                    * `CIDR_BLOCK`: If the rule's `source` is an IP address range in CIDR notation.
+                                                    * `SERVICE_CIDR_BLOCK`: If the rule's `source` is the `cidrBlock` value for a
+                                                      Service (the rule is for traffic coming from a
+                                                      particular `Service` through a service gateway).
+                                                    * `NETWORK_SECURITY_GROUP`: If the rule's `destination` is the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a
+                                                      NetworkSecurityGroup.
                                                 type: string
                                               tcpOptions:
-                                                description: TcpOptions Optional and
-                                                  valid only for TCP. Use to specify
-                                                  particular destination ports for
-                                                  TCP rules. If you specify TCP as
-                                                  the protocol but omit this object,
-                                                  then all destination ports are allowed.
+                                                description: |-
+                                                  TcpOptions Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                                                  If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
                                                 properties:
                                                   destinationPortRange:
                                                     description: PortRange The representation
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -2358,13 +2008,9 @@ spec:
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -2375,25 +2021,18 @@ spec:
                                                     type: object
                                                 type: object
                                               udpOptions:
-                                                description: UdpOptions Optional and
-                                                  valid only for UDP. Use to specify
-                                                  particular destination ports for
-                                                  UDP rules. If you specify UDP as
-                                                  the protocol but omit this object,
-                                                  then all destination ports are allowed.
+                                                description: |-
+                                                  UdpOptions Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                                                  If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
                                                 properties:
                                                   destinationPortRange:
                                                     description: PortRange The representation
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -2407,13 +2046,9 @@ spec:
                                                       of PortRange.
                                                     properties:
                                                       max:
-                                                        description: The maximum port
-                                                          number, which must not be
-                                                          less than the minimum port
-                                                          number. To specify a single
-                                                          port number, set both the
-                                                          min and max to the same
-                                                          value.
+                                                        description: |-
+                                                          The maximum port number, which must not be less than the minimum port number. To specify
+                                                          a single port number, set both the min and max to the same value.
                                                         type: integer
                                                       min:
                                                         description: The minimum port
@@ -2429,6 +2064,11 @@ spec:
                                           description: SecurityList Name.
                                           type: string
                                       type: object
+                                    skip:
+                                      description: |-
+                                        Skip specifies whether to skip creating subnets. If set to true(default: false) the ID
+                                        must be specified by the user to a valid Subnet ID.
+                                      type: boolean
                                     type:
                                       description: Type defines the subnet type (e.g.
                                         public, private).
@@ -2446,83 +2086,73 @@ spec:
                             description: VCNPeering configuration.
                             properties:
                               drg:
-                                description: DRG configuration refers to the DRG which
-                                  has to be created if required. If management cluster
-                                  and workload cluster shares the same DRG, this fields
-                                  is not required to be specified.
+                                description: |-
+                                  DRG configuration refers to the DRG which has to be created if required. If management cluster
+                                  and workload cluster shares the same DRG, this fields is not required to be specified.
                                 properties:
                                   id:
                                     description: ID is the OCID for the created DRG.
                                     type: string
                                   manage:
-                                    description: Manage defines whether the DRG has
-                                      to be managed(including create). If set to false(the
-                                      default) the ID has to be specified by the user
-                                      to a valid DRG ID to which the VCN has to be
-                                      attached.
+                                    description: |-
+                                      Manage defines whether the DRG has to be managed(including create). If set to false(the default) the ID
+                                      has to be specified by the user to a valid DRG ID to which the VCN has to be attached.
                                     type: boolean
                                   name:
                                     description: Name is the name of the created DRG.
                                     type: string
                                   vcnAttachmentId:
-                                    description: VcnAttachmentId is the ID of the
-                                      VCN attachment of the DRG. The workload cluster
-                                      VCN can be attached to either the management
-                                      cluster VCN if they are sharing the same DRG
+                                    description: |-
+                                      VcnAttachmentId is the ID of the VCN attachment of the DRG.
+                                      The workload cluster VCN can be attached to either the management cluster VCN if they are sharing the same DRG
                                       or to the workload cluster DRG.
                                     type: string
                                 type: object
                               peerRouteRules:
-                                description: PeerRouteRules defines the routing rules
-                                  which will be added to the private route tables
-                                  of the workload cluster VCN. The routes defined
-                                  here will be directed to DRG.
+                                description: |-
+                                  PeerRouteRules defines the routing rules which will be added to the private route tables
+                                  of the workload cluster VCN. The routes defined here will be directed to DRG.
                                 items:
                                   description: PeerRouteRule defines a Route Rule
                                     to be routed via a DRG.
                                   properties:
                                     vcnCIDRRange:
-                                      description: VCNCIDRRange is the CIDR Range
-                                        of peer VCN to which the workload cluster
-                                        VCN will be peered. The CIDR range is required
-                                        to add the route rule in the workload cluster
-                                        VCN, the route rule will forward any traffic
-                                        to the CIDR to the DRG.
+                                      description: |-
+                                        VCNCIDRRange is the CIDR Range of peer VCN to which the
+                                        workload cluster VCN will be peered. The CIDR range is required to add the route rule
+                                        in the workload cluster VCN, the route rule will forward any traffic to the CIDR to the DRG.
                                       type: string
                                   type: object
                                 type: array
                               remotePeeringConnections:
-                                description: RemotePeeringConnections defines the
-                                  RPC connections which be established with the workload
-                                  cluster DRG.
+                                description: |-
+                                  RemotePeeringConnections defines the RPC connections which be established with the
+                                  workload cluster DRG.
                                 items:
-                                  description: RemotePeeringConnection is used to
-                                    peer VCNs residing in different regions(typically).
+                                  description: |-
+                                    RemotePeeringConnection is used to peer VCNs residing in different regions(typically).
                                     Remote VCN Peering is explained here - https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/remoteVCNpeering.htm
                                   properties:
                                     managePeerRPC:
-                                      description: ManagePeerRPC will define if the
-                                        Peer VCN needs to be managed. If set to true
-                                        a Remote Peering Connection will be created
-                                        in the Peer DRG and the connection will be
-                                        created between local and peer RPC.
+                                      description: |-
+                                        ManagePeerRPC will define if the Peer VCN needs to be managed. If set to true
+                                        a Remote Peering Connection will be created in the Peer DRG and the connection
+                                        will be created between local and peer RPC.
                                       type: boolean
                                     name:
-                                      description: A unique name identifying the RPC,
-                                        please note this is to identify the RPC from
-                                        other RPC elements, and will not be used in
-                                        any OCI API call.
+                                      description: |-
+                                        A unique name identifying the RPC, please note this is to identify the RPC
+                                        from other RPC elements, and will not be used in any OCI API call.
                                       type: string
                                     peerDRGId:
                                       description: PeerDRGId defines the DRG ID of
                                         the peer.
                                       type: string
                                     peerRPCConnectionId:
-                                      description: PeerRPCConnectionId defines the
-                                        RPC ID of peer. If ManagePeerRPC is set to
-                                        true this will be created by Cluster API Provider
-                                        for OCI, otherwise this has be defined by
-                                        the user.
+                                      description: |-
+                                        PeerRPCConnectionId defines the RPC ID of peer. If ManagePeerRPC is set to true
+                                        this will be created by Cluster API Provider for OCI, otherwise this has be defined by the
+                                        user.
                                       type: string
                                     peerRegionName:
                                       description: PeerRegionName defined the region
@@ -2538,14 +2168,15 @@ spec:
                             type: object
                         type: object
                       ociResourceIdentifier:
-                        description: The unique ID which will be used to tag all the
-                          resources created by this Cluster. The tag will be used
-                          to identify resources belonging to this cluster. this will
-                          be auto-generated and should not be set by the user.
+                        description: |-
+                          The unique ID which will be used to tag all the resources created by this Cluster.
+                          The tag will be used to identify resources belonging to this cluster.
+                          this will be auto-generated and should not be set by the user.
                         type: string
                       region:
-                        description: Region the cluster operates in. It must be one
-                          of available regions in Region Identifier format. See https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm
+                        description: |-
+                          Region the cluster operates in. It must be one of available regions in Region Identifier format.
+                          See https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm
                         type: string
                     type: object
                 required:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimanagedcontrolplanes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: ocimanagedcontrolplanes.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -21,19 +21,25 @@ spec:
           API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: OCIManagedControlPlaneSpec defines the desired state of OCIManagedControlPlane.
+            description: |-
+              OCIManagedControlPlaneSpec defines the desired state of OCIManagedControlPlane.
               The properties are generated from https://docs.oracle.com/en-us/iaas/api/#/en/containerengine/20180222/datatypes/CreateClusterDetails
             properties:
               clusterOptions:
@@ -61,87 +67,6 @@ spec:
                           not to enable the Pod Security Policy admission controller.
                         type: boolean
                     type: object
-                  openIdConnectDiscovery:
-                    description: OpenIDConnectDiscovery specifies OIDC discovery settings
-                    properties:
-                      isOpenIdConnectDiscoveryEnabled:
-                        description: IsOpenIDConnectDiscoveryEnabled defines whether
-                          or not to enable the OIDC discovery.
-                        type: boolean
-                    type: object
-                  openIdConnectTokenAuthenticationConfig:
-                    description: OpenIDConnectTokenAuthenticationConfig
-                    properties:
-                      caCertificate:
-                        description: A Base64 encoded public RSA or ECDSA certificates
-                          used to sign your identity provider's web certificate.
-                        type: string
-                      clientId:
-                        description: A client id that all tokens must be issued for.
-                        type: string
-                      groupsClaim:
-                        description: JWT claim to use as the user's group. If the
-                          claim is present it must be an array of strings.
-                        type: string
-                      groupsPrefix:
-                        description: Prefix prepended to group claims to prevent clashes
-                          with existing names (such as system:groups).
-                        type: string
-                      isOpenIdConnectAuthEnabled:
-                        description: IsOpenIdConnectAuthEnabled defines whether or
-                          not to enable the OIDC authentication.
-                        type: boolean
-                      issuerUrl:
-                        description: URL of the provider that allows the API server
-                          to discover public signing keys. Only URLs that use the
-                          https:// scheme are accepted. This is typically the provider's
-                          discovery URL, changed to have an empty path.
-                        type: string
-                      requiredClaims:
-                        description: A key=value pair that describes a required claim
-                          in the ID Token. If set, the claim is verified to be present
-                          in the ID Token with a matching value. Repeat this flag
-                          to specify multiple claims.
-                        items:
-                          description: KeyValue The properties that define a key value
-                            pair.
-                          properties:
-                            key:
-                              description: The key of the pair.
-                              type: string
-                            value:
-                              description: The value of the pair.
-                              type: string
-                          required:
-                          - key
-                          - value
-                          type: object
-                        type: array
-                      signingAlgorithms:
-                        description: The signing algorithms accepted. Default is ["RS256"].
-                        items:
-                          type: string
-                        type: array
-                      usernameClaim:
-                        description: JWT claim to use as the user name. By default
-                          sub, which is expected to be a unique identifier of the
-                          end user. Admins can choose other claims, such as email
-                          or name, depending on their provider. However, claims other
-                          than email will be prefixed with the issuer URL to prevent
-                          naming clashes with other plugins.
-                        type: string
-                      usernamePrefix:
-                        description: 'Prefix prepended to username claims to prevent
-                          clashes with existing names (such as system:users). For
-                          example, the value oidc: will create usernames like oidc:jane.doe.
-                          If this flag isn''t provided and --oidc-username-claim is
-                          a value other than email the prefix defaults to ( Issuer
-                          URL )# where ( Issuer URL ) is the value of --oidc-issuer-url.
-                          The value - can be used to disable all prefixing.'
-                        type: string
-                    required:
-                    - isOpenIdConnectAuthEnabled
-                    type: object
                 type: object
               clusterPodNetworkOptions:
                 description: ClusterPodNetworkOptions defines the available CNIs and
@@ -160,10 +85,11 @@ spec:
                   communicate with the control plane.
                 properties:
                   host:
-                    description: The hostname on which the API server is serving.
+                    description: host is the hostname on which the API server is serving.
+                    maxLength: 512
                     type: string
                   port:
-                    description: The port on which the API server is serving.
+                    description: port is the port on which the API server is serving.
                     format: int32
                     type: integer
                 required:
@@ -216,37 +142,44 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
+                      description: status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -255,8 +188,9 @@ spec:
                   type: object
                 type: array
               initialized:
-                description: Initialized denotes whether or not the control plane
-                  has the uploaded kubernetes config-map.
+                description: |-
+                  Initialized denotes whether or not the control plane has the
+                  uploaded kubernetes config-map.
                 type: boolean
               ready:
                 type: boolean
@@ -277,19 +211,25 @@ spec:
           API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: OCIManagedControlPlaneSpec defines the desired state of OCIManagedControlPlane.
+            description: |-
+              OCIManagedControlPlaneSpec defines the desired state of OCIManagedControlPlane.
               The properties are generated from https://docs.oracle.com/en-us/iaas/api/#/en/containerengine/20180222/datatypes/CreateClusterDetails
             properties:
               addons:
@@ -392,8 +332,9 @@ spec:
                           in the ID Token with a matching value. Repeat this flag
                           to specify multiple claims.
                         items:
-                          description: KeyValue The properties that define a key value
-                            pair.
+                          description: KeyValue defines the properties that define
+                            a key value pair. This is alias to containerengine.KeyValue,
+                            to support the sdk type
                           properties:
                             key:
                               description: The key of the pair.
@@ -445,18 +386,21 @@ spec:
                   type: object
                 type: array
               clusterType:
-                description: ClusterTypeEnum defines the type of cluster. Supported
-                  types are * `BASIC_CLUSTER` * `ENHANCED_CLUSTER`
+                description: |-
+                  ClusterTypeEnum defines the type of cluster. Supported types are
+                  * `BASIC_CLUSTER`
+                  * `ENHANCED_CLUSTER`
                 type: string
               controlPlaneEndpoint:
                 description: ControlPlaneEndpoint represents the endpoint used to
                   communicate with the control plane.
                 properties:
                   host:
-                    description: The hostname on which the API server is serving.
+                    description: host is the hostname on which the API server is serving.
+                    maxLength: 512
                     type: string
                   port:
-                    description: The port on which the API server is serving.
+                    description: port is the port on which the API server is serving.
                     format: int32
                     type: integer
                 required:
@@ -540,37 +484,44 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
+                      description: status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -579,8 +530,9 @@ spec:
                   type: object
                 type: array
               initialized:
-                description: Initialized denotes whether or not the control plane
-                  has the uploaded kubernetes config-map.
+                description: |-
+                  Initialized denotes whether or not the control plane has the
+                  uploaded kubernetes config-map.
                 type: boolean
               ready:
                 type: boolean

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimanagedcontrolplanetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimanagedcontrolplanetemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: ocimanagedcontrolplanetemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -23,14 +23,19 @@ spec:
           API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -43,9 +48,9 @@ spec:
                   to create an OCIManagedControlPlane from a template.
                 properties:
                   spec:
-                    description: OCIManagedControlPlaneSpec defines the desired state
-                      of OCIManagedControlPlane. The properties are generated from
-                      https://docs.oracle.com/en-us/iaas/api/#/en/containerengine/20180222/datatypes/CreateClusterDetails
+                    description: |-
+                      OCIManagedControlPlaneSpec defines the desired state of OCIManagedControlPlane.
+                      The properties are generated from https://docs.oracle.com/en-us/iaas/api/#/en/containerengine/20180222/datatypes/CreateClusterDetails
                     properties:
                       clusterOptions:
                         description: ClusterOptions defines Optional attributes for
@@ -75,94 +80,6 @@ spec:
                                   controller.
                                 type: boolean
                             type: object
-                          openIdConnectDiscovery:
-                            description: OpenIDConnectDiscovery specifies OIDC discovery
-                              settings
-                            properties:
-                              isOpenIdConnectDiscoveryEnabled:
-                                description: IsOpenIDConnectDiscoveryEnabled defines
-                                  whether or not to enable the OIDC discovery.
-                                type: boolean
-                            type: object
-                          openIdConnectTokenAuthenticationConfig:
-                            description: OpenIDConnectTokenAuthenticationConfig
-                            properties:
-                              caCertificate:
-                                description: A Base64 encoded public RSA or ECDSA
-                                  certificates used to sign your identity provider's
-                                  web certificate.
-                                type: string
-                              clientId:
-                                description: A client id that all tokens must be issued
-                                  for.
-                                type: string
-                              groupsClaim:
-                                description: JWT claim to use as the user's group.
-                                  If the claim is present it must be an array of strings.
-                                type: string
-                              groupsPrefix:
-                                description: Prefix prepended to group claims to prevent
-                                  clashes with existing names (such as system:groups).
-                                type: string
-                              isOpenIdConnectAuthEnabled:
-                                description: IsOpenIdConnectAuthEnabled defines whether
-                                  or not to enable the OIDC authentication.
-                                type: boolean
-                              issuerUrl:
-                                description: URL of the provider that allows the API
-                                  server to discover public signing keys. Only URLs
-                                  that use the https:// scheme are accepted. This
-                                  is typically the provider's discovery URL, changed
-                                  to have an empty path.
-                                type: string
-                              requiredClaims:
-                                description: A key=value pair that describes a required
-                                  claim in the ID Token. If set, the claim is verified
-                                  to be present in the ID Token with a matching value.
-                                  Repeat this flag to specify multiple claims.
-                                items:
-                                  description: KeyValue The properties that define
-                                    a key value pair.
-                                  properties:
-                                    key:
-                                      description: The key of the pair.
-                                      type: string
-                                    value:
-                                      description: The value of the pair.
-                                      type: string
-                                  required:
-                                  - key
-                                  - value
-                                  type: object
-                                type: array
-                              signingAlgorithms:
-                                description: The signing algorithms accepted. Default
-                                  is ["RS256"].
-                                items:
-                                  type: string
-                                type: array
-                              usernameClaim:
-                                description: JWT claim to use as the user name. By
-                                  default sub, which is expected to be a unique identifier
-                                  of the end user. Admins can choose other claims,
-                                  such as email or name, depending on their provider.
-                                  However, claims other than email will be prefixed
-                                  with the issuer URL to prevent naming clashes with
-                                  other plugins.
-                                type: string
-                              usernamePrefix:
-                                description: 'Prefix prepended to username claims
-                                  to prevent clashes with existing names (such as
-                                  system:users). For example, the value oidc: will
-                                  create usernames like oidc:jane.doe. If this flag
-                                  isn''t provided and --oidc-username-claim is a value
-                                  other than email the prefix defaults to ( Issuer
-                                  URL )# where ( Issuer URL ) is the value of --oidc-issuer-url.
-                                  The value - can be used to disable all prefixing.'
-                                type: string
-                            required:
-                            - isOpenIdConnectAuthEnabled
-                            type: object
                         type: object
                       clusterPodNetworkOptions:
                         description: ClusterPodNetworkOptions defines the available
@@ -184,10 +101,13 @@ spec:
                           used to communicate with the control plane.
                         properties:
                           host:
-                            description: The hostname on which the API server is serving.
+                            description: host is the hostname on which the API server
+                              is serving.
+                            maxLength: 512
                             type: string
                           port:
-                            description: The port on which the API server is serving.
+                            description: port is the port on which the API server
+                              is serving.
                             format: int32
                             type: integer
                         required:
@@ -246,14 +166,19 @@ spec:
           API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -266,9 +191,9 @@ spec:
                   to create an OCIManagedControlPlane from a template.
                 properties:
                   spec:
-                    description: OCIManagedControlPlaneSpec defines the desired state
-                      of OCIManagedControlPlane. The properties are generated from
-                      https://docs.oracle.com/en-us/iaas/api/#/en/containerengine/20180222/datatypes/CreateClusterDetails
+                    description: |-
+                      OCIManagedControlPlaneSpec defines the desired state of OCIManagedControlPlane.
+                      The properties are generated from https://docs.oracle.com/en-us/iaas/api/#/en/containerengine/20180222/datatypes/CreateClusterDetails
                     properties:
                       addons:
                         description: The list of addons to be applied to the OKE cluster.
@@ -377,8 +302,9 @@ spec:
                                   to be present in the ID Token with a matching value.
                                   Repeat this flag to specify multiple claims.
                                 items:
-                                  description: KeyValue The properties that define
-                                    a key value pair.
+                                  description: KeyValue defines the properties that
+                                    define a key value pair. This is alias to containerengine.KeyValue,
+                                    to support the sdk type
                                   properties:
                                     key:
                                       description: The key of the pair.
@@ -436,18 +362,23 @@ spec:
                           type: object
                         type: array
                       clusterType:
-                        description: ClusterTypeEnum defines the type of cluster.
-                          Supported types are * `BASIC_CLUSTER` * `ENHANCED_CLUSTER`
+                        description: |-
+                          ClusterTypeEnum defines the type of cluster. Supported types are
+                          * `BASIC_CLUSTER`
+                          * `ENHANCED_CLUSTER`
                         type: string
                       controlPlaneEndpoint:
                         description: ControlPlaneEndpoint represents the endpoint
                           used to communicate with the control plane.
                         properties:
                           host:
-                            description: The hostname on which the API server is serving.
+                            description: host is the hostname on which the API server
+                              is serving.
+                            maxLength: 512
                             type: string
                           port:
-                            description: The port on which the API server is serving.
+                            description: port is the port on which the API server
+                              is serving.
                             format: int32
                             type: integer
                         required:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimanagedmachinepools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: ocimanagedmachinepools.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -21,21 +21,27 @@ spec:
           API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: OCIManagedMachinePoolSpec defines the desired state of an
-              OCI managed machine pool. An OCIManagedMachinePool translates to an
-              OKE NodePool. The properties are generated from https://docs.oracle.com/en-us/iaas/api/#/en/containerengine/20180222/datatypes/CreateNodePoolDetails
+            description: |-
+              OCIManagedMachinePoolSpec defines the desired state of an OCI managed machine pool.
+              An OCIManagedMachinePool translates to an OKE NodePool.
+              The properties are generated from https://docs.oracle.com/en-us/iaas/api/#/en/containerengine/20180222/datatypes/CreateNodePoolDetails
             properties:
               id:
                 description: ID is the OCID of the associated NodePool
@@ -101,9 +107,9 @@ spec:
                           options specific to using the OCI VCN Native CNI
                         properties:
                           maxPodsPerNode:
-                            description: MemoryInGBs defines the max number of pods
-                              per node in the node pool. This value will be limited
-                              by the number of VNICs attachable to the node pool shape
+                            description: |-
+                              MemoryInGBs defines the max number of pods per node in the node pool. This value will be limited by the
+                              number of VNICs attachable to the node pool shape
                             type: integer
                           nsgNames:
                             description: NSGNames defines the NSGs associated with
@@ -120,9 +126,9 @@ spec:
                         type: object
                     type: object
                   nsgNames:
-                    description: NsgNames defines the names of NSGs which will be
-                      associated with the nodes. the NSGs are defined in OCIManagedCluster
-                      object.
+                    description: |-
+                      NsgNames defines the names of NSGs which will be associated with the nodes. the NSGs are defined
+                      in OCIManagedCluster object.
                     items:
                       type: string
                     type: array
@@ -149,9 +155,9 @@ spec:
                             type: string
                           type: array
                         subnetName:
-                          description: SubnetName defines the name of the subnet which
-                            need ot be associated with the Nodepool. The subnets are
-                            defined in the OCiManagedCluster object.
+                          description: |-
+                            SubnetName defines the name of the subnet which need ot be associated with the Nodepool.
+                            The subnets are defined in the OCiManagedCluster object.
                           type: string
                       type: object
                     type: array
@@ -192,10 +198,9 @@ spec:
                   a provider format
                 type: string
               providerIDList:
-                description: ProviderIDList are the identification IDs of machine
-                  instances provided by the provider. This field must match the provider
-                  IDs as seen on the node objects corresponding to a machine pool's
-                  machine instances.
+                description: |-
+                  ProviderIDList are the identification IDs of machine instances provided by the provider.
+                  This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
                 items:
                   type: string
                 type: array
@@ -218,37 +223,44 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
+                      description: status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -289,21 +301,27 @@ spec:
           API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: OCIManagedMachinePoolSpec defines the desired state of an
-              OCI managed machine pool. An OCIManagedMachinePool translates to an
-              OKE NodePool. The properties are generated from https://docs.oracle.com/en-us/iaas/api/#/en/containerengine/20180222/datatypes/CreateNodePoolDetails
+            description: |-
+              OCIManagedMachinePoolSpec defines the desired state of an OCI managed machine pool.
+              An OCIManagedMachinePool translates to an OKE NodePool.
+              The properties are generated from https://docs.oracle.com/en-us/iaas/api/#/en/containerengine/20180222/datatypes/CreateNodePoolDetails
             properties:
               id:
                 description: ID is the OCID of the associated NodePool
@@ -353,17 +371,15 @@ spec:
                       will be cycled to have new changes.
                     type: boolean
                   maximumSurge:
-                    description: MaximumSurge refers to the maximum additional new
-                      compute instances that would be temporarily created and added
-                      to nodepool during the cycling nodepool process. OKE supports
-                      both integer and percentage input. Defaults to 1, Ranges from
-                      0 to Nodepool size or 0% to 100%
+                    description: |-
+                      MaximumSurge refers to the maximum additional new compute instances that would be temporarily created and
+                      added to nodepool during the cycling nodepool process. OKE supports both integer and percentage input.
+                      Defaults to 1, Ranges from 0 to Nodepool size or 0% to 100%
                     type: string
                   maximumUnavailable:
-                    description: Maximum active nodes that would be terminated from
-                      nodepool during the cycling nodepool process. OKE supports both
-                      integer and percentage input. Defaults to 0, Ranges from 0 to
-                      Nodepool size or 0% to 100%
+                    description: |-
+                      Maximum active nodes that would be terminated from nodepool during the cycling nodepool process.
+                      OKE supports both integer and percentage input. Defaults to 0, Ranges from 0 to Nodepool size or 0% to 100%
                     type: string
                 type: object
               nodePoolNodeConfig:
@@ -391,9 +407,9 @@ spec:
                           options specific to using the OCI VCN Native CNI
                         properties:
                           maxPodsPerNode:
-                            description: MemoryInGBs defines the max number of pods
-                              per node in the node pool. This value will be limited
-                              by the number of VNICs attachable to the node pool shape
+                            description: |-
+                              MemoryInGBs defines the max number of pods per node in the node pool. This value will be limited by the
+                              number of VNICs attachable to the node pool shape
                             type: integer
                           nsgNames:
                             description: NSGNames defines the NSGs associated with
@@ -410,9 +426,9 @@ spec:
                         type: object
                     type: object
                   nsgNames:
-                    description: NsgNames defines the names of NSGs which will be
-                      associated with the nodes. the NSGs are defined in OCIManagedCluster
-                      object.
+                    description: |-
+                      NsgNames defines the names of NSGs which will be associated with the nodes. the NSGs are defined
+                      in OCIManagedCluster object.
                     items:
                       type: string
                     type: array
@@ -439,9 +455,9 @@ spec:
                             type: string
                           type: array
                         subnetName:
-                          description: SubnetName defines the name of the subnet which
-                            need ot be associated with the Nodepool. The subnets are
-                            defined in the OCiManagedCluster object.
+                          description: |-
+                            SubnetName defines the name of the subnet which need ot be associated with the Nodepool.
+                            The subnets are defined in the OCiManagedCluster object.
                           type: string
                       type: object
                     type: array
@@ -482,10 +498,9 @@ spec:
                   a provider format
                 type: string
               providerIDList:
-                description: ProviderIDList are the identification IDs of machine
-                  instances provided by the provider. This field must match the provider
-                  IDs as seen on the node objects corresponding to a machine pool's
-                  machine instances.
+                description: |-
+                  ProviderIDList are the identification IDs of machine instances provided by the provider.
+                  This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
                 items:
                   type: string
                 type: array
@@ -508,37 +523,44 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
+                      description: status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -551,8 +573,6 @@ spec:
                   type: string
                 type: array
               failureReason:
-                description: MachineStatusError defines errors states for Machine
-                  objects.
                 type: string
               infrastructureMachineKind:
                 description: InfrastructureMachineKind is the kind of the infrastructure

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimanagedmachinepooltemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimanagedmachinepooltemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: ocimanagedmachinepooltemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -23,14 +23,19 @@ spec:
           API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -43,9 +48,10 @@ spec:
                   create an OCIManagedMachinePool from a template.
                 properties:
                   spec:
-                    description: OCIManagedMachinePoolSpec defines the desired state
-                      of an OCI managed machine pool. An OCIManagedMachinePool translates
-                      to an OKE NodePool. The properties are generated from https://docs.oracle.com/en-us/iaas/api/#/en/containerengine/20180222/datatypes/CreateNodePoolDetails
+                    description: |-
+                      OCIManagedMachinePoolSpec defines the desired state of an OCI managed machine pool.
+                      An OCIManagedMachinePool translates to an OKE NodePool.
+                      The properties are generated from https://docs.oracle.com/en-us/iaas/api/#/en/containerengine/20180222/datatypes/CreateNodePoolDetails
                     properties:
                       id:
                         description: ID is the OCID of the associated NodePool
@@ -116,10 +122,9 @@ spec:
                                   Native CNI
                                 properties:
                                   maxPodsPerNode:
-                                    description: MemoryInGBs defines the max number
-                                      of pods per node in the node pool. This value
-                                      will be limited by the number of VNICs attachable
-                                      to the node pool shape
+                                    description: |-
+                                      MemoryInGBs defines the max number of pods per node in the node pool. This value will be limited by the
+                                      number of VNICs attachable to the node pool shape
                                     type: integer
                                   nsgNames:
                                     description: NSGNames defines the NSGs associated
@@ -136,8 +141,8 @@ spec:
                                 type: object
                             type: object
                           nsgNames:
-                            description: NsgNames defines the names of NSGs which
-                              will be associated with the nodes. the NSGs are defined
+                            description: |-
+                              NsgNames defines the names of NSGs which will be associated with the nodes. the NSGs are defined
                               in OCIManagedCluster object.
                             items:
                               type: string
@@ -165,10 +170,9 @@ spec:
                                     type: string
                                   type: array
                                 subnetName:
-                                  description: SubnetName defines the name of the
-                                    subnet which need ot be associated with the Nodepool.
-                                    The subnets are defined in the OCiManagedCluster
-                                    object.
+                                  description: |-
+                                    SubnetName defines the name of the subnet which need ot be associated with the Nodepool.
+                                    The subnets are defined in the OCiManagedCluster object.
                                   type: string
                               type: object
                             type: array
@@ -209,10 +213,9 @@ spec:
                           in a provider format
                         type: string
                       providerIDList:
-                        description: ProviderIDList are the identification IDs of
-                          machine instances provided by the provider. This field must
-                          match the provider IDs as seen on the node objects corresponding
-                          to a machine pool's machine instances.
+                        description: |-
+                          ProviderIDList are the identification IDs of machine instances provided by the provider.
+                          This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
                         items:
                           type: string
                         type: array
@@ -241,14 +244,19 @@ spec:
           API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -261,9 +269,10 @@ spec:
                   create an OCIManagedMachinePool from a template.
                 properties:
                   spec:
-                    description: OCIManagedMachinePoolSpec defines the desired state
-                      of an OCI managed machine pool. An OCIManagedMachinePool translates
-                      to an OKE NodePool. The properties are generated from https://docs.oracle.com/en-us/iaas/api/#/en/containerengine/20180222/datatypes/CreateNodePoolDetails
+                    description: |-
+                      OCIManagedMachinePoolSpec defines the desired state of an OCI managed machine pool.
+                      An OCIManagedMachinePool translates to an OKE NodePool.
+                      The properties are generated from https://docs.oracle.com/en-us/iaas/api/#/en/containerengine/20180222/datatypes/CreateNodePoolDetails
                     properties:
                       id:
                         description: ID is the OCID of the associated NodePool
@@ -316,17 +325,15 @@ spec:
                               nodepool will be cycled to have new changes.
                             type: boolean
                           maximumSurge:
-                            description: MaximumSurge refers to the maximum additional
-                              new compute instances that would be temporarily created
-                              and added to nodepool during the cycling nodepool process.
-                              OKE supports both integer and percentage input. Defaults
-                              to 1, Ranges from 0 to Nodepool size or 0% to 100%
+                            description: |-
+                              MaximumSurge refers to the maximum additional new compute instances that would be temporarily created and
+                              added to nodepool during the cycling nodepool process. OKE supports both integer and percentage input.
+                              Defaults to 1, Ranges from 0 to Nodepool size or 0% to 100%
                             type: string
                           maximumUnavailable:
-                            description: Maximum active nodes that would be terminated
-                              from nodepool during the cycling nodepool process. OKE
-                              supports both integer and percentage input. Defaults
-                              to 0, Ranges from 0 to Nodepool size or 0% to 100%
+                            description: |-
+                              Maximum active nodes that would be terminated from nodepool during the cycling nodepool process.
+                              OKE supports both integer and percentage input. Defaults to 0, Ranges from 0 to Nodepool size or 0% to 100%
                             type: string
                         type: object
                       nodePoolNodeConfig:
@@ -356,10 +363,9 @@ spec:
                                   Native CNI
                                 properties:
                                   maxPodsPerNode:
-                                    description: MemoryInGBs defines the max number
-                                      of pods per node in the node pool. This value
-                                      will be limited by the number of VNICs attachable
-                                      to the node pool shape
+                                    description: |-
+                                      MemoryInGBs defines the max number of pods per node in the node pool. This value will be limited by the
+                                      number of VNICs attachable to the node pool shape
                                     type: integer
                                   nsgNames:
                                     description: NSGNames defines the NSGs associated
@@ -376,8 +382,8 @@ spec:
                                 type: object
                             type: object
                           nsgNames:
-                            description: NsgNames defines the names of NSGs which
-                              will be associated with the nodes. the NSGs are defined
+                            description: |-
+                              NsgNames defines the names of NSGs which will be associated with the nodes. the NSGs are defined
                               in OCIManagedCluster object.
                             items:
                               type: string
@@ -405,10 +411,9 @@ spec:
                                     type: string
                                   type: array
                                 subnetName:
-                                  description: SubnetName defines the name of the
-                                    subnet which need ot be associated with the Nodepool.
-                                    The subnets are defined in the OCiManagedCluster
-                                    object.
+                                  description: |-
+                                    SubnetName defines the name of the subnet which need ot be associated with the Nodepool.
+                                    The subnets are defined in the OCiManagedCluster object.
                                   type: string
                               type: object
                             type: array
@@ -449,10 +454,9 @@ spec:
                           in a provider format
                         type: string
                       providerIDList:
-                        description: ProviderIDList are the identification IDs of
-                          machine instances provided by the provider. This field must
-                          match the provider IDs as seen on the node objects corresponding
-                          to a machine pool's machine instances.
+                        description: |-
+                          ProviderIDList are the identification IDs of machine instances provided by the provider.
+                          This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
                         items:
                           type: string
                         type: array

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ocivirtualmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ocivirtualmachinepools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: ocivirtualmachinepools.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -21,21 +21,27 @@ spec:
           API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: OCIVirtualMachinePoolSpec defines the desired state of an
-              OCI virtual machine pool. An OCIVirtualMachinePool translates to an
-              OKE Virtual node poo;. The properties are generated from https://docs.oracle.com/en-us/iaas/api/#/en/containerengine/20180222/datatypes/CreateVirtualNodePoolDetails
+            description: |-
+              OCIVirtualMachinePoolSpec defines the desired state of an OCI virtual machine pool.
+              An OCIVirtualMachinePool translates to an OKE Virtual node poo;.
+              The properties are generated from https://docs.oracle.com/en-us/iaas/api/#/en/containerengine/20180222/datatypes/CreateVirtualNodePoolDetails
             properties:
               id:
                 description: ID is the OCID of the associated NodePool
@@ -55,8 +61,9 @@ spec:
                   type: object
                 type: array
               nsgNames:
-                description: NsgNames defines the names of NSGs which will be associated
-                  with the nodes. the NSGs are defined in OCIManagedCluster object.
+                description: |-
+                  NsgNames defines the names of NSGs which will be associated with the nodes. the NSGs are defined
+                  in OCIManagedCluster object.
                 items:
                   type: string
                 type: array
@@ -76,9 +83,9 @@ spec:
                         type: string
                       type: array
                     subnetName:
-                      description: SubnetName defines the name of the subnet which
-                        need to be associated with the Virtual Node Pool. The subnets
-                        are defined in the OCiManagedCluster object.
+                      description: |-
+                        SubnetName defines the name of the subnet which need to be associated with the Virtual Node Pool.
+                        The subnets are defined in the OCiManagedCluster object.
                       type: string
                   type: object
                 type: array
@@ -104,10 +111,9 @@ spec:
                   a provider format
                 type: string
               providerIDList:
-                description: ProviderIDList are the identification IDs of machine
-                  instances provided by the provider. This field must match the provider
-                  IDs as seen on the node objects corresponding to a machine pool's
-                  machine instances.
+                description: |-
+                  ProviderIDList are the identification IDs of machine instances provided by the provider.
+                  This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
                 items:
                   type: string
                 type: array
@@ -140,37 +146,44 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
+                      description: status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -213,21 +226,27 @@ spec:
           API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: OCIVirtualMachinePoolSpec defines the desired state of an
-              OCI virtual machine pool. An OCIVirtualMachinePool translates to an
-              OKE Virtual node poo;. The properties are generated from https://docs.oracle.com/en-us/iaas/api/#/en/containerengine/20180222/datatypes/CreateVirtualNodePoolDetails
+            description: |-
+              OCIVirtualMachinePoolSpec defines the desired state of an OCI virtual machine pool.
+              An OCIVirtualMachinePool translates to an OKE Virtual node poo;.
+              The properties are generated from https://docs.oracle.com/en-us/iaas/api/#/en/containerengine/20180222/datatypes/CreateVirtualNodePoolDetails
             properties:
               id:
                 description: ID is the OCID of the associated NodePool
@@ -247,8 +266,9 @@ spec:
                   type: object
                 type: array
               nsgNames:
-                description: NsgNames defines the names of NSGs which will be associated
-                  with the nodes. the NSGs are defined in OCIManagedCluster object.
+                description: |-
+                  NsgNames defines the names of NSGs which will be associated with the nodes. the NSGs are defined
+                  in OCIManagedCluster object.
                 items:
                   type: string
                 type: array
@@ -268,9 +288,9 @@ spec:
                         type: string
                       type: array
                     subnetName:
-                      description: SubnetName defines the name of the subnet which
-                        need to be associated with the Virtual Node Pool. The subnets
-                        are defined in the OCiManagedCluster object.
+                      description: |-
+                        SubnetName defines the name of the subnet which need to be associated with the Virtual Node Pool.
+                        The subnets are defined in the OCiManagedCluster object.
                       type: string
                   type: object
                 type: array
@@ -296,10 +316,9 @@ spec:
                   a provider format
                 type: string
               providerIDList:
-                description: ProviderIDList are the identification IDs of machine
-                  instances provided by the provider. This field must match the provider
-                  IDs as seen on the node objects corresponding to a machine pool's
-                  machine instances.
+                description: |-
+                  ProviderIDList are the identification IDs of machine instances provided by the provider.
+                  This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
                 items:
                   type: string
                 type: array
@@ -332,37 +351,44 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
+                      description: status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime

--- a/exp/api/v1beta1/ocimanagedmachinepool_types.go
+++ b/exp/api/v1beta1/ocimanagedmachinepool_types.go
@@ -50,7 +50,7 @@ type OCIManagedMachinePoolSpec struct {
 
 	// SshPublicKey defines the SSH public key on each node in the node pool on launch.
 	// +optional
-	SshPublicKey string `json:"sshPublicKey,omitempty"`
+	SshPublicKey *string `json:"sshPublicKey,omitempty"`
 
 	// NodeMetadata defines a list of key/value pairs to add to each underlying OCI instance in the node pool on launch.
 	// +optional

--- a/exp/api/v1beta1/zz_generated.conversion.go
+++ b/exp/api/v1beta1/zz_generated.conversion.go
@@ -1037,7 +1037,7 @@ func autoConvert_v1beta1_OCIManagedMachinePoolSpec_To_v1beta2_OCIManagedMachineP
 	out.NodeShape = in.NodeShape
 	out.NodeShapeConfig = (*v1beta2.NodeShapeConfig)(unsafe.Pointer(in.NodeShapeConfig))
 	out.NodeSourceViaImage = (*v1beta2.NodeSourceViaImage)(unsafe.Pointer(in.NodeSourceViaImage))
-	out.SshPublicKey = in.SshPublicKey
+	out.SshPublicKey = (*string)(unsafe.Pointer(in.SshPublicKey))
 	out.NodeMetadata = *(*map[string]string)(unsafe.Pointer(&in.NodeMetadata))
 	out.InitialNodeLabels = *(*[]v1beta2.KeyValue)(unsafe.Pointer(&in.InitialNodeLabels))
 	out.ProviderIDList = *(*[]string)(unsafe.Pointer(&in.ProviderIDList))
@@ -1058,7 +1058,7 @@ func autoConvert_v1beta2_OCIManagedMachinePoolSpec_To_v1beta1_OCIManagedMachineP
 	out.NodeShape = in.NodeShape
 	out.NodeShapeConfig = (*NodeShapeConfig)(unsafe.Pointer(in.NodeShapeConfig))
 	out.NodeSourceViaImage = (*NodeSourceViaImage)(unsafe.Pointer(in.NodeSourceViaImage))
-	out.SshPublicKey = in.SshPublicKey
+	out.SshPublicKey = (*string)(unsafe.Pointer(in.SshPublicKey))
 	out.NodeMetadata = *(*map[string]string)(unsafe.Pointer(&in.NodeMetadata))
 	out.InitialNodeLabels = *(*[]KeyValue)(unsafe.Pointer(&in.InitialNodeLabels))
 	// WARNING: in.NodePoolCyclingDetails requires manual conversion: does not exist in peer-type

--- a/exp/api/v1beta1/zz_generated.deepcopy.go
+++ b/exp/api/v1beta1/zz_generated.deepcopy.go
@@ -714,6 +714,11 @@ func (in *OCIManagedMachinePoolSpec) DeepCopyInto(out *OCIManagedMachinePoolSpec
 		*out = new(NodeSourceViaImage)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.SshPublicKey != nil {
+		in, out := &in.SshPublicKey, &out.SshPublicKey
+		*out = new(string)
+		**out = **in
+	}
 	if in.NodeMetadata != nil {
 		in, out := &in.NodeMetadata, &out.NodeMetadata
 		*out = make(map[string]string, len(*in))

--- a/exp/api/v1beta2/ocimanagedmachinepool_types.go
+++ b/exp/api/v1beta2/ocimanagedmachinepool_types.go
@@ -49,7 +49,7 @@ type OCIManagedMachinePoolSpec struct {
 
 	// SshPublicKey defines the SSH public key on each node in the node pool on launch.
 	// +optional
-	SshPublicKey string `json:"sshPublicKey,omitempty"`
+	SshPublicKey *string `json:"sshPublicKey,omitempty"`
 
 	// NodeMetadata defines a list of key/value pairs to add to each underlying OCI instance in the node pool on launch.
 	// +optional

--- a/exp/api/v1beta2/zz_generated.deepcopy.go
+++ b/exp/api/v1beta2/zz_generated.deepcopy.go
@@ -744,6 +744,11 @@ func (in *OCIManagedMachinePoolSpec) DeepCopyInto(out *OCIManagedMachinePoolSpec
 		*out = new(NodeSourceViaImage)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.SshPublicKey != nil {
+		in, out := &in.SshPublicKey, &out.SshPublicKey
+		*out = new(string)
+		**out = **in
+	}
 	if in.NodeMetadata != nil {
 		in, out := &in.NodeMetadata, &out.NodeMetadata
 		*out = make(map[string]string, len(*in))

--- a/exp/controllers/ocimanaged_machinepool_controller_test.go
+++ b/exp/controllers/ocimanaged_machinepool_controller_test.go
@@ -756,7 +756,7 @@ func getOCIManagedMachinePool() *infrav2exp.OCIManagedMachinePool {
 			NodeSourceViaImage: &infrav2exp.NodeSourceViaImage{
 				ImageId: common.String("test-image-id"),
 			},
-			SshPublicKey: "test-ssh-public-key",
+			SshPublicKey: common.String("test-ssh-public-key"),
 			NodePoolNodeConfig: &infrav2exp.NodePoolNodeConfig{
 				PlacementConfigs: []infrav2exp.PlacementConfig{
 					{


### PR DESCRIPTION
<!-- please add a type to the title of this PR (see https://www.conventionalcommits.org/en/v1.0.0/#summary), and delete this line and similar ones -->
<!-- the type will be either fix:, feat:, docs:, test: see https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional for a more exhaustive list -->

**What this PR does / why we need it**:
This PR introduces a new field for OCIManagedCluster that allows for the network to be created in a different compartment than the one specified in `OCIManagedCluster.Spec.CompartmentId`

The new field is called `OCIManagedCluster.Spec.NetworkSpec.CompartmentId`, it is optional and if not set it will default to the only compartment specified.

In addition, this PR fixes many bugs on the managed machine pool controller. The controller logic caused continues updates on the node pool if the original OCIManagedCluster was modified. This is because not all fields were set as the actual managed node pool state and updated correctly.

The new reconciliation logic is following this design:
* If the user has defined a value for a field in the OCIManagedCluster object, then the controller will try to synchronize it
* If the field is not specified entirely, the controller will try to keep it as defined in the actual state of the node pool

**Which issue(s) this PR fixes**:
Fixes #450 
