### PR TITLE
Fix: variablize the namespace in templates

### DIFF
--- a/templates/cluster-template-alternative-region.yaml
+++ b/templates/cluster-template-alternative-region.yaml
@@ -28,6 +28,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -75,6 +76,7 @@ spec:
 kind: OCIMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:
@@ -93,6 +95,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -111,6 +114,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -124,6 +128,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   clusterName: "${CLUSTER_NAME}"

--- a/templates/cluster-template-antrea.yaml
+++ b/templates/cluster-template-antrea.yaml
@@ -28,6 +28,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -289,6 +290,7 @@ spec:
 kind: OCIMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:
@@ -307,6 +309,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -325,6 +328,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -338,6 +342,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   clusterName: "${CLUSTER_NAME}"

--- a/templates/cluster-template-arm-free-tier.yaml
+++ b/templates/cluster-template-arm-free-tier.yaml
@@ -28,6 +28,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -96,6 +97,7 @@ spec:
 kind: OCIMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:
@@ -116,6 +118,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -136,6 +139,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -152,6 +156,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   clusterName: "${CLUSTER_NAME}"

--- a/templates/cluster-template-cluster-class.yaml
+++ b/templates/cluster-template-cluster-class.yaml
@@ -2,6 +2,7 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cni: ${CLUSTER_NAME}-0
   name: "${CLUSTER_NAME}"

--- a/templates/cluster-template-failure-domain-spread.yaml
+++ b/templates/cluster-template-failure-domain-spread.yaml
@@ -28,6 +28,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -74,6 +75,7 @@ spec:
 kind: OCIMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:
@@ -92,6 +94,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md"
 spec:
   template:
@@ -110,6 +113,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md"
 spec:
   template:
@@ -123,6 +127,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-fd-1-md-0"
 spec:
   clusterName: "${CLUSTER_NAME}"
@@ -147,6 +152,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-fd-2-md-0"
 spec:
   clusterName: "${CLUSTER_NAME}"
@@ -171,6 +177,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-fd-3-md-0"
 spec:
   clusterName: "${CLUSTER_NAME}"

--- a/templates/cluster-template-healthcheck.yaml
+++ b/templates/cluster-template-healthcheck.yaml
@@ -28,6 +28,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -77,6 +78,7 @@ spec:
 kind: OCIMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 #  labels:
 #    controlplane.remediation: ""
@@ -97,6 +99,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 #  labels:
 #    machine.remediation: ""
@@ -117,6 +120,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -130,6 +134,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 #  labels:
 #    machine.remediation: ""
@@ -158,6 +163,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane-unhealthy-5m"
 spec:
   clusterName: "${CLUSTER_NAME}"
@@ -177,6 +183,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-unhealthy-5m"
 spec:
   clusterName: "${CLUSTER_NAME}"

--- a/templates/cluster-template-local-vcn-peering.yaml
+++ b/templates/cluster-template-local-vcn-peering.yaml
@@ -28,6 +28,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -387,6 +388,7 @@ spec:
 kind: OCIMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:
@@ -406,6 +408,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -425,6 +428,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -438,6 +442,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   clusterName: "${CLUSTER_NAME}"

--- a/templates/cluster-template-machinepool.yaml
+++ b/templates/cluster-template-machinepool.yaml
@@ -28,6 +28,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -74,6 +75,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:
@@ -93,7 +95,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
   name: ${CLUSTER_NAME}-mp-0
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${NODE_MACHINE_COUNT}
@@ -115,7 +117,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachinePool
 metadata:
   name: ${CLUSTER_NAME}-mp-0
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   instanceConfiguration:
     instanceOptions:
@@ -137,6 +139,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfig
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-mp-0"
 spec:
   joinConfiguration:

--- a/templates/cluster-template-managed-flannel.yaml
+++ b/templates/cluster-template-managed-flannel.yaml
@@ -20,6 +20,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIManagedCluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -248,7 +249,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
   name: ${CLUSTER_NAME}-mp-0
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${NODE_MACHINE_COUNT}
@@ -267,7 +268,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIManagedMachinePool
 metadata:
   name: ${CLUSTER_NAME}-mp-0
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   version: "${KUBERNETES_VERSION}"
   nodeShape: "${OCI_MANAGED_NODE_SHAPE=VM.Standard.E4.Flex}"

--- a/templates/cluster-template-managed-private.yaml
+++ b/templates/cluster-template-managed-private.yaml
@@ -20,6 +20,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIManagedCluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -336,7 +337,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
   name: ${CLUSTER_NAME}-mp-0
-  namespace: default
+  namespace: "${NAMESPACE}"
   annotations:
     "cluster.x-k8s.io/replicas-managed-by": ""
 spec:
@@ -357,7 +358,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIManagedMachinePool
 metadata:
   name: ${CLUSTER_NAME}-mp-0
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   version: "${KUBERNETES_VERSION}"
   nodeShape: "${OCI_MANAGED_NODE_SHAPE=VM.Standard.E4.Flex}"

--- a/templates/cluster-template-managed-self-managed-nodes.yaml
+++ b/templates/cluster-template-managed-self-managed-nodes.yaml
@@ -20,6 +20,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIManagedCluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -248,6 +249,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -264,6 +266,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   clusterName: "${CLUSTER_NAME}"

--- a/templates/cluster-template-managed-virtual-node.yaml
+++ b/templates/cluster-template-managed-virtual-node.yaml
@@ -20,6 +20,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIManagedCluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -39,7 +40,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
   name: ${CLUSTER_NAME}-mp-0
-  namespace: default
+  namespace: "${NAMESPACE}"
   annotations:
     "cluster.x-k8s.io/replicas-managed-by": ""
 spec:
@@ -60,6 +61,6 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIVirtualMachinePool
 metadata:
   name: ${CLUSTER_NAME}-mp-0
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
 ---

--- a/templates/cluster-template-managed.yaml
+++ b/templates/cluster-template-managed.yaml
@@ -20,6 +20,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIManagedCluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -38,7 +39,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
   name: ${CLUSTER_NAME}-mp-0
-  namespace: default
+  namespace: "${NAMESPACE}"
   annotations:
     "cluster.x-k8s.io/replicas-managed-by": ""
 spec:
@@ -59,7 +60,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIManagedMachinePool
 metadata:
   name: ${CLUSTER_NAME}-mp-0
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   version: "${KUBERNETES_VERSION}"
   nodeShape: "${OCI_MANAGED_NODE_SHAPE=VM.Standard.E4.Flex}"

--- a/templates/cluster-template-nlb-healthcheck.yaml
+++ b/templates/cluster-template-nlb-healthcheck.yaml
@@ -28,6 +28,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -96,6 +97,7 @@ spec:
 kind: OCIMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:
@@ -114,6 +116,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -132,6 +135,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -145,6 +149,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   clusterName: "${CLUSTER_NAME}"

--- a/templates/cluster-template-nlb-reserved-ip-config.yaml
+++ b/templates/cluster-template-nlb-reserved-ip-config.yaml
@@ -28,6 +28,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -84,6 +85,7 @@ spec:
 kind: OCIMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:
@@ -102,6 +104,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -120,6 +123,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -133,6 +137,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   clusterName: "${CLUSTER_NAME}"

--- a/templates/cluster-template-oci-addons.yaml
+++ b/templates/cluster-template-oci-addons.yaml
@@ -28,6 +28,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -74,6 +75,7 @@ spec:
 kind: OCIMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:
@@ -92,6 +94,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -110,6 +113,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -123,6 +127,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   clusterName: "${CLUSTER_NAME}"
@@ -147,7 +152,7 @@ apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
   name: ${CLUSTER_NAME}-ccm-resource-set
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   clusterSelector:
     matchLabels:
@@ -161,7 +166,7 @@ apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
   name: ${CLUSTER_NAME}-csi-resource-set
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   clusterSelector:
     matchLabels:
@@ -425,7 +430,7 @@ metadata:
   labels:
     type: generated
   name: ${CLUSTER_NAME}-oci-cloud-controller-manager
-  namespace: default
+  namespace: "${NAMESPACE}"
 ---
 apiVersion: v1
 data:
@@ -926,4 +931,4 @@ metadata:
   labels:
     type: generated
   name: ${CLUSTER_NAME}-oci-csi
-  namespace: default
+  namespace: "${NAMESPACE}"

--- a/templates/cluster-template-oraclelinux.yaml
+++ b/templates/cluster-template-oraclelinux.yaml
@@ -28,6 +28,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -77,6 +78,7 @@ spec:
 kind: OCIMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:
@@ -95,6 +97,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -113,6 +116,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -129,6 +133,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   clusterName: "${CLUSTER_NAME}"

--- a/templates/cluster-template-remote-vcn-peering.yaml
+++ b/templates/cluster-template-remote-vcn-peering.yaml
@@ -28,6 +28,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -389,6 +390,7 @@ spec:
 kind: OCIMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:
@@ -408,6 +410,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -427,6 +430,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -440,6 +444,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   clusterName: "${CLUSTER_NAME}"

--- a/templates/cluster-template-windows-calico.yaml
+++ b/templates/cluster-template-windows-calico.yaml
@@ -31,6 +31,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -366,6 +367,7 @@ spec:
 kind: OCIMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:
@@ -384,6 +386,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-win"
 spec:
   template:
@@ -405,6 +408,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-win"
 spec:
   template:
@@ -426,6 +430,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-win"
 spec:
   clusterName: "${CLUSTER_NAME}"

--- a/templates/cluster-template-with-bv-autotuned.yaml
+++ b/templates/cluster-template-with-bv-autotuned.yaml
@@ -29,6 +29,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -75,6 +76,7 @@ spec:
 kind: OCIMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:
@@ -102,6 +104,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -129,6 +132,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -142,6 +146,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   clusterName: "${CLUSTER_NAME}"

--- a/templates/cluster-template-with-ipv6.yaml
+++ b/templates/cluster-template-with-ipv6.yaml
@@ -28,6 +28,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -95,6 +96,7 @@ spec:
 kind: OCIMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:
@@ -115,6 +117,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -135,6 +138,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -148,6 +152,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   clusterName: "${CLUSTER_NAME}"

--- a/templates/cluster-template-with-nsg.yaml
+++ b/templates/cluster-template-with-nsg.yaml
@@ -29,6 +29,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -110,6 +111,7 @@ spec:
 kind: OCIMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:
@@ -128,6 +130,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -146,6 +149,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -159,6 +163,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   clusterName: "${CLUSTER_NAME}"

--- a/templates/cluster-template-with-paravirt-bv.yaml
+++ b/templates/cluster-template-with-paravirt-bv.yaml
@@ -28,6 +28,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -74,6 +75,7 @@ spec:
 kind: OCIMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:
@@ -92,6 +94,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -120,6 +123,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -133,6 +137,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   clusterName: "${CLUSTER_NAME}"

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -28,6 +28,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -74,6 +75,7 @@ spec:
 kind: OCIMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:
@@ -92,6 +94,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -110,6 +113,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -123,6 +127,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   clusterName: "${CLUSTER_NAME}"

--- a/templates/clusterclass-example.yaml
+++ b/templates/clusterclass-example.yaml
@@ -1,6 +1,7 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: ClusterClass
 metadata:
+  namespace: "${NAMESPACE}"
   name: cluster-class-example
 spec:
   controlPlane:
@@ -159,6 +160,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIClusterTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: ocicluster
 spec:
   template:
@@ -167,6 +169,7 @@ spec:
 kind: KubeadmControlPlaneTemplate
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 metadata:
+  namespace: "${NAMESPACE}"
   name: control-plane
 spec:
   template:
@@ -196,6 +199,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: control-plane
 spec:
   template:
@@ -211,6 +215,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: worker-machine-template
 spec:
   template:
@@ -225,6 +230,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: worker-bootstrap-template
 spec:
   template:

--- a/templates/namespaces_test.go
+++ b/templates/namespaces_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright (c) 2026, Oracle and/or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/yamlprocessor"
+	utilyaml "sigs.k8s.io/cluster-api/util/yaml"
+)
+
+// TestTemplateNamespaces guards against hard-coded or omitted namespaces in the
+// example templates. When applied after variable substitution, related resources
+// must stay in the selected namespace, including when it is not "default".
+// Clusterctl's later namespace rewrite can mask these mistakes, so this test
+// checks substitution alone for both default and custom namespaces. It runs
+// locally without a cluster or E2E setup; embedded workload addon YAML retains
+// its own namespaces, such as kube-system.
+func TestTemplateNamespaces(t *testing.T) {
+	paths, err := filepath.Glob("*.yaml")
+	if err != nil || len(paths) == 0 {
+		t.Fatalf("finding release templates: %v", err)
+	}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, namespace := range []string{"default", "custom-namespace"} {
+				t.Run(namespace, func(t *testing.T) {
+					// Use clusterctl's substitution without its subsequent namespace rewrite,
+					// which would hide hard-coded namespaces from this regression check.
+					rendered, err := yamlprocessor.NewSimpleProcessor().Process(raw, func(name string) (string, error) {
+						if name == "NAMESPACE" {
+							return namespace, nil
+						}
+						return "1", nil
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					objects, err := utilyaml.ToUnstructured(rendered)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if len(objects) == 0 {
+						t.Fatal("template contains no resources")
+					}
+					for _, object := range objects {
+						if object.GetNamespace() != namespace {
+							t.Errorf("%s/%s namespace = %q, want %q", object.GetKind(), object.GetName(), object.GetNamespace(), namespace)
+						}
+						checkNamespaces(t, object.Object, namespace)
+					}
+				})
+			}
+		})
+	}
+}
+
+func checkNamespaces(t *testing.T, value interface{}, namespace string) {
+	t.Helper()
+	switch value := value.(type) {
+	case map[string]interface{}:
+		for key, child := range value {
+			if key == "namespace" && child != namespace {
+				t.Errorf("namespace = %v, want %s", child, namespace)
+			}
+			// Embedded addon YAML is a string, so workload namespaces are not traversed.
+			checkNamespaces(t, child, namespace)
+		}
+	case []interface{}:
+		for _, child := range value {
+			checkNamespaces(t, child, namespace)
+		}
+	}
+}

--- a/test/e2e/data/infrastructure-oci/bases/ccm.yaml
+++ b/test/e2e/data/infrastructure-oci/bases/ccm.yaml
@@ -2,7 +2,7 @@ apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
   name: ${CLUSTER_NAME}-ccm-resource-set
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   clusterSelector:
     matchLabels:
@@ -16,7 +16,7 @@ apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
   name: ${CLUSTER_NAME}-csi-resource-set
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   clusterSelector:
     matchLabels:
@@ -284,7 +284,7 @@ metadata:
   labels:
     type: generated
   name: ${CLUSTER_NAME}-oci-cloud-controller-manager
-  namespace: default
+  namespace: "${NAMESPACE}"
 ---
 apiVersion: v1
 data:
@@ -765,4 +765,4 @@ metadata:
   labels:
     type: generated
   name: ${CLUSTER_NAME}-oci-csi
-  namespace: default
+  namespace: "${NAMESPACE}"

--- a/test/e2e/data/infrastructure-oci/bases/crs.yaml
+++ b/test/e2e/data/infrastructure-oci/bases/crs.yaml
@@ -4,6 +4,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  namespace: "${NAMESPACE}"
   name: "cni-${CLUSTER_NAME}-crs-0"
 data: ${CNI_RESOURCES}
 binaryData:
@@ -13,6 +14,7 @@ binaryData:
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
+  namespace: "${NAMESPACE}"
   name:  "${CLUSTER_NAME}-crs-0"
 spec:
   strategy: ApplyOnce

--- a/test/e2e/data/infrastructure-oci/v1beta1/bases/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta1/bases/cluster.yaml
@@ -5,7 +5,7 @@ metadata:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
     cni: "calico"
   name: "${CLUSTER_NAME}"
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   clusterNetwork:
     pods:
@@ -29,6 +29,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -39,7 +40,7 @@ kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 metadata:
   name: "${CLUSTER_NAME}-control-plane"
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   version: "${KUBERNETES_VERSION}"
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
@@ -75,6 +76,7 @@ spec:
 kind: OCIMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:

--- a/test/e2e/data/infrastructure-oci/v1beta1/bases/md.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta1/bases/md.yaml
@@ -1,6 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -18,6 +19,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -31,6 +33,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   clusterName: "${CLUSTER_NAME}"

--- a/test/e2e/data/infrastructure-oci/v1beta1/cluster-template-custom-networking-nsg/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta1/cluster-template-custom-networking-nsg/cluster.yaml
@@ -2,6 +2,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}"
 spec:
   networkSpec:

--- a/test/e2e/data/infrastructure-oci/v1beta2/bases/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/bases/cluster.yaml
@@ -5,7 +5,7 @@ metadata:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
     cni: "calico"
   name: "${CLUSTER_NAME}"
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   clusterNetwork:
     pods:
@@ -29,6 +29,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -39,7 +40,7 @@ kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 metadata:
   name: "${CLUSTER_NAME}-control-plane"
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   version: "${KUBERNETES_VERSION}"
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
@@ -75,6 +76,7 @@ spec:
 kind: OCIMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:

--- a/test/e2e/data/infrastructure-oci/v1beta2/bases/md.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/bases/md.yaml
@@ -1,6 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -26,6 +27,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -39,6 +41,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   clusterName: "${CLUSTER_NAME}"

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-alternative-region/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-alternative-region/cluster.yaml
@@ -1,6 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -10,6 +11,7 @@ spec:
 kind: OCIMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-alternative-region/md.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-alternative-region/md.yaml
@@ -1,6 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-antrea/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-antrea/cluster.yaml
@@ -4,11 +4,12 @@ metadata:
   labels:
     cni: "antrea"
   name: "${CLUSTER_NAME}"
-  namespace: default
+  namespace: "${NAMESPACE}"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}"
 spec:
   networkSpec:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-antrea/crs.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-antrea/crs.yaml
@@ -4,6 +4,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  namespace: "${NAMESPACE}"
   name: "cni-${CLUSTER_NAME}-antrea-0"
 data: ${ANTREA_RESOURCES}
 binaryData:
@@ -13,6 +14,7 @@ binaryData:
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
+  namespace: "${NAMESPACE}"
   name:  "${CLUSTER_NAME}-antrea-0"
 spec:
   strategy: ApplyOnce

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-bare-metal/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-bare-metal/cluster.yaml
@@ -1,6 +1,7 @@
 kind: OCIMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-bare-metal/md.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-bare-metal/md.yaml
@@ -1,6 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-cluster-class/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-cluster-class/cluster-template.yaml
@@ -2,6 +2,7 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cni: ${CLUSTER_NAME}-0
   name: "${CLUSTER_NAME}"

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-cluster-class/clusterclass-test-cluster-class.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-cluster-class/clusterclass-test-cluster-class.yaml
@@ -1,6 +1,7 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: ClusterClass
 metadata:
+  namespace: "${NAMESPACE}"
   name: test-cluster-class
 spec:
   controlPlane:
@@ -159,6 +160,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIClusterTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: ocicluster
 spec:
   template:
@@ -167,6 +169,7 @@ spec:
 kind: KubeadmControlPlaneTemplate
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 metadata:
+  namespace: "${NAMESPACE}"
   name: control-plane
 spec:
   template:
@@ -196,6 +199,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: control-plane
 spec:
   template:
@@ -210,6 +214,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: worker-machine-template
 spec:
   template:
@@ -224,6 +229,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: worker-bootstrap-template
 spec:
   template:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-cluster-identity/cluster-identity.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-cluster-identity/cluster-identity.yaml
@@ -1,6 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIClusterIdentity
 metadata:
+  namespace: "${NAMESPACE}"
   name: cluster-identity-user-principal
 spec:
   type: UserPrincipal
@@ -12,6 +13,7 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
+  namespace: "${NAMESPACE}"
   name: user-credentials
 type: Opaque
 data:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-cluster-identity/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-cluster-identity/cluster.yaml
@@ -2,6 +2,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}"
 spec:
   identityRef:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-custom-networking-seclist/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-custom-networking-seclist/cluster.yaml
@@ -2,6 +2,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}"
 spec:
   networkSpec:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-externally-managed-vcn/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-externally-managed-vcn/cluster.yaml
@@ -2,6 +2,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}"
 spec:
   networkSpec:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-kcp-remediation/mhc.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-kcp-remediation/mhc.yaml
@@ -5,6 +5,7 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-mhc-0"
 spec:
   clusterName: "${CLUSTER_NAME}"

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-local-vcn-peering/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-local-vcn-peering/cluster.yaml
@@ -2,6 +2,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}"
 spec:
   networkSpec:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-machine-pool-fd/machine-pool.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-machine-pool-fd/machine-pool.yaml
@@ -3,7 +3,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachinePool
 metadata:
   name: "${CLUSTER_NAME}-mp-0"
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   placementDetails:
     - availabilityDomain: 1

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-machine-pool/machine-pool.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-machine-pool/machine-pool.yaml
@@ -3,7 +3,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
   name: "${CLUSTER_NAME}-mp-0"
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   clusterName: "${CLUSTER_NAME}"
   replicas: "${WORKER_MACHINE_COUNT}"
@@ -25,7 +25,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachinePool
 metadata:
   name: "${CLUSTER_NAME}-mp-0"
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   instanceConfiguration:
     instanceOptions:
@@ -42,6 +42,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfig
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-mp-0"
 spec:
   joinConfiguration:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-machine-with-ipv6/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-machine-with-ipv6/cluster.yaml
@@ -2,6 +2,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"
@@ -31,6 +32,7 @@ spec:
 kind: OCIMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-machine-with-ipv6/md.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-machine-with-ipv6/md.yaml
@@ -2,6 +2,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-cluster-identity/cluster-identity.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-cluster-identity/cluster-identity.yaml
@@ -1,6 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIClusterIdentity
 metadata:
+  namespace: "${NAMESPACE}"
   name: cluster-identity-user-principal
 spec:
   type: UserPrincipal
@@ -12,6 +13,7 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
+  namespace: "${NAMESPACE}"
   name: user-credentials
 type: Opaque
 data:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-cluster-identity/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-cluster-identity/cluster.yaml
@@ -20,6 +20,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIManagedCluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-cluster-identity/machine-pool.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-cluster-identity/machine-pool.yaml
@@ -3,7 +3,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
   name: ${CLUSTER_NAME}-mp-0
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${NODE_MACHINE_COUNT}
@@ -22,7 +22,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIManagedMachinePool
 metadata:
   name: ${CLUSTER_NAME}-mp-0
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   version: "${OCI_MANAGED_KUBERNETES_VERSION}"
   nodeShape: "${OCI_MANAGED_NODE_SHAPE}"

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-node-recycling/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-node-recycling/cluster.yaml
@@ -20,6 +20,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIManagedCluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-node-recycling/machine-pool.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-node-recycling/machine-pool.yaml
@@ -4,7 +4,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
   name: ${CLUSTER_NAME}-mp-1
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${NODE_MACHINE_COUNT}
@@ -23,7 +23,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIManagedMachinePool
 metadata:
   name: ${CLUSTER_NAME}-mp-1
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   version: "${OCI_MANAGED_KUBERNETES_VERSION}"
   nodeShape: "${OCI_MANAGED_NODE_SHAPE}"

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-self-managed-nodes/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-self-managed-nodes/cluster.yaml
@@ -20,6 +20,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIManagedCluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-self-managed-nodes/machine-pool.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-self-managed-nodes/machine-pool.yaml
@@ -3,7 +3,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
   name: "${CLUSTER_NAME}-mp-0"
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   clusterName: "${CLUSTER_NAME}"
   replicas: "${WORKER_MACHINE_COUNT}"
@@ -22,7 +22,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachinePool
 metadata:
   name: "${CLUSTER_NAME}-mp-0"
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   instanceConfiguration:
     instanceOptions:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-self-managed-nodes/md.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-self-managed-nodes/md.yaml
@@ -1,6 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -19,6 +20,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   clusterName: "${CLUSTER_NAME}"

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-virtual/cluster-identity.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-virtual/cluster-identity.yaml
@@ -1,6 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIClusterIdentity
 metadata:
