### PR TITLE
chore: Add Macaron check for GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-cluster-api-provider-book.yaml
+++ b/.github/workflows/build-cluster-api-provider-book.yaml
@@ -6,18 +6,23 @@ on:
   # Enable manual trigger
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build-and-publish-book:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       with:
         fetch-depth: 0
     - name: Install mdbook
       run: |
-        mkdir mdbook
-        curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.21/mdbook-v0.4.21-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
-        echo `pwd`/mdbook >> $GITHUB_PATH
+        mkdir -p mdbook
+        archive_path="${RUNNER_TEMP}/mdbook-v0.4.21-x86_64-unknown-linux-gnu.tar.gz"
+        curl -sSL -o "${archive_path}" https://github.com/rust-lang/mdBook/releases/download/v0.4.21/mdbook-v0.4.21-x86_64-unknown-linux-gnu.tar.gz
+        tar -xzf "${archive_path}" --directory=./mdbook
+        echo "${PWD}/mdbook" >> "${GITHUB_PATH}"
         cargo install --version 1.8.0 mdbook-admonish
     - name: Deploy Book to GitHub Pages
       run: |

--- a/.github/workflows/macaron-check-github-actions.yml
+++ b/.github/workflows/macaron-check-github-actions.yml
@@ -13,7 +13,7 @@ on:
       - ".github/workflows/**"
       - ".github/actions/**"
   schedule:
-    - cron: "17 4 * * 1"
+    - cron: "20 15 * * 3"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/macaron-check-github-actions.yml
+++ b/.github/workflows/macaron-check-github-actions.yml
@@ -34,4 +34,4 @@ jobs:
         with:
           repo_path: https://github.com/${{ github.repository }}
           policy_file: check-github-actions
-          policy_purl: pkg:github/${{ github.repository }}@${{ github.sha }}
+          policy_purl: pkg:github.com/${{ github.repository }}@${{ github.sha }}

--- a/.github/workflows/macaron-check-github-actions.yml
+++ b/.github/workflows/macaron-check-github-actions.yml
@@ -1,0 +1,37 @@
+name: Macaron check-github-actions
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  schedule:
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  macaron-check-github-actions:
+    runs-on: ubuntu-latest
+    name: Macaron policy verification
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Macaron check-github-actions policy
+        uses: oracle/macaron@b31acfe389133a5587d9639063ec70cb84e7bc47 # v0.23.0
+        with:
+          repo_path: https://github.com/${{ github.repository }}
+          policy_file: check-github-actions
+          policy_purl: pkg:github/${{ github.repository }}@${{ github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,9 @@ on:
       - "v*.*.*"
 
 permissions:
+  attestations: write
   contents: read
+  id-token: write
   packages: write
 
 jobs:
@@ -33,6 +35,11 @@ jobs:
         run: |
           echo "Release Tag: ${{ github.ref_name }}" 
           curl -sSL https://doc.crds.dev/github.com/oracle/cluster-api-provider-oci@${{ github.ref_name }}
+
+      - name: Attest release artifacts
+        uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
+        with:
+          subject-path: out/*
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,19 +6,23 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Log into GitHub Container Registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${GITHUB_ACTOR,,} --password-stdin
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: 1.17
 
@@ -30,7 +34,7 @@ jobs:
           echo "Release Tag: ${{ github.ref_name }}" 
           curl -sSL https://doc.crds.dev/github.com/oracle/cluster-api-provider-oci@${{ github.ref_name }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: CAPOCI Artifacts
           path: out/


### PR DESCRIPTION
<!-- please add a type to the title of this PR (see https://www.conventionalcommits.org/en/v1.0.0/#summary), and delete this line and similar ones -->
<!-- the type will be either fix:, feat:, docs:, test: see https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional for a more exhaustive list -->

**What this PR does / why we need it**:
Add Macaron policy verification for GitHub Actions using the `check-github-actions` policy.
- Adds a dedicated workflow for Macaron verification
- Checks workflow definitions and local composite actions
- Uses pinned actions and disables persisted checkout credentials

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
