### PR TITLE
fix: add ability to mock instance principal config

### DIFF
--- a/cloud/config/config.go
+++ b/cloud/config/config.go
@@ -27,6 +27,9 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// set this way to allow for mocks to be used for testing
+var instancePrincipalProviderFunc = auth.InstancePrincipalConfigurationProvider
+
 const (
 	UseInstancePrincipal = "useInstancePrincipal"
 	Tenancy              = "tenancy"
@@ -150,7 +153,7 @@ func NewConfigurationProvider(cfg *AuthConfig) (common.ConfigurationProvider, er
 		return nil, errors.New("auth config must not be nil")
 	}
 	if cfg.UseInstancePrincipals {
-		return auth.InstancePrincipalConfigurationProvider()
+		return instancePrincipalProviderFunc()
 	} else {
 		return NewConfigurationProviderWithUserPrincipal(cfg)
 	}


### PR DESCRIPTION
<!-- please add a type to the title of this PR (see https://www.conventionalcommits.org/en/v1.0.0/#summary), and delete this line and similar ones -->
<!-- the type will be either fix:, feat:, docs:, test: see https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional for a more exhaustive list -->

**What this PR does / why we need it**:
Fixes a small issue with https://github.com/oracle/cluster-api-provider-oci/pull/456
If you run this on an instance in the cloud it works, if you run it locally it won't pass. This mocks out the auth provider to allow instance principals to pass locally.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
no open issue for this.
