### PR TITLE
Update templates imds

### DIFF
--- a/templates/cluster-template-alternative-region.yaml
+++ b/templates/cluster-template-alternative-region.yaml
@@ -87,6 +87,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_CONTROL_PLANE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
@@ -103,6 +105,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_NODE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/templates/cluster-template-antrea.yaml
+++ b/templates/cluster-template-antrea.yaml
@@ -301,6 +301,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_CONTROL_PLANE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
@@ -317,6 +319,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_NODE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/templates/cluster-template-arm-free-tier.yaml
+++ b/templates/cluster-template-arm-free-tier.yaml
@@ -110,6 +110,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       IsPvEncryptionInTransitEnabled: ${OCI_CONTROL_PLANE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
@@ -128,6 +130,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       IsPvEncryptionInTransitEnabled: ${OCI_NODE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/templates/cluster-template-failure-domain-spread.yaml
+++ b/templates/cluster-template-failure-domain-spread.yaml
@@ -86,6 +86,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_CONTROL_PLANE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
@@ -102,6 +104,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_NODE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/templates/cluster-template-healthcheck.yaml
+++ b/templates/cluster-template-healthcheck.yaml
@@ -91,6 +91,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_CONTROL_PLANE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
@@ -109,6 +111,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_NODE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/templates/cluster-template-local-vcn-peering.yaml
+++ b/templates/cluster-template-local-vcn-peering.yaml
@@ -398,6 +398,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
@@ -415,6 +417,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/templates/cluster-template-machinepool.yaml
+++ b/templates/cluster-template-machinepool.yaml
@@ -86,6 +86,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_CONTROL_PLANE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
@@ -116,6 +118,8 @@ metadata:
   namespace: default
 spec:
   instanceConfiguration:
+    instanceOptions:
+      areLegacyImdsEndpointsDisabled: true
     instanceSourceViaImageConfig:
       imageId: "${OCI_IMAGE_ID}"
     shape: "${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}"

--- a/templates/cluster-template-nlb-healthcheck.yaml
+++ b/templates/cluster-template-nlb-healthcheck.yaml
@@ -108,6 +108,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_CONTROL_PLANE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
@@ -124,6 +126,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_NODE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/templates/cluster-template-nlb-reserved-ip-config.yaml
+++ b/templates/cluster-template-nlb-reserved-ip-config.yaml
@@ -96,6 +96,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_CONTROL_PLANE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
@@ -112,6 +114,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_NODE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/templates/cluster-template-oci-addons.yaml
+++ b/templates/cluster-template-oci-addons.yaml
@@ -86,6 +86,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_CONTROL_PLANE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
@@ -102,6 +104,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_NODE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/templates/cluster-template-oraclelinux.yaml
+++ b/templates/cluster-template-oraclelinux.yaml
@@ -89,6 +89,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_CONTROL_PLANE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
@@ -105,6 +107,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_NODE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/templates/cluster-template-remote-vcn-peering.yaml
+++ b/templates/cluster-template-remote-vcn-peering.yaml
@@ -402,6 +402,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
@@ -419,6 +421,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/templates/cluster-template-windows-calico.yaml
+++ b/templates/cluster-template-windows-calico.yaml
@@ -378,6 +378,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_CONTROL_PLANE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
@@ -397,6 +399,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_NODE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/templates/cluster-template-with-bv-autotuned.yaml
+++ b/templates/cluster-template-with-bv-autotuned.yaml
@@ -87,6 +87,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_CONTROL_PLANE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
       blockvolumeSpec:
         autotunePolicies:
           - autotuneType: "PERFORMANCE_BASED"
@@ -112,6 +114,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_NODE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
       blockvolumeSpec:
         autotunePolicies:
           - autotuneType: "PERFORMANCE_BASED"

--- a/templates/cluster-template-with-ipv6.yaml
+++ b/templates/cluster-template-with-ipv6.yaml
@@ -107,6 +107,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_CONTROL_PLANE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
       networkDetails:
         assignIpv6Ip: true
 ---
@@ -125,6 +127,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_NODE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
       networkDetails:
         assignIpv6Ip: true
 ---

--- a/templates/cluster-template-with-nsg.yaml
+++ b/templates/cluster-template-with-nsg.yaml
@@ -122,6 +122,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_CONTROL_PLANE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
@@ -138,6 +140,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_NODE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/templates/cluster-template-with-paravirt-bv.yaml
+++ b/templates/cluster-template-with-paravirt-bv.yaml
@@ -86,6 +86,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_CONTROL_PLANE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
@@ -102,6 +104,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_NODE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
       launchVolumeAttachments:
         - volumeType: "paravirtualized"
           launchParavirtualizedVolumeAttachment:

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -86,6 +86,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_CONTROL_PLANE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
@@ -102,6 +104,8 @@ spec:
       metadata:
         ssh_authorized_keys: "${OCI_SSH_KEY}"
       isPvEncryptionInTransitEnabled: ${OCI_NODE_PV_TRANSIT_ENCRYPTION=true}
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/templates/clusterclass-example.yaml
+++ b/templates/clusterclass-example.yaml
@@ -202,6 +202,8 @@ spec:
     spec:
       # will be replaced by shape variable defined above
       shape: VM.Standard.E4.Flex
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
       metadata: {}
       shapeConfig: {}
 
@@ -215,6 +217,8 @@ spec:
     spec:
       # will be replaced by shape variable defined above
       shape: VM.Standard.E4.Flex
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
       metadata: {}
       shapeConfig: {}
 ---

--- a/test/e2e/data/infrastructure-oci/v1beta1/bases/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta1/bases/cluster.yaml
@@ -82,6 +82,8 @@ spec:
       imageId: "${OCI_IMAGE_ID}"
       compartmentId: "${OCI_COMPARTMENT_ID}"
       shape: "${OCI_CONTROL_PLANE_MACHINE_TYPE}"
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
       shapeConfig:
         ocpus: "1"
       metadata:

--- a/test/e2e/data/infrastructure-oci/v1beta1/bases/md.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta1/bases/md.yaml
@@ -8,6 +8,8 @@ spec:
       imageId: "${OCI_IMAGE_ID}"
       compartmentId: "${OCI_COMPARTMENT_ID}"
       shape: "${OCI_NODE_MACHINE_TYPE}"
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
       shapeConfig:
         ocpus: "1"
       metadata:

--- a/test/e2e/data/infrastructure-oci/v1beta2/bases/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/bases/cluster.yaml
@@ -83,6 +83,8 @@ spec:
       compartmentId: "${OCI_COMPARTMENT_ID}"
       shape: "${OCI_CONTROL_PLANE_MACHINE_TYPE}"
       isPvEncryptionInTransitEnabled: true
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
       shapeConfig:
         ocpus: "1"
       metadata:

--- a/test/e2e/data/infrastructure-oci/v1beta2/bases/md.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/bases/md.yaml
@@ -9,6 +9,8 @@ spec:
       compartmentId: "${OCI_COMPARTMENT_ID}"
       shape: "${OCI_NODE_MACHINE_TYPE}"
       isPvEncryptionInTransitEnabled: true
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
       shapeConfig:
         ocpus: "1"
       metadata:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-cluster-class/clusterclass-test-cluster-class.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-cluster-class/clusterclass-test-cluster-class.yaml
@@ -202,6 +202,8 @@ spec:
     spec:
       # will be replaced by shape variable defined above
       shape: VM.Standard.E5.Flex
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
       metadata: {}
       shapeConfig: {}
 ---
@@ -214,6 +216,8 @@ spec:
     spec:
       # will be replaced by shape variable defined above
       shape: VM.Standard.E5.Flex
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
       metadata: {}
       shapeConfig: {}
 ---

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-machine-pool/machine-pool.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-machine-pool/machine-pool.yaml
@@ -28,6 +28,8 @@ metadata:
   namespace: default
 spec:
   instanceConfiguration:
+    instanceOptions:
+      areLegacyImdsEndpointsDisabled: true
     metadata:
       ssh_authorized_keys: "${OCI_SSH_KEY}"
     instanceSourceViaImageConfig:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-multiple-node-nsg/md-0.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-multiple-node-nsg/md-0.yaml
@@ -12,6 +12,8 @@ spec:
       networkDetails:
         nsgNames:
           - "worker-nsg-1"
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
       shapeConfig:
         ocpus: "1"
       metadata:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-multiple-node-nsg/md-1.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-multiple-node-nsg/md-1.yaml
@@ -12,6 +12,8 @@ spec:
       networkDetails:
         nsgNames:
           - "worker-nsg-2"
+      instanceOptions:
+        areLegacyImdsEndpointsDisabled: true
       shapeConfig:
         ocpus: "1"
       metadata:


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds `areLegacyImdsEndpointsDisabled: true` to our templates and e2e tests to make sure instances aren't launched with IMDS v1 enabled.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes NA

## Checklist
- [x] All unit tests are passing
- [x] All PRBlocking tests are passing
- [x] Code builds successfully