### PR TITLE
fix OKE image version matching to use bounded segment

### DIFF
--- a/cloud/scope/managed_machine_pool.go
+++ b/cloud/scope/managed_machine_pool.go
@@ -397,6 +397,7 @@ func (m *ManagedMachinePoolScope) setNodepoolImageId(ctx context.Context) error 
 		return errors.New(fmt.Sprintf("invalid/nil kubernetes version is set in OCIManagedMachinePool Spec"))
 	}
 	k8sVersion := (*specVersion)[1:]
+	k8sVersionImageSegment := fmt.Sprintf("-OKE-%s-", k8sVersion)
 	shape := m.OCIManagedMachinePool.Spec.NodeShape
 	armShapeRegex := regexp.MustCompile(`Standard\.A\d+`)
 	isArmShape := armShapeRegex.MatchString(shape)
@@ -409,7 +410,7 @@ func (m *ManagedMachinePoolScope) setNodepoolImageId(ctx context.Context) error 
 				if strings.Contains(sourceName, "aarch64") && !isArmShape {
 					continue
 				}
-				if strings.Contains(sourceName, k8sVersion) {
+				if strings.Contains(sourceName, k8sVersionImageSegment) {
 					m.Info("Image being used", "Name", sourceName, "OCID", *image.ImageId)
 					m.OCIManagedMachinePool.Spec.NodeSourceViaImage.ImageId = image.ImageId
 					return nil

--- a/cloud/scope/managed_machine_pool_test.go
+++ b/cloud/scope/managed_machine_pool_test.go
@@ -357,6 +357,10 @@ func TestManagedMachinePoolCreate(t *testing.T) {
 									ImageId:    common.String("image-id-2"),
 								},
 								oke.NodeSourceViaImageOption{
+									SourceName: common.String("Oracle-Linux-8.10-2026.02.28-0-OKE-1.24.50-1392"),
+									ImageId:    common.String("wrong-prefix-match-image-id"),
+								},
+								oke.NodeSourceViaImageOption{
 									SourceName: common.String("Oracle-Linux-8.6-2022.12.15-0-OKE-1.24.5-543"),
 									ImageId:    common.String("image-id-3"),
 								},


### PR DESCRIPTION
<!-- please add a type to the title of this PR (see https://www.conventionalcommits.org/en/v1.0.0/#summary), and delete this line and similar ones -->
<!-- the type will be either fix:, feat:, docs:, test: see https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional for a more exhaustive list -->

**What this PR does / why we need it**:
When selecting a node source image by kubernetes version, the previous check used strings. Contains(sourceName,k8sVersion) where k8sVersion is a bare semver string 1.28.0. This couldd false-match image names containing that string as a substring of a longer version. This PR inrtroduces k8sVersionImageSegment formatted as -OKE-<version>-, which bounds the version and ensures an exact segment match.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

## Checklist
- [x] All unit tests are passing
- [x] All PRBlocking tests are passing
- [x] Code builds successfully