### PR TITLE
feat: Add ability to override tags for OCIMachinePool's Instance Config

### DIFF
--- a/cloud/hash/instanceconfighash.go
+++ b/cloud/hash/instanceconfighash.go
@@ -34,6 +34,8 @@ type comparableLaunchDetails struct {
 	CapacityReservationID          *string                              `json:"capacityReservationId,omitempty"`
 	CompartmentID                  *string                              `json:"compartmentId,omitempty"`
 	CreateVnicDetails              *comparableCreateVnicDetails         `json:"createVnicDetails,omitempty"`
+	FreeformTags                   map[string]string                    `json:"freeformTags,omitempty"`
+	DefinedTags                    map[string]map[string]interface{}    `json:"definedTags,omitempty"`
 	Metadata                       map[string]string                    `json:"metadata,omitempty"`
 	ExtendedMetadata               map[string]interface{}               `json:"extendedMetadata,omitempty"`
 	Shape                          *string                              `json:"shape,omitempty"`
@@ -50,14 +52,16 @@ type comparableLaunchDetails struct {
 }
 
 type comparableCreateVnicDetails struct {
-	AssignIPv6IP           *bool    `json:"assignIpv6Ip,omitempty"`
-	AssignPublicIP         *bool    `json:"assignPublicIp,omitempty"`
-	AssignPrivateDNSRecord *bool    `json:"assignPrivateDnsRecord,omitempty"`
-	HostnameLabel          *string  `json:"hostnameLabel,omitempty"`
-	NSGIDs                 []string `json:"nsgIds,omitempty"`
-	PrivateIP              *string  `json:"privateIp,omitempty"`
-	SkipSourceDestCheck    *bool    `json:"skipSourceDestCheck,omitempty"`
-	SubnetID               *string  `json:"subnetId,omitempty"`
+	AssignIPv6IP           *bool                             `json:"assignIpv6Ip,omitempty"`
+	AssignPublicIP         *bool                             `json:"assignPublicIp,omitempty"`
+	AssignPrivateDNSRecord *bool                             `json:"assignPrivateDnsRecord,omitempty"`
+	FreeformTags           map[string]string                 `json:"freeformTags,omitempty"`
+	DefinedTags            map[string]map[string]interface{} `json:"definedTags,omitempty"`
+	HostnameLabel          *string                           `json:"hostnameLabel,omitempty"`
+	NSGIDs                 []string                          `json:"nsgIds,omitempty"`
+	PrivateIP              *string                           `json:"privateIp,omitempty"`
+	SkipSourceDestCheck    *bool                             `json:"skipSourceDestCheck,omitempty"`
+	SubnetID               *string                           `json:"subnetId,omitempty"`
 }
 
 type comparableShapeConfig struct {
@@ -154,6 +158,8 @@ func projectLaunchDetails(in, mask *core.InstanceConfigurationLaunchInstanceDeta
 		CapacityReservationID:          pickString(in.CapacityReservationId, mask.CapacityReservationId),
 		CompartmentID:                  pickString(in.CompartmentId, mask.CompartmentId),
 		CreateVnicDetails:              projectCreateVnicDetails(in.CreateVnicDetails, mask.CreateVnicDetails),
+		FreeformTags:                   normalizeFreeformTags(in.FreeformTags),
+		DefinedTags:                    normalizeDefinedTags(in.DefinedTags),
 		Metadata:                       normalizeMetadata(pickMetadata(in.Metadata, mask.Metadata)),
 		ExtendedMetadata:               pickExtendedMetadata(in.ExtendedMetadata, mask.ExtendedMetadata),
 		Shape:                          pickString(in.Shape, mask.Shape),
@@ -184,6 +190,38 @@ func normalizeMetadata(md map[string]string) map[string]string {
 			continue
 		}
 		output[k] = v
+	}
+	if len(output) == 0 {
+		return nil
+	}
+	return output
+}
+
+func normalizeFreeformTags(tags map[string]string) map[string]string {
+	if len(tags) == 0 {
+		return nil
+	}
+	output := make(map[string]string, len(tags))
+	for k, v := range tags {
+		output[k] = v
+	}
+	return output
+}
+
+func normalizeDefinedTags(tags map[string]map[string]interface{}) map[string]map[string]interface{} {
+	if len(tags) == 0 {
+		return nil
+	}
+	output := make(map[string]map[string]interface{}, len(tags))
+	for namespace, values := range tags {
+		if len(values) == 0 {
+			continue
+		}
+		copiedValues := make(map[string]interface{}, len(values))
+		for k, v := range values {
+			copiedValues[k] = v
+		}
+		output[namespace] = copiedValues
 	}
 	if len(output) == 0 {
 		return nil
@@ -286,6 +324,8 @@ func projectCreateVnicDetails(in, mask *core.InstanceConfigurationCreateVnicDeta
 		AssignIPv6IP:           pickDefaultFalseBool(in.AssignIpv6Ip, mask.AssignIpv6Ip),
 		AssignPublicIP:         pickDefaultFalseBool(in.AssignPublicIp, mask.AssignPublicIp),
 		AssignPrivateDNSRecord: pickBool(in.AssignPrivateDnsRecord, mask.AssignPrivateDnsRecord),
+		FreeformTags:           normalizeFreeformTags(in.FreeformTags),
+		DefinedTags:            normalizeDefinedTags(in.DefinedTags),
 		HostnameLabel:          pickString(in.HostnameLabel, mask.HostnameLabel),
 		NSGIDs:                 nsgIDs,
 		PrivateIP:              pickString(in.PrivateIp, mask.PrivateIp),

--- a/cloud/hash/instanceconfighash_test.go
+++ b/cloud/hash/instanceconfighash_test.go
@@ -476,7 +476,7 @@ func TestComputeHash_IgnoresDisplayName(t *testing.T) {
 	g.Expect(hash1).To(Equal(hash2))
 }
 
-func TestComputeHash_IgnoresFreeformTags(t *testing.T) {
+func TestComputeHash_FreeformTagChangeProducesDifferentHash(t *testing.T) {
 	g := NewWithT(t)
 	baseLd := &core.InstanceConfigurationLaunchInstanceDetails{
 		Shape: common.String("VM.Standard2.1"),
@@ -494,7 +494,271 @@ func TestComputeHash_IgnoresFreeformTags(t *testing.T) {
 	hash2, err := ComputeHash(&ld2)
 	g.Expect(err).To(BeNil())
 
+	g.Expect(hash1).ToNot(Equal(hash2))
+}
+
+func TestComputeHash_DefinedTagChangeProducesDifferentHash(t *testing.T) {
+	g := NewWithT(t)
+	baseLd := &core.InstanceConfigurationLaunchInstanceDetails{
+		Shape: common.String("VM.Standard2.1"),
+	}
+
+	ld1 := *baseLd
+	ld1.DefinedTags = map[string]map[string]interface{}{"Operations": {"CostCenter": "42"}}
+
+	ld2 := *baseLd
+	ld2.DefinedTags = map[string]map[string]interface{}{"Operations": {"CostCenter": "43"}}
+
+	hash1, err := ComputeHash(&ld1)
+	g.Expect(err).To(BeNil())
+
+	hash2, err := ComputeHash(&ld2)
+	g.Expect(err).To(BeNil())
+
+	g.Expect(hash1).ToNot(Equal(hash2))
+}
+
+func TestComputeHash_DefinedTagOrderIsDeterministic(t *testing.T) {
+	g := NewWithT(t)
+
+	ld1 := &core.InstanceConfigurationLaunchInstanceDetails{
+		Shape: common.String("VM.Standard2.1"),
+		DefinedTags: map[string]map[string]interface{}{
+			"Operations": {
+				"CostCenter": "42",
+				"Owner":      "platform",
+			},
+			"Security": {
+				"Profile": "restricted",
+			},
+		},
+	}
+
+	ld2 := &core.InstanceConfigurationLaunchInstanceDetails{
+		Shape: common.String("VM.Standard2.1"),
+		DefinedTags: map[string]map[string]interface{}{
+			"Security": {
+				"Profile": "restricted",
+			},
+			"Operations": {
+				"Owner":      "platform",
+				"CostCenter": "42",
+			},
+		},
+	}
+
+	hash1, err := ComputeHash(ld1)
+	g.Expect(err).To(BeNil())
+
+	hash2, err := ComputeHash(ld2)
+	g.Expect(err).To(BeNil())
+
 	g.Expect(hash1).To(Equal(hash2))
+}
+
+func TestComputeHash_FreeformTagOrderIsDeterministic(t *testing.T) {
+	g := NewWithT(t)
+
+	ld1 := &core.InstanceConfigurationLaunchInstanceDetails{
+		Shape: common.String("VM.Standard2.1"),
+		FreeformTags: map[string]string{
+			"owner":      "platform",
+			"costcenter": "42",
+			"profile":    "restricted",
+		},
+	}
+
+	ld2 := &core.InstanceConfigurationLaunchInstanceDetails{
+		Shape: common.String("VM.Standard2.1"),
+		FreeformTags: map[string]string{
+			"profile":    "restricted",
+			"costcenter": "42",
+			"owner":      "platform",
+		},
+	}
+
+	hash1, err := ComputeHash(ld1)
+	g.Expect(err).To(BeNil())
+
+	hash2, err := ComputeHash(ld2)
+	g.Expect(err).To(BeNil())
+
+	g.Expect(hash1).To(Equal(hash2))
+}
+
+func TestComputeHash_VnicTagChangesProduceDifferentHashes(t *testing.T) {
+	tests := []struct {
+		name  string
+		left  *core.InstanceConfigurationCreateVnicDetails
+		right *core.InstanceConfigurationCreateVnicDetails
+	}{
+		{
+			name: "freeform tags",
+			left: &core.InstanceConfigurationCreateVnicDetails{
+				FreeformTags: map[string]string{"owner": "platform"},
+			},
+			right: &core.InstanceConfigurationCreateVnicDetails{
+				FreeformTags: map[string]string{"owner": "apps"},
+			},
+		},
+		{
+			name: "defined tags",
+			left: &core.InstanceConfigurationCreateVnicDetails{
+				DefinedTags: map[string]map[string]interface{}{"Operations": {"CostCenter": "42"}},
+			},
+			right: &core.InstanceConfigurationCreateVnicDetails{
+				DefinedTags: map[string]map[string]interface{}{"Operations": {"CostCenter": "43"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ld1 := &core.InstanceConfigurationLaunchInstanceDetails{
+				Shape:             common.String("VM.Standard2.1"),
+				CreateVnicDetails: tt.left,
+			}
+			ld2 := &core.InstanceConfigurationLaunchInstanceDetails{
+				Shape:             common.String("VM.Standard2.1"),
+				CreateVnicDetails: tt.right,
+			}
+
+			hash1, err := ComputeHash(ld1)
+			g.Expect(err).To(BeNil())
+
+			hash2, err := ComputeHash(ld2)
+			g.Expect(err).To(BeNil())
+
+			g.Expect(hash1).ToNot(Equal(hash2))
+		})
+	}
+}
+
+func TestComputeHash_VnicTagOrderIsDeterministic(t *testing.T) {
+	tests := []struct {
+		name  string
+		left  *core.InstanceConfigurationCreateVnicDetails
+		right *core.InstanceConfigurationCreateVnicDetails
+	}{
+		{
+			name: "freeform tags",
+			left: &core.InstanceConfigurationCreateVnicDetails{
+				FreeformTags: map[string]string{
+					"owner":      "platform",
+					"costcenter": "42",
+					"profile":    "restricted",
+				},
+			},
+			right: &core.InstanceConfigurationCreateVnicDetails{
+				FreeformTags: map[string]string{
+					"profile":    "restricted",
+					"costcenter": "42",
+					"owner":      "platform",
+				},
+			},
+		},
+		{
+			name: "defined tags",
+			left: &core.InstanceConfigurationCreateVnicDetails{
+				DefinedTags: map[string]map[string]interface{}{
+					"Operations": {
+						"CostCenter": "42",
+						"Owner":      "platform",
+					},
+					"Security": {
+						"Profile": "restricted",
+					},
+				},
+			},
+			right: &core.InstanceConfigurationCreateVnicDetails{
+				DefinedTags: map[string]map[string]interface{}{
+					"Security": {
+						"Profile": "restricted",
+					},
+					"Operations": {
+						"Owner":      "platform",
+						"CostCenter": "42",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ld1 := &core.InstanceConfigurationLaunchInstanceDetails{
+				Shape:             common.String("VM.Standard2.1"),
+				CreateVnicDetails: tt.left,
+			}
+			ld2 := &core.InstanceConfigurationLaunchInstanceDetails{
+				Shape:             common.String("VM.Standard2.1"),
+				CreateVnicDetails: tt.right,
+			}
+
+			hash1, err := ComputeHash(ld1)
+			g.Expect(err).To(BeNil())
+
+			hash2, err := ComputeHash(ld2)
+			g.Expect(err).To(BeNil())
+
+			g.Expect(hash1).To(Equal(hash2))
+		})
+	}
+}
+
+func TestComputeHash_NilAndEmptyTagsDoNotAffectHash(t *testing.T) {
+	g := NewWithT(t)
+
+	withNil := &core.InstanceConfigurationLaunchInstanceDetails{
+		Shape:             common.String("VM.Standard2.1"),
+		CreateVnicDetails: &core.InstanceConfigurationCreateVnicDetails{},
+	}
+
+	withEmpty := &core.InstanceConfigurationLaunchInstanceDetails{
+		Shape:        common.String("VM.Standard2.1"),
+		FreeformTags: map[string]string{},
+		DefinedTags:  map[string]map[string]interface{}{},
+		CreateVnicDetails: &core.InstanceConfigurationCreateVnicDetails{
+			FreeformTags: map[string]string{},
+			DefinedTags:  map[string]map[string]interface{}{},
+		},
+	}
+
+	hashNil, err := ComputeHash(withNil)
+	g.Expect(err).To(BeNil())
+
+	hashEmpty, err := ComputeHash(withEmpty)
+	g.Expect(err).To(BeNil())
+
+	g.Expect(hashNil).To(Equal(hashEmpty))
+}
+
+func TestComputeComparableHash_TagRemovalDetected(t *testing.T) {
+	g := NewWithT(t)
+
+	actual := &core.InstanceConfigurationLaunchInstanceDetails{
+		Shape:        common.String("VM.Standard2.1"),
+		FreeformTags: map[string]string{"owner": "platform"},
+		DefinedTags:  map[string]map[string]interface{}{"Operations": {"CostCenter": "42"}},
+		CreateVnicDetails: &core.InstanceConfigurationCreateVnicDetails{
+			FreeformTags: map[string]string{"vnic-owner": "platform"},
+			DefinedTags:  map[string]map[string]interface{}{"Network": {"Tier": "worker"}},
+		},
+	}
+	desired := &core.InstanceConfigurationLaunchInstanceDetails{
+		Shape:             common.String("VM.Standard2.1"),
+		CreateVnicDetails: &core.InstanceConfigurationCreateVnicDetails{},
+	}
+
+	actualHash, err := ComputeComparableHash(actual, desired)
+	g.Expect(err).To(BeNil())
+
+	desiredHash, err := ComputeHash(desired)
+	g.Expect(err).To(BeNil())
+
+	g.Expect(actualHash).ToNot(Equal(desiredHash))
 }
 
 func TestComputeHash_IgnoresUserData(t *testing.T) {
@@ -694,7 +958,7 @@ func TestComputeHash_ComprehensiveTest(t *testing.T) {
 			Nvmes:       &nvmes,
 		},
 
-		// VNIC details - display name/tags/security should be EXCLUDED, NSGs sorted
+		// VNIC details - display name/security attributes excluded, tags included, NSGs sorted
 		CreateVnicDetails: &core.InstanceConfigurationCreateVnicDetails{
 			DisplayName:            common.String("test-vnic"),
 			FreeformTags:           map[string]string{"vnic-tag": "value"},
@@ -793,6 +1057,8 @@ func TestComputeHash_ComprehensiveTest(t *testing.T) {
 	g.Expect(normalized.CreateVnicDetails.SkipSourceDestCheck).To(BeNil())
 	g.Expect(*normalized.CreateVnicDetails.AssignPrivateDNSRecord).To(BeTrue())
 	g.Expect(*normalized.CreateVnicDetails.HostnameLabel).To(Equal("test-host"))
+	g.Expect(normalized.CreateVnicDetails.FreeformTags).To(Equal(map[string]string{"vnic-tag": "value"}))
+	g.Expect(normalized.CreateVnicDetails.DefinedTags).To(Equal(map[string]map[string]interface{}{"vnic-ns": {"key": "val"}}))
 	expectedNSGs := []string{"ocid1.nsg.oc1..nsg1", "ocid1.nsg.oc1..nsg2", "ocid1.nsg.oc1..nsg3"}
 	g.Expect(normalized.CreateVnicDetails.NSGIDs).To(Equal(expectedNSGs))
 

--- a/cloud/scope/machine_pool.go
+++ b/cloud/scope/machine_pool.go
@@ -433,11 +433,18 @@ func (s *MachinePoolScope) IsResourceCreatedByClusterAPI(resourceFreeFormTags ma
 
 // GetFreeFormTags gets the free form tags for the MachinePoolScope cluster and returns them
 func (m *MachinePoolScope) GetFreeFormTags() map[string]string {
-	tags := ociutil.BuildClusterTags(m.OCIClusterAccesor.GetOCIResourceIdentifier())
-	if m.OCIClusterAccesor.GetFreeformTags() != nil {
-		for k, v := range m.OCIClusterAccesor.GetFreeformTags() {
-			tags[k] = v
-		}
+	tags := make(map[string]string)
+	for k, v := range m.OCIClusterAccesor.GetFreeformTags() {
+		tags[k] = v
+	}
+	for k, v := range m.OCIMachinePool.Spec.InstanceConfiguration.FreeformTags {
+		tags[k] = v
+	}
+	// Ownership tags must be applied last. Resource discovery and cleanup depend
+	// on these values matching the controller-owned cluster identifiers, so users
+	// cannot override them through cluster or machine pool freeform tags.
+	for k, v := range ociutil.BuildClusterTags(m.OCIClusterAccesor.GetOCIResourceIdentifier()) {
+		tags[k] = v
 	}
 
 	return tags
@@ -540,10 +547,11 @@ func (m *MachinePoolScope) ReconcileInstanceConfiguration(ctx context.Context, _
 	//   configChanged:     desired config hash  vs  actual config hash (projected)
 	//   bootstrapChanged: desired user_data hash  vs  actual user_data hash
 	//
-	// Config uses ComputeComparableHash which projects the actual OCI
-	// response onto only the fields present in the desired spec. This
-	// filters out OCI-returned defaults (e.g. ShapeConfig.MemoryInGBs on
-	// flex shapes) that would otherwise cause continuous recreates (issue #509).
+	// Config uses ComputeComparableHash which filters out OCI-returned scalar
+	// defaults (e.g. ShapeConfig.MemoryInGBs on flex shapes) that would otherwise
+	// cause continuous recreates (issue #509). Tag maps are compared as part of
+	// the launch behavior so tag additions, changes, and removals recreate the
+	// immutable instance configuration.
 	//
 	// Bootstrap compares OCI actual vs desired. We still classify kubeadm
 	// discovery-token-only drift separately for observability, but bootstrap
@@ -612,15 +620,22 @@ func (m *MachinePoolScope) ReconcileInstanceConfiguration(ctx context.Context, _
 // getDefinedTags builds the defined tags map for InstanceConfiguration creation.
 func (m *MachinePoolScope) getDefinedTags() map[string]map[string]interface{} {
 	definedTags := make(map[string]map[string]interface{})
-	if m.OCIClusterAccesor.GetDefinedTags() == nil {
-		return definedTags
-	}
 	for ns, mapNs := range m.OCIClusterAccesor.GetDefinedTags() {
 		mapValues := make(map[string]interface{})
 		for k, v := range mapNs {
 			mapValues[k] = v
 		}
 		definedTags[ns] = mapValues
+	}
+	for ns, mapNs := range m.OCIMachinePool.Spec.InstanceConfiguration.DefinedTags {
+		mapValues, ok := definedTags[ns]
+		if !ok {
+			mapValues = make(map[string]interface{})
+			definedTags[ns] = mapValues
+		}
+		for k, v := range mapNs {
+			mapValues[k] = v
+		}
 	}
 	return definedTags
 }
@@ -860,6 +875,7 @@ func (m *MachinePoolScope) UpdatePool(ctx context.Context, instancePool *core.In
 
 		updateDetails := core.UpdateInstancePoolDetails{
 			InstanceConfigurationId: m.OCIMachinePool.Spec.InstanceConfiguration.InstanceConfigurationId,
+			FreeformTags:            m.GetFreeFormTags(),
 		}
 		if !annotations.ReplicasManagedByExternalAutoscaler(m.MachinePool) {
 			updateDetails.Size = common.Int(replicas)

--- a/cloud/scope/machine_pool_test.go
+++ b/cloud/scope/machine_pool_test.go
@@ -196,6 +196,7 @@ func TestInstanceConfigCreate(t *testing.T) {
 									CompartmentId: common.String("test-compartment"),
 									Shape:         common.String("test-shape"),
 									CreateVnicDetails: &core.InstanceConfigurationCreateVnicDetails{
+										DefinedTags:  definedTagsInterface,
 										FreeformTags: tags,
 										NsgIds:       []string{"nsg-id"},
 										SubnetId:     common.String("subnet-id"),
@@ -701,6 +702,7 @@ write_files:
 									CompartmentId: common.String("test-compartment"),
 									Shape:         common.String("test-shape"),
 									CreateVnicDetails: &core.InstanceConfigurationCreateVnicDetails{
+										DefinedTags:    definedTagsInterface,
 										FreeformTags:   tags,
 										NsgIds:         []string{"nsg-id", "nsg-id-2"},
 										AssignPublicIp: common.Bool(false),
@@ -739,6 +741,7 @@ write_files:
 									CompartmentId: common.String("test-compartment"),
 									Shape:         common.String("VM.Standard.E4.Flex"),
 									CreateVnicDetails: &core.InstanceConfigurationCreateVnicDetails{
+										DefinedTags:  definedTagsInterface,
 										FreeformTags: tags,
 										NsgIds:       []string{"nsg-id"},
 										SubnetId:     common.String("subnet-id"),
@@ -789,6 +792,7 @@ write_files:
 									CompartmentId: common.String("test-compartment"),
 									Shape:         common.String("test-shape"),
 									CreateVnicDetails: &core.InstanceConfigurationCreateVnicDetails{
+										DefinedTags:  definedTagsInterface,
 										FreeformTags: tags,
 										NsgIds:       []string{"nsg-id"},
 										SubnetId:     common.String("subnet-id"),
@@ -812,6 +816,133 @@ write_files:
 						},
 					}, nil)
 				computeManagementClient.EXPECT().CreateInstanceConfiguration(gomock.Any(), gomock.Any()).Times(0)
+			},
+		},
+		{
+			name:          "instance config recreated when machine pool freeform tags change",
+			errorExpected: false,
+			testSpecificSetup: func(ms *MachinePoolScope, g *WithT) {
+				ms.OCIMachinePool.Spec.InstanceConfiguration = infrav2exp.InstanceConfiguration{
+					Shape:                   common.String("test-shape"),
+					InstanceConfigurationId: common.String("test"),
+					FreeformTags: map[string]string{
+						"workload": "batch",
+					},
+				}
+
+				computeManagementClient.EXPECT().GetInstanceConfiguration(gomock.Any(), gomock.Eq(core.GetInstanceConfigurationRequest{
+					InstanceConfigurationId: common.String("test"),
+				})).
+					Return(core.GetInstanceConfigurationResponse{
+						InstanceConfiguration: core.InstanceConfiguration{
+							Id: common.String("test"),
+							InstanceDetails: core.ComputeInstanceDetails{
+								LaunchDetails: &core.InstanceConfigurationLaunchInstanceDetails{
+									DefinedTags:   definedTagsInterface,
+									FreeformTags:  tags,
+									CompartmentId: common.String("test-compartment"),
+									Shape:         common.String("test-shape"),
+									CreateVnicDetails: &core.InstanceConfigurationCreateVnicDetails{
+										DefinedTags:  definedTagsInterface,
+										FreeformTags: tags,
+										NsgIds:       []string{"nsg-id"},
+										SubnetId:     common.String("subnet-id"),
+									},
+									SourceDetails: core.InstanceConfigurationInstanceSourceViaImageDetails{},
+									Metadata:      map[string]string{"user_data": "dGVzdA=="},
+								},
+							},
+						},
+					}, nil)
+
+				computeManagementClient.EXPECT().ListInstanceConfigurations(gomock.Any(), gomock.Any()).
+					Return(core.ListInstanceConfigurationsResponse{}, nil)
+
+				computeManagementClient.EXPECT().CreateInstanceConfiguration(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req core.CreateInstanceConfigurationRequest) (core.CreateInstanceConfigurationResponse, error) {
+						expectedTags := map[string]string{
+							ociutil.CreatedBy:                 ociutil.OCIClusterAPIProvider,
+							ociutil.ClusterResourceIdentifier: "resource_uid",
+							"workload":                        "batch",
+						}
+						createDetails := req.CreateInstanceConfiguration.(core.CreateInstanceConfigurationDetails)
+						launchDetails := createDetails.InstanceDetails.(core.ComputeInstanceDetails).LaunchDetails
+						g.Expect(createDetails.FreeformTags).To(Equal(expectedTags))
+						g.Expect(launchDetails.FreeformTags).To(Equal(expectedTags))
+						g.Expect(launchDetails.CreateVnicDetails.FreeformTags).To(Equal(expectedTags))
+						return core.CreateInstanceConfigurationResponse{
+							InstanceConfiguration: core.InstanceConfiguration{
+								Id: common.String("id"),
+							},
+						}, nil
+					})
+			},
+		},
+		{
+			name:          "instance config recreated when machine pool defined tags change",
+			errorExpected: false,
+			testSpecificSetup: func(ms *MachinePoolScope, g *WithT) {
+				ms.OCIMachinePool.Spec.InstanceConfiguration = infrav2exp.InstanceConfiguration{
+					Shape:                   common.String("test-shape"),
+					InstanceConfigurationId: common.String("test"),
+					DefinedTags: map[string]map[string]string{
+						"ns1": {
+							"tag1": "pool-override",
+						},
+					},
+				}
+
+				computeManagementClient.EXPECT().GetInstanceConfiguration(gomock.Any(), gomock.Eq(core.GetInstanceConfigurationRequest{
+					InstanceConfigurationId: common.String("test"),
+				})).
+					Return(core.GetInstanceConfigurationResponse{
+						InstanceConfiguration: core.InstanceConfiguration{
+							Id: common.String("test"),
+							InstanceDetails: core.ComputeInstanceDetails{
+								LaunchDetails: &core.InstanceConfigurationLaunchInstanceDetails{
+									DefinedTags:   definedTagsInterface,
+									FreeformTags:  tags,
+									CompartmentId: common.String("test-compartment"),
+									Shape:         common.String("test-shape"),
+									CreateVnicDetails: &core.InstanceConfigurationCreateVnicDetails{
+										DefinedTags:  definedTagsInterface,
+										FreeformTags: tags,
+										NsgIds:       []string{"nsg-id"},
+										SubnetId:     common.String("subnet-id"),
+									},
+									SourceDetails: core.InstanceConfigurationInstanceSourceViaImageDetails{},
+									Metadata:      map[string]string{"user_data": "dGVzdA=="},
+								},
+							},
+						},
+					}, nil)
+
+				computeManagementClient.EXPECT().ListInstanceConfigurations(gomock.Any(), gomock.Any()).
+					Return(core.ListInstanceConfigurationsResponse{}, nil)
+
+				computeManagementClient.EXPECT().CreateInstanceConfiguration(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req core.CreateInstanceConfigurationRequest) (core.CreateInstanceConfigurationResponse, error) {
+						expectedDefinedTags := map[string]map[string]interface{}{
+							"ns1": {
+								"tag1": "pool-override",
+								"tag2": "bar",
+							},
+							"ns2": {
+								"tag1": "foo1",
+								"tag2": "bar1",
+							},
+						}
+						createDetails := req.CreateInstanceConfiguration.(core.CreateInstanceConfigurationDetails)
+						launchDetails := createDetails.InstanceDetails.(core.ComputeInstanceDetails).LaunchDetails
+						g.Expect(createDetails.DefinedTags).To(Equal(expectedDefinedTags))
+						g.Expect(launchDetails.DefinedTags).To(Equal(expectedDefinedTags))
+						g.Expect(launchDetails.CreateVnicDetails.DefinedTags).To(Equal(expectedDefinedTags))
+						return core.CreateInstanceConfigurationResponse{
+							InstanceConfiguration: core.InstanceConfiguration{
+								Id: common.String("id"),
+							},
+						}, nil
+					})
 			},
 		},
 		{
@@ -1119,6 +1250,7 @@ func TestBackfillAnnotations_Upgrade(t *testing.T) {
 			CompartmentId: common.String("test-compartment"),
 			Shape:         common.String("test-shape"),
 			CreateVnicDetails: &core.InstanceConfigurationCreateVnicDetails{
+				DefinedTags:  definedTagsInterface,
 				FreeformTags: tags,
 				NsgIds:       []string{"nsg-id"},
 				SubnetId:     common.String("subnet-id"),
@@ -1526,6 +1658,186 @@ func TestGetLaunchInstanceDetailsCopiesMetadataAndPropagatesSupportedFields(t *t
 	g.Expect(*sourceDetails.BootVolumeSizeInGBs).To(Equal(int64(100)))
 	g.Expect(*sourceDetails.BootVolumeVpusPerGB).To(Equal(int64(20)))
 	g.Expect(*launchDetails.AvailabilityConfig.IsLiveMigrationPreferred).To(BeTrue())
+}
+
+func TestMachinePoolEffectiveInstanceTags(t *testing.T) {
+	g := NewWithT(t)
+
+	ociCluster := &infrastructurev1beta2.OCICluster{
+		Spec: infrastructurev1beta2.OCIClusterSpec{
+			OCIResourceIdentifier: "resource_uid",
+			FreeformTags: map[string]string{
+				"cluster-only":                    "cluster",
+				"overlap":                         "cluster",
+				ociutil.CreatedBy:                 "user-created-by",
+				ociutil.ClusterResourceIdentifier: "user-resource-id",
+			},
+			DefinedTags: map[string]map[string]string{
+				"Operations": {
+					"CostCenter": "cluster-42",
+					"Owner":      "cluster-platform",
+				},
+				"Security": {
+					"Profile": "restricted",
+				},
+			},
+		},
+	}
+	machinePool := &infrav2exp.OCIMachinePool{
+		Spec: infrav2exp.OCIMachinePoolSpec{
+			InstanceConfiguration: infrav2exp.InstanceConfiguration{
+				FreeformTags: map[string]string{
+					"pool-only":       "pool",
+					"overlap":         "pool",
+					ociutil.CreatedBy: "pool-created-by",
+				},
+				DefinedTags: map[string]map[string]string{
+					"Operations": {
+						"CostCenter": "pool-43",
+					},
+					"Billing": {
+						"Project": "capoci",
+					},
+				},
+			},
+		},
+	}
+	ms := &MachinePoolScope{
+		OCIClusterAccesor: OCISelfManagedCluster{OCICluster: ociCluster},
+		OCIMachinePool:    machinePool,
+	}
+
+	g.Expect(ms.GetFreeFormTags()).To(Equal(map[string]string{
+		"cluster-only":                    "cluster",
+		"pool-only":                       "pool",
+		"overlap":                         "pool",
+		ociutil.CreatedBy:                 ociutil.OCIClusterAPIProvider,
+		ociutil.ClusterResourceIdentifier: "resource_uid",
+	}))
+
+	effectiveDefinedTags := ms.getDefinedTags()
+	g.Expect(effectiveDefinedTags).To(Equal(map[string]map[string]interface{}{
+		"Operations": {
+			"CostCenter": "pool-43",
+			"Owner":      "cluster-platform",
+		},
+		"Security": {
+			"Profile": "restricted",
+		},
+		"Billing": {
+			"Project": "capoci",
+		},
+	}))
+
+	ociCluster.Spec.DefinedTags["Operations"]["Owner"] = "mutated"
+	machinePool.Spec.InstanceConfiguration.DefinedTags["Operations"]["CostCenter"] = "mutated"
+	g.Expect(effectiveDefinedTags["Operations"]["Owner"]).To(Equal("cluster-platform"))
+	g.Expect(effectiveDefinedTags["Operations"]["CostCenter"]).To(Equal("pool-43"))
+}
+
+func TestGetLaunchInstanceDetailsAppliesEffectiveInstanceTagsToLaunchAndVnic(t *testing.T) {
+	g := NewWithT(t)
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bootstrap",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"value": []byte("test"),
+		},
+	}
+	ociCluster := &infrastructurev1beta2.OCICluster{
+		Spec: infrastructurev1beta2.OCIClusterSpec{
+			CompartmentId:         "test-compartment",
+			OCIResourceIdentifier: "resource_uid",
+			FreeformTags: map[string]string{
+				"cluster-only": "cluster",
+				"overlap":      "cluster",
+			},
+			DefinedTags: map[string]map[string]string{
+				"Operations": {
+					"CostCenter": "cluster-42",
+					"Owner":      "cluster-platform",
+				},
+			},
+			NetworkSpec: infrastructurev1beta2.NetworkSpec{
+				Vcn: infrastructurev1beta2.VCN{
+					Subnets: []*infrastructurev1beta2.Subnet{
+						{
+							Role: infrastructurev1beta2.WorkerRole,
+							ID:   common.String("worker-subnet-id"),
+						},
+					},
+				},
+			},
+		},
+	}
+	machinePool := &infrav2exp.OCIMachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: infrav2exp.OCIMachinePoolSpec{
+			InstanceConfiguration: infrav2exp.InstanceConfiguration{
+				Shape: common.String("test-shape"),
+				FreeformTags: map[string]string{
+					"pool-only": "pool",
+					"overlap":   "pool",
+				},
+				DefinedTags: map[string]map[string]string{
+					"Operations": {
+						"CostCenter": "pool-43",
+					},
+				},
+			},
+		},
+	}
+	client := fake.NewClientBuilder().WithStatusSubresource(machinePool).WithObjects(secret, machinePool).Build()
+	ms, err := NewMachinePoolScope(MachinePoolScopeParams{
+		ComputeManagementClient: mock_computemanagement.NewMockClient(mockCtrl),
+		OCIMachinePool:          machinePool,
+		OCIClusterAccessor:      OCISelfManagedCluster{OCICluster: ociCluster},
+		Cluster:                 &clusterv1.Cluster{},
+		MachinePool: &clusterv1.MachinePool{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+			Spec: clusterv1.MachinePoolSpec{
+				Template: clusterv1.MachineTemplateSpec{
+					Spec: clusterv1.MachineSpec{
+						Bootstrap: clusterv1.Bootstrap{
+							DataSecretName: common.String("bootstrap"),
+						},
+					},
+				},
+			},
+		},
+		Client: client,
+	})
+	g.Expect(err).To(BeNil())
+
+	freeformTags := ms.GetFreeFormTags()
+	definedTags := ms.getDefinedTags()
+	launchDetails, err := ms.getLaunchInstanceDetails(machinePool.Spec.InstanceConfiguration, freeformTags, definedTags)
+	g.Expect(err).To(BeNil())
+
+	expectedFreeformTags := map[string]string{
+		"cluster-only":                    "cluster",
+		"pool-only":                       "pool",
+		"overlap":                         "pool",
+		ociutil.CreatedBy:                 ociutil.OCIClusterAPIProvider,
+		ociutil.ClusterResourceIdentifier: "resource_uid",
+	}
+	expectedDefinedTags := map[string]map[string]interface{}{
+		"Operations": {
+			"CostCenter": "pool-43",
+			"Owner":      "cluster-platform",
+		},
+	}
+	g.Expect(launchDetails.FreeformTags).To(Equal(expectedFreeformTags))
+	g.Expect(launchDetails.DefinedTags).To(Equal(expectedDefinedTags))
+	g.Expect(launchDetails.CreateVnicDetails.FreeformTags).To(Equal(expectedFreeformTags))
+	g.Expect(launchDetails.CreateVnicDetails.DefinedTags).To(Equal(expectedDefinedTags))
 }
 
 func TestGetLaunchInstanceDetailsExtendedMetadata(t *testing.T) {
@@ -2136,6 +2448,7 @@ func TestInstancePoolUpdate(t *testing.T) {
 					UpdateInstancePoolDetails: core.UpdateInstancePoolDetails{
 						Size:                    common.Int(3),
 						InstanceConfigurationId: common.String("config_id_new"),
+						FreeformTags:            tags,
 					},
 				})).
 					Return(core.UpdateInstancePoolResponse{
@@ -2171,6 +2484,7 @@ func TestInstancePoolUpdate(t *testing.T) {
 					UpdateInstancePoolDetails: core.UpdateInstancePoolDetails{
 						Size:                    common.Int(3),
 						InstanceConfigurationId: common.String("config_id"),
+						FreeformTags:            tags,
 						PlacementConfigurations: []core.UpdateInstancePoolPlacementConfigurationDetails{
 							{
 								AvailabilityDomain: common.String("ad-2"),
@@ -2215,6 +2529,7 @@ func TestInstancePoolUpdate(t *testing.T) {
 				computeManagementClient.EXPECT().UpdateInstancePool(gomock.Any(), gomock.Eq(core.UpdateInstancePoolRequest{
 					UpdateInstancePoolDetails: core.UpdateInstancePoolDetails{
 						InstanceConfigurationId: common.String("config_id"),
+						FreeformTags:            tags,
 						PlacementConfigurations: []core.UpdateInstancePoolPlacementConfigurationDetails{
 							{
 								AvailabilityDomain: common.String("ad-2"),
@@ -2385,6 +2700,10 @@ func TestInstancePoolUpdatePrimarySubnetPlacement(t *testing.T) {
 		UpdateInstancePoolDetails: core.UpdateInstancePoolDetails{
 			Size:                    common.Int(3),
 			InstanceConfigurationId: common.String("config_id"),
+			FreeformTags: map[string]string{
+				ociutil.ClusterResourceIdentifier: "",
+				ociutil.CreatedBy:                 ociutil.OCIClusterAPIProvider,
+			},
 			PlacementConfigurations: []core.UpdateInstancePoolPlacementConfigurationDetails{
 				{
 					AvailabilityDomain: common.String("ad-1"),

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ocimachinepools.yaml
@@ -138,6 +138,17 @@ spec:
                     description: DedicatedVmHostId defines the OCID of the dedicated
                       VM host.
                     type: string
+                  definedTags:
+                    additionalProperties:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    description: |-
+                      Defined tags for instances launched by this machine pool. Each key is
+                      predefined and scoped to a namespace.
+                      These tags override OCICluster defined tags with the same namespace/key.
+                      Example: `{"Operations": {"CostCenter": "42"}}`
+                    type: object
                   extendedMetadata:
                     additionalProperties:
                       x-kubernetes-preserve-unknown-fields: true
@@ -146,6 +157,13 @@ spec:
                       Values support nested JSON objects and arrays and map to OCI InstanceConfigurationLaunchInstanceDetails.extendedMetadata.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+                  freeformTags:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Free-form tags for instances launched by this machine pool.
+                      These tags override OCICluster freeform tags with the same key.
+                    type: object
                   instanceConfigurationId:
                     type: string
                   instanceOptions:
@@ -886,6 +904,17 @@ spec:
                     description: DedicatedVmHostId defines the OCID of the dedicated
                       VM host.
                     type: string
+                  definedTags:
+                    additionalProperties:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    description: |-
+                      Defined tags for instances launched by this machine pool. Each key is
+                      predefined and scoped to a namespace.
+                      These tags override OCICluster defined tags with the same namespace/key.
+                      Example: `{"Operations": {"CostCenter": "42"}}`
+                    type: object
                   extendedMetadata:
                     additionalProperties:
                       x-kubernetes-preserve-unknown-fields: true
@@ -894,6 +923,13 @@ spec:
                       Values support nested JSON objects and arrays and map to OCI InstanceConfigurationLaunchInstanceDetails.extendedMetadata.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+                  freeformTags:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Free-form tags for instances launched by this machine pool.
+                      These tags override OCICluster freeform tags with the same key.
+                    type: object
                   instanceConfigurationId:
                     type: string
                   instanceOptions:

--- a/exp/api/v1beta1/ocimachinepool_types.go
+++ b/exp/api/v1beta1/ocimachinepool_types.go
@@ -59,6 +59,18 @@ type InstanceConfiguration struct {
 	// The shape configuration of the instance, applicable for flex instances.
 	ShapeConfig *ShapeConfig `json:"shapeConfig,omitempty"`
 
+	// Free-form tags for instances launched by this machine pool.
+	// These tags override OCICluster freeform tags with the same key.
+	// +optional
+	FreeformTags map[string]string `json:"freeformTags,omitempty"`
+
+	// Defined tags for instances launched by this machine pool. Each key is
+	// predefined and scoped to a namespace.
+	// These tags override OCICluster defined tags with the same namespace/key.
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	// +optional
+	DefinedTags map[string]map[string]string `json:"definedTags,omitempty"`
+
 	InstanceVnicConfiguration *infrastructurev1beta1.NetworkDetails `json:"instanceVnicConfiguration,omitempty"`
 
 	// PlatformConfig defines the platform config parameters

--- a/exp/api/v1beta1/zz_generated.conversion.go
+++ b/exp/api/v1beta1/zz_generated.conversion.go
@@ -433,6 +433,8 @@ func autoConvert_v1beta1_InstanceConfiguration_To_v1beta2_InstanceConfiguration(
 	out.InstanceConfigurationId = (*string)(unsafe.Pointer(in.InstanceConfigurationId))
 	out.Shape = (*string)(unsafe.Pointer(in.Shape))
 	out.ShapeConfig = (*v1beta2.ShapeConfig)(unsafe.Pointer(in.ShapeConfig))
+	out.FreeformTags = *(*map[string]string)(unsafe.Pointer(&in.FreeformTags))
+	out.DefinedTags = *(*map[string]map[string]string)(unsafe.Pointer(&in.DefinedTags))
 	if in.InstanceVnicConfiguration != nil {
 		in, out := &in.InstanceVnicConfiguration, &out.InstanceVnicConfiguration
 		*out = new(apiv1beta2.NetworkDetails)
@@ -466,6 +468,8 @@ func autoConvert_v1beta2_InstanceConfiguration_To_v1beta1_InstanceConfiguration(
 	out.InstanceConfigurationId = (*string)(unsafe.Pointer(in.InstanceConfigurationId))
 	out.Shape = (*string)(unsafe.Pointer(in.Shape))
 	out.ShapeConfig = (*ShapeConfig)(unsafe.Pointer(in.ShapeConfig))
+	out.FreeformTags = *(*map[string]string)(unsafe.Pointer(&in.FreeformTags))
+	out.DefinedTags = *(*map[string]map[string]string)(unsafe.Pointer(&in.DefinedTags))
 	if in.InstanceVnicConfiguration != nil {
 		in, out := &in.InstanceVnicConfiguration, &out.InstanceVnicConfiguration
 		*out = new(apiv1beta1.NetworkDetails)

--- a/exp/api/v1beta1/zz_generated.deepcopy.go
+++ b/exp/api/v1beta1/zz_generated.deepcopy.go
@@ -46,6 +46,31 @@ func (in *InstanceConfiguration) DeepCopyInto(out *InstanceConfiguration) {
 		*out = new(ShapeConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.FreeformTags != nil {
+		in, out := &in.FreeformTags, &out.FreeformTags
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.DefinedTags != nil {
+		in, out := &in.DefinedTags, &out.DefinedTags
+		*out = make(map[string]map[string]string, len(*in))
+		for key, val := range *in {
+			var outVal map[string]string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				inVal := (*in)[key]
+				in, out := &inVal, &outVal
+				*out = make(map[string]string, len(*in))
+				for key, val := range *in {
+					(*out)[key] = val
+				}
+			}
+			(*out)[key] = outVal
+		}
+	}
 	if in.InstanceVnicConfiguration != nil {
 		in, out := &in.InstanceVnicConfiguration, &out.InstanceVnicConfiguration
 		*out = new(apiv1beta1.NetworkDetails)

--- a/exp/api/v1beta2/ocimachinepool_types.go
+++ b/exp/api/v1beta2/ocimachinepool_types.go
@@ -59,6 +59,18 @@ type InstanceConfiguration struct {
 	// The shape configuration of the instance, applicable for flex instances.
 	ShapeConfig *ShapeConfig `json:"shapeConfig,omitempty"`
 
+	// Free-form tags for instances launched by this machine pool.
+	// These tags override OCICluster freeform tags with the same key.
+	// +optional
+	FreeformTags map[string]string `json:"freeformTags,omitempty"`
+
+	// Defined tags for instances launched by this machine pool. Each key is
+	// predefined and scoped to a namespace.
+	// These tags override OCICluster defined tags with the same namespace/key.
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	// +optional
+	DefinedTags map[string]map[string]string `json:"definedTags,omitempty"`
+
 	InstanceVnicConfiguration *infrastructurev1beta2.NetworkDetails `json:"instanceVnicConfiguration,omitempty"`
 
 	// PlatformConfig defines the platform config parameters

--- a/exp/api/v1beta2/zz_generated.deepcopy.go
+++ b/exp/api/v1beta2/zz_generated.deepcopy.go
@@ -46,6 +46,31 @@ func (in *InstanceConfiguration) DeepCopyInto(out *InstanceConfiguration) {
 		*out = new(ShapeConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.FreeformTags != nil {
+		in, out := &in.FreeformTags, &out.FreeformTags
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.DefinedTags != nil {
+		in, out := &in.DefinedTags, &out.DefinedTags
+		*out = make(map[string]map[string]string, len(*in))
+		for key, val := range *in {
+			var outVal map[string]string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				inVal := (*in)[key]
+				in, out := &inVal, &outVal
+				*out = make(map[string]string, len(*in))
+				for key, val := range *in {
+					(*out)[key] = val
+				}
+			}
+			(*out)[key] = outVal
+		}
+	}
 	if in.InstanceVnicConfiguration != nil {
 		in, out := &in.InstanceVnicConfiguration, &out.InstanceVnicConfiguration
 		*out = new(apiv1beta2.NetworkDetails)

--- a/exp/controllers/ocimachinepool_controller_test.go
+++ b/exp/controllers/ocimachinepool_controller_test.go
@@ -225,6 +225,7 @@ func TestReconciliationFunction(t *testing.T) {
 		ociMachinePool = getOCIMachinePool()
 		client := fake.NewClientBuilder().WithScheme(testScheme()).WithStatusSubresource(ociMachinePool).WithObjects(getSecret(), ociMachinePool, machinePool).Build()
 		ociCluster := getOCIClusterWithOwner()
+		ociCluster.Spec.DefinedTags = definedTags
 		ms, err = scope.NewMachinePoolScope(scope.MachinePoolScopeParams{
 			ComputeManagementClient: computeManagementClient,
 			OCIClusterAccessor: scope.OCISelfManagedCluster{
@@ -290,6 +291,7 @@ func TestReconciliationFunction(t *testing.T) {
 									CompartmentId: common.String("test-compartment"),
 									Shape:         common.String("test-shape"),
 									CreateVnicDetails: &core.InstanceConfigurationCreateVnicDetails{
+										DefinedTags:  definedTagsInterface,
 										FreeformTags: tags,
 										NsgIds:       []string{"worker-nsg-id"},
 										SubnetId:     common.String("worker-subnet-id"),
@@ -343,6 +345,7 @@ func TestReconciliationFunction(t *testing.T) {
 									CompartmentId: common.String("test-compartment"),
 									Shape:         common.String("test-shape"),
 									CreateVnicDetails: &core.InstanceConfigurationCreateVnicDetails{
+										DefinedTags:  definedTagsInterface,
 										FreeformTags: tags,
 										NsgIds:       []string{"worker-nsg-id"},
 										SubnetId:     common.String("worker-subnet-id"),
@@ -418,6 +421,7 @@ func TestReconciliationFunction(t *testing.T) {
 									CompartmentId: common.String("test-compartment"),
 									Shape:         common.String("test-shape"),
 									CreateVnicDetails: &core.InstanceConfigurationCreateVnicDetails{
+										DefinedTags:  definedTagsInterface,
 										FreeformTags: tags,
 										NsgIds:       []string{"worker-nsg-id"},
 										SubnetId:     common.String("worker-subnet-id"),
@@ -529,6 +533,7 @@ func TestReconciliationFunction(t *testing.T) {
 									CompartmentId: common.String("test-compartment"),
 									Shape:         common.String("test-shape"),
 									CreateVnicDetails: &core.InstanceConfigurationCreateVnicDetails{
+										DefinedTags:  definedTagsInterface,
 										FreeformTags: tags,
 										NsgIds:       []string{"worker-nsg-id"},
 										SubnetId:     common.String("worker-subnet-id"),
@@ -597,6 +602,7 @@ func TestReconciliationFunction(t *testing.T) {
 									CompartmentId: common.String("test-compartment"),
 									Shape:         common.String("test-shape"),
 									CreateVnicDetails: &core.InstanceConfigurationCreateVnicDetails{
+										DefinedTags:  definedTagsInterface,
 										FreeformTags: tags,
 										NsgIds:       []string{"worker-nsg-id"},
 										SubnetId:     common.String("worker-subnet-id"),


### PR DESCRIPTION
<!-- please add a type to the title of this PR (see https://www.conventionalcommits.org/en/v1.0.0/#summary), and delete this line and similar ones -->
<!-- the type will be either fix:, feat:, docs:, test: see https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional for a more exhaustive list -->

**What this PR does / why we need it**:
This allows the user to override the OCICluster tags at the OCIMachinePool instance config level.

Example
```
apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
kind: OCIMachinePool
metadata:
  name: ${CLUSTER_NAME}-mp-0
  namespace: default
spec:
  instanceConfiguration:
    freeformTags:
      tag1: "machinepool-instance-updated"
      my-tag-2: "${CLUSTER_NAME}-mp-0-updated"
    definedTags:
      issue-538:
        tag1: "machinepool-instance-updated"
        my-tag-2: "${CLUSTER_NAME}-mp-0-updated"
```

This will allow MachinePool Machines (OCI instances) to have separate freeform and defined tags added the InstanceConfig. Tag changes will now cause InstanceConfig reconciliation. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #538 

## Checklist
- [x] All unit tests are passing
- [x] All PRBlocking tests are passing
- [x] Code builds successfully