### PR TITLE
feat: include CAPOCI identifier in OCI API User-Agent headers

### DIFF
--- a/cloud/scope/clients.go
+++ b/cloud/scope/clients.go
@@ -19,6 +19,7 @@ package scope
 import (
 	"crypto/x509"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -45,6 +46,8 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2/klogr"
 )
+
+const capociUserAgentToken = "Oracle-ClusterAPI"
 
 // OCIClients is the struct of all the needed OCI clients
 type OCIClients struct {
@@ -210,7 +213,7 @@ func (c *ClientProvider) createVcnClient(region string, ociAuthConfigProvider co
 	if c.ociClientOverrides != nil && c.ociClientOverrides.VCNClientUrl != nil {
 		vcnClient.Host = *c.ociClientOverrides.VCNClientUrl
 	}
-	vcnClient.Interceptor = setVersionHeader()
+	vcnClient.Interceptor = setCAPOCIRequestHeaders()
 
 	return &vcnClient, nil
 }
@@ -228,7 +231,7 @@ func (c *ClientProvider) createNLbClient(region string, ociAuthConfigProvider co
 	if c.ociClientOverrides != nil && c.ociClientOverrides.NetworkLoadBalancerClientUrl != nil {
 		nlbClient.Host = *c.ociClientOverrides.NetworkLoadBalancerClientUrl
 	}
-	nlbClient.Interceptor = setVersionHeader()
+	nlbClient.Interceptor = setCAPOCIRequestHeaders()
 
 	return &nlbClient, nil
 }
@@ -246,7 +249,7 @@ func (c *ClientProvider) createLBClient(region string, ociAuthConfigProvider com
 	if c.ociClientOverrides != nil && c.ociClientOverrides.LoadBalancerClientUrl != nil {
 		lbClient.Host = *c.ociClientOverrides.LoadBalancerClientUrl
 	}
-	lbClient.Interceptor = setVersionHeader()
+	lbClient.Interceptor = setCAPOCIRequestHeaders()
 
 	return &lbClient, nil
 }
@@ -264,7 +267,7 @@ func (c *ClientProvider) createIdentityClient(region string, ociAuthConfigProvid
 	if c.ociClientOverrides != nil && c.ociClientOverrides.IdentityClientUrl != nil {
 		identityClt.Host = *c.ociClientOverrides.IdentityClientUrl
 	}
-	identityClt.Interceptor = setVersionHeader()
+	identityClt.Interceptor = setCAPOCIRequestHeaders()
 
 	return &identityClt, nil
 }
@@ -279,7 +282,7 @@ func (c *ClientProvider) createBlockVolumeClient(region string, ociAuthConfigPro
 	dispatcher := blockVolumeClient.HTTPClient
 	blockVolumeClient.HTTPClient = metrics.NewHttpRequestDispatcherWrapper(dispatcher, region)
 
-	blockVolumeClient.Interceptor = setVersionHeader()
+	blockVolumeClient.Interceptor = setCAPOCIRequestHeaders()
 
 	return &blockVolumeClient, nil
 }
@@ -297,7 +300,7 @@ func (c *ClientProvider) createComputeClient(region string, ociAuthConfigProvide
 	if c.ociClientOverrides != nil && c.ociClientOverrides.ComputeClientUrl != nil {
 		computeClient.Host = *c.ociClientOverrides.ComputeClientUrl
 	}
-	computeClient.Interceptor = setVersionHeader()
+	computeClient.Interceptor = setCAPOCIRequestHeaders()
 
 	return &computeClient, nil
 }
@@ -315,7 +318,7 @@ func (c *ClientProvider) createComputeManagementClient(region string, ociAuthCon
 	if c.ociClientOverrides != nil && c.ociClientOverrides.ComputeManagementClientUrl != nil {
 		computeManagementClient.Host = *c.ociClientOverrides.ComputeManagementClientUrl
 	}
-	computeManagementClient.Interceptor = setVersionHeader()
+	computeManagementClient.Interceptor = setCAPOCIRequestHeaders()
 
 	return &computeManagementClient, nil
 }
@@ -333,7 +336,7 @@ func (c *ClientProvider) createContainerEngineClient(region string, ociAuthConfi
 	if c.ociClientOverrides != nil && c.ociClientOverrides.ContainerEngineClientUrl != nil {
 		containerEngineClt.Host = *c.ociClientOverrides.ContainerEngineClientUrl
 	}
-	containerEngineClt.Interceptor = setVersionHeader()
+	containerEngineClt.Interceptor = setCAPOCIRequestHeaders()
 
 	return &containerEngineClt, nil
 }
@@ -351,7 +354,7 @@ func (c *ClientProvider) createWorkrequestsClient(region string, ociAuthConfigPr
 	if c.ociClientOverrides != nil && c.ociClientOverrides.WorkrequestClientUrl != nil {
 		workrequestsClt.Host = *c.ociClientOverrides.WorkrequestClientUrl
 	}
-	workrequestsClt.Interceptor = setVersionHeader()
+	workrequestsClt.Interceptor = setCAPOCIRequestHeaders()
 
 	return &workrequestsClt, nil
 }
@@ -365,9 +368,24 @@ func (c *ClientProvider) createBaseClient(region string, ociAuthConfigProvider c
 	return baseClient, nil
 }
 
-func setVersionHeader() func(request *http.Request) error {
+func setCAPOCIRequestHeaders() func(request *http.Request) error {
 	return func(request *http.Request) error {
+		request.Header.Set("User-Agent", appendUserAgentToken(request.Header.Get("User-Agent"), capociUserAgentToken))
 		request.Header.Set("X-CAPOCI-VERSION", version.GitVersion)
 		return nil
 	}
+}
+
+func appendUserAgentToken(existing, token string) string {
+	for _, currentToken := range strings.Fields(existing) {
+		if currentToken == token {
+			return strings.TrimSpace(existing)
+		}
+	}
+
+	if existing == "" {
+		return token
+	}
+
+	return strings.TrimSpace(existing) + " " + token
 }

--- a/cloud/scope/clients_test.go
+++ b/cloud/scope/clients_test.go
@@ -17,13 +17,16 @@ limitations under the License.
 package scope
 
 import (
+	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	"github.com/oracle/cluster-api-provider-oci/api/v1beta2"
 	"github.com/oracle/cluster-api-provider-oci/cloud/config"
 	"github.com/oracle/cluster-api-provider-oci/cloud/services/vcn/mock_vcn"
+	"github.com/oracle/cluster-api-provider-oci/version"
 	"github.com/oracle/oci-go-sdk/v65/common"
 )
 
@@ -219,5 +222,34 @@ func TestClients_GetAuthProvider(t *testing.T) {
 
 	if clientProvider.GetAuthProvider() != ociAuthConfigProvider {
 		t.Errorf("returned authprovider %v doesn't equal: %v", clientProvider.GetAuthProvider(), ociAuthConfigProvider)
+	}
+}
+
+func TestSetCAPOCIRequestHeaders(t *testing.T) {
+	request, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+
+	originalUserAgent := "Oracle-GoSDK/65.102.0 (go1.22.0; amd64)"
+	request.Header.Set("User-Agent", originalUserAgent)
+
+	interceptor := setCAPOCIRequestHeaders()
+	if err := interceptor(request); err != nil {
+		t.Fatalf("unexpected interceptor error on first call: %v", err)
+	}
+	if err := interceptor(request); err != nil {
+		t.Fatalf("unexpected interceptor error on second call: %v", err)
+	}
+
+	userAgent := request.Header.Get("User-Agent")
+	if !strings.Contains(userAgent, originalUserAgent) {
+		t.Fatalf("expected user-agent %q to preserve original content %q", userAgent, originalUserAgent)
+	}
+	if strings.Count(userAgent, capociUserAgentToken) != 1 {
+		t.Fatalf("expected user-agent %q to contain %q exactly once", userAgent, capociUserAgentToken)
+	}
+	if request.Header.Get("X-CAPOCI-VERSION") != version.GitVersion {
+		t.Fatalf("expected X-CAPOCI-VERSION %q, got %q", version.GitVersion, request.Header.Get("X-CAPOCI-VERSION"))
 	}
 }


### PR DESCRIPTION
<!-- please add a type to the title of this PR (see https://www.conventionalcommits.org/en/v1.0.0/#summary), and delete this line and similar ones -->
<!-- the type will be either fix:, feat:, docs:, test: see https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional for a more exhaustive list -->

**What this PR does / why we need it**:
This appends `Oracle-ClusterAPI` to `user-agent` header. This will allow better help debugging.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

## Checklist
- [x] All unit tests are passing
- [x] All PRBlocking tests are passing
- [x] Code builds successfully