### PR TITLE
fix nil dereference on IsPublic in getNetworkLoadbalancerIp

### DIFF
--- a/cloud/scope/network_load_balancer_reconciler.go
+++ b/cloud/scope/network_load_balancer_reconciler.go
@@ -283,11 +283,14 @@ func (s *ClusterScope) getNetworkLoadbalancerIp(nlb networkloadbalancer.NetworkL
 	}
 	if ptr.ToBool(nlb.IsPrivate) {
 		nlbIp = nlb.IpAddresses[0].IpAddress
-	} else {
-		for _, ip := range nlb.IpAddresses {
-			if *ip.IsPublic {
-				nlbIp = ip.IpAddress
-			}
+		if nlbIp == nil {
+			return nil, errors.New("nlb does not have valid private ip address")
+		}
+		return nlbIp, nil
+	}
+	for _, ip := range nlb.IpAddresses {
+		if ptr.ToBool(ip.IsPublic) {
+			nlbIp = ip.IpAddress
 		}
 	}
 	if nlbIp == nil {
@@ -355,7 +358,6 @@ func isHealthCheckerEqual(actual, desired *networkloadbalancer.HealthChecker) bo
 	}
 	return true
 }
-
 
 // GetNetworkLoadBalancers retrieves the Cluster's networkloadbalancer.NetworkLoadBalancer using the one of the following methods
 //

--- a/cloud/scope/network_load_balancer_reconciler_test.go
+++ b/cloud/scope/network_load_balancer_reconciler_test.go
@@ -1357,6 +1357,85 @@ func TestNLBDeletion(t *testing.T) {
 		})
 	}
 }
+func TestGetNetworkLoadbalancerIp(t *testing.T) {
+	tests := []struct {
+		name        string
+		nlb         networkloadbalancer.NetworkLoadBalancer
+		expectedIP  string
+		errContains string
+	}{
+		{
+			name:        "no ip addresses returns error",
+			nlb:         networkloadbalancer.NetworkLoadBalancer{IsPrivate: common.Bool(false)},
+			errContains: "nlb does not have valid ip addresses",
+		},
+		{
+			name: "private nlb returns first ip",
+			nlb: networkloadbalancer.NetworkLoadBalancer{
+				IsPrivate: common.Bool(true),
+				IpAddresses: []networkloadbalancer.IpAddress{
+					{IpAddress: common.String("10.0.0.1"), IsPublic: common.Bool(false)},
+				},
+			},
+			expectedIP: "10.0.0.1",
+		},
+		{
+			name: "private nlb with nil IpAddress returns error",
+			nlb: networkloadbalancer.NetworkLoadBalancer{
+				IsPrivate:   common.Bool(true),
+				IpAddresses: []networkloadbalancer.IpAddress{{IpAddress: nil}},
+			},
+			errContains: "nlb does not have valid private ip address",
+		},
+		{
+			name: "public nlb with nil IsPublic on entry does not panic",
+			nlb: networkloadbalancer.NetworkLoadBalancer{
+				IsPrivate: common.Bool(false),
+				IpAddresses: []networkloadbalancer.IpAddress{
+					{IpAddress: common.String("1.2.3.4"), IsPublic: nil},
+				},
+			},
+			errContains: "nlb does not have valid public ip address",
+		},
+		{
+			name: "public nlb skips private entries and returns public ip",
+			nlb: networkloadbalancer.NetworkLoadBalancer{
+				IsPrivate: common.Bool(false),
+				IpAddresses: []networkloadbalancer.IpAddress{
+					{IpAddress: common.String("10.0.0.1"), IsPublic: common.Bool(false)},
+					{IpAddress: common.String("2.2.2.2"), IsPublic: common.Bool(true)},
+				},
+			},
+			expectedIP: "2.2.2.2",
+		},
+		{
+			name: "public nlb with no public entry returns error",
+			nlb: networkloadbalancer.NetworkLoadBalancer{
+				IsPrivate: common.Bool(false),
+				IpAddresses: []networkloadbalancer.IpAddress{
+					{IpAddress: common.String("10.0.0.1"), IsPublic: common.Bool(false)},
+				},
+			},
+			errContains: "nlb does not have valid public ip address",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			scope := newTestClusterScope(t)
+			ip, err := scope.getNetworkLoadbalancerIp(tt.nlb)
+			if tt.errContains != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.errContains))
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(*ip).To(Equal(tt.expectedIP))
+		})
+	}
+}
+
 func getDefinedTags() (map[string]map[string]string, map[string]map[string]interface{}) {
 	definedTags := map[string]map[string]string{
 		"ns1": {


### PR DESCRIPTION
`IpAddress.IsPublic` is `mandatory:"false"` in the OCI SDK — the API can return it nil. We were dereferencing it directly, which panics. Switched to `ptr.ToBool`, which is already used in the same function for `IsPrivate`.

Also fixes a misleading error message: a nil `IpAddress` on a private NLB was falling through to "does not have valid public ip address", which is wrong.

Relates to #530.