+  namespace: "${NAMESPACE}"
   name: cluster-identity-instance-principal
 spec:
   type: InstancePrincipal

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-virtual/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-virtual/cluster.yaml
@@ -20,6 +20,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIManagedCluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}-virtual"

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-virtual/machine-pool.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed-virtual/machine-pool.yaml
@@ -3,7 +3,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
   name: ${CLUSTER_NAME}-mp-0
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${NODE_MACHINE_COUNT}
@@ -22,6 +22,6 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIVirtualMachinePool
 metadata:
   name: ${CLUSTER_NAME}-mp-0
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
 ---

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed/cluster.yaml
@@ -20,6 +20,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIManagedCluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}-managed"

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed/machine-pool.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-managed/machine-pool.yaml
@@ -3,7 +3,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
   name: ${CLUSTER_NAME}-mp-0
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${NODE_MACHINE_COUNT}
@@ -22,7 +22,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIManagedMachinePool
 metadata:
   name: ${CLUSTER_NAME}-mp-0
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   version: "${OCI_MANAGED_KUBERNETES_VERSION}"
   nodeShape: "${OCI_MANAGED_NODE_SHAPE}"
@@ -41,7 +41,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
   name: ${CLUSTER_NAME}-mp-1
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${NODE_MACHINE_COUNT}
@@ -60,7 +60,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIManagedMachinePool
 metadata:
   name: ${CLUSTER_NAME}-mp-1
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   version: "${OCI_MANAGED_KUBERNETES_VERSION}"
   nodeShape: "${OCI_MANAGED_NODE_SHAPE}"

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-md-remediation/md.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-md-remediation/md.yaml
@@ -1,6 +1,7 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-md-remediation/mhc.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-md-remediation/mhc.yaml
@@ -5,6 +5,7 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-mhc-0"
 spec:
   clusterName: "${CLUSTER_NAME}"

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-multiple-node-nsg/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-multiple-node-nsg/cluster.yaml
@@ -2,6 +2,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}"
 spec:
   networkSpec:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-multiple-node-nsg/md-0.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-multiple-node-nsg/md-0.yaml
@@ -1,6 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -22,6 +23,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -35,6 +37,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   clusterName: "${CLUSTER_NAME}"

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-multiple-node-nsg/md-1.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-multiple-node-nsg/md-1.yaml
@@ -1,6 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-1"
 spec:
   template:
@@ -22,6 +23,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-1"
 spec:
   template:
@@ -35,6 +37,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-1"
 spec:
   clusterName: "${CLUSTER_NAME}"

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-node-drain/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-node-drain/cluster.yaml
@@ -3,6 +3,7 @@
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   machineTemplate:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-node-drain/md.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-node-drain/md.yaml
@@ -1,6 +1,7 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-oracle-linux/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-oracle-linux/cluster.yaml
@@ -1,6 +1,7 @@
 kind: OCIMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:
@@ -10,6 +11,7 @@ spec:
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   kubeadmConfigSpec:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-oracle-linux/md.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-oracle-linux/md.yaml
@@ -1,6 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -10,6 +11,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-remote-vcn-peering/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-remote-vcn-peering/cluster.yaml
@@ -2,6 +2,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}"
 spec:
   region: "${OCI_ALTERNATIVE_REGION}"
@@ -320,6 +321,7 @@ spec:
 kind: OCIMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-remote-vcn-peering/md.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-remote-vcn-peering/md.yaml
@@ -1,6 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-self-manage-nsg/cluster.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-self-manage-nsg/cluster.yaml
@@ -2,6 +2,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCICluster
 metadata:
+  namespace: "${NAMESPACE}"
   labels:
     cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   name: "${CLUSTER_NAME}"

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-windows-calico/md.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-windows-calico/md.yaml
@@ -1,6 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
   labels:
     os: windows
@@ -19,6 +20,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:
@@ -39,6 +41,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:

--- a/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-with-paravirt-bv/md.yaml
+++ b/test/e2e/data/infrastructure-oci/v1beta2/cluster-template-with-paravirt-bv/md.yaml
@@ -2,6 +2,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
 metadata:
+  namespace: "${NAMESPACE}"
   name: "${CLUSTER_NAME}-md-0"
 spec:
   template:


### PR DESCRIPTION
Many of our template examples had the namespace hard coded to `default`

<!-- please add a type to the title of this PR (see https://www.conventionalcommits.org/en/v1.0.0/#summary), and delete this line and similar ones -->
<!-- the type will be either fix:, feat:, docs:, test: see https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional for a more exhaustive list -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

## Checklist
- [x] All unit tests are passing
- [x] All PRBlocking tests are passing
- [x] Code builds successfully