### PR TITLE
fix: Add nil check for getOCIClientCertFromSecret

### DIFF
--- a/cloud/util/util.go
+++ b/cloud/util/util.go
@@ -78,7 +78,7 @@ func GetClusterIdentityFromRef(ctx context.Context, c client.Client, ociClusterN
 // getOCIClientCertFromSecret returns the cert referenced by the OCICluster.
 func getOCIClientCertFromSecret(ctx context.Context, c client.Client, ociClusterNamespace string, overrides *infrastructurev1beta2.ClientOverrides) (*corev1.Secret, error) {
 	secret := &corev1.Secret{}
-	if overrides != nil {
+	if overrides != nil && overrides.CertOverride != nil {
 		certSecretRef := overrides.CertOverride
 		namespace := certSecretRef.Namespace
 		if namespace == "" {

--- a/cloud/util/util_test.go
+++ b/cloud/util/util_test.go
@@ -879,3 +879,40 @@ func TestDeleteManagedMachinesIfNotExists(t *testing.T) {
 		})
 	}
 }
+
+func TestGetOCIClientCertFromSecret(t *testing.T) {
+	testCases := []struct {
+		name          string
+		overrides     *infrastructurev1beta2.ClientOverrides
+		objects       []client.Object
+		errorExpected bool
+		errorMessage  string
+	}{
+		{
+			name: "NPE case - nil CertOverride",
+			overrides: &infrastructurev1beta2.ClientOverrides{
+				CertOverride: nil, // This should cause NPE
+			},
+			objects:       []client.Object{},
+			errorExpected: true, // Should panic or return error
+		},
+		// Add more test cases...
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			client := fake.NewClientBuilder().WithObjects(tt.objects...).Build()
+
+			// This should either panic or return an error
+			_, err := getOCIClientCertFromSecret(context.Background(), client, "default", tt.overrides)
+
+			if tt.errorExpected {
+				// Currently this will panic, but after the fix it should return an error
+				g.Expect(err).To(Not(BeNil()))
+			} else {
+				g.Expect(err).To(BeNil())
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- please add a type to the title of this PR (see https://www.conventionalcommits.org/en/v1.0.0/#summary), and delete this line and similar ones -->
<!-- the type will be either fix:, feat:, docs:, test: see https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional for a more exhaustive list -->

**What this PR does / why we need it**:
Adds a nil check around a possible nil case

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
NA